### PR TITLE
Redesign market visualizer rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.893.0",
     "@aws-sdk/s3-request-presigner": "^3.893.0",
+    "@fontsource/public-sans": "^5.2.7",
     "@napi-rs/canvas": "^0.1.97",
     "@prisma/client": "^6.7.0",
+    "@tabler/icons": "^3.41.1",
     "bullmq": "^5.56.1",
     "d3": "^7.9.0",
     "discord.js": "^14.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,18 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.893.0
         version: 3.1016.0
+      '@fontsource/public-sans':
+        specifier: ^5.2.7
+        version: 5.2.7
       '@napi-rs/canvas':
         specifier: ^0.1.97
         version: 0.1.97
       '@prisma/client':
         specifier: ^6.7.0
         version: 6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3)
+      '@tabler/icons':
+        specifier: ^3.41.1
+        version: 3.41.1
       bullmq:
         specifier: ^5.56.1
         version: 5.71.0
@@ -478,6 +484,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource/public-sans@5.2.7':
+    resolution: {integrity: sha512-pVttDr3HvhVIt2x6sZJfZKksNEpq23C1JCHTQwT9KWJdmFRdNeRM8gQftq8uP72sPW+p3Ku9x8HPk2E392DFvg==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1117,6 +1126,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tabler/icons@3.41.1':
+    resolution: {integrity: sha512-OaRnVbRmH2nHtFeg+RmMJ/7m2oBIF9XCJAUD5gQnMrpK9f05ydj8MZrAf3NZQqOXyxGN1UBL0D5IKLLEUfr74Q==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -2591,6 +2603,8 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
+  '@fontsource/public-sans@5.2.7': {}
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -3221,6 +3235,8 @@ snapshots:
       tslib: 2.8.1
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tabler/icons@3.41.1': {}
 
   '@types/chai@5.2.3':
     dependencies:

--- a/src/features/markets/ui/visualize.ts
+++ b/src/features/markets/ui/visualize.ts
@@ -1,23 +1,67 @@
 import { AttachmentBuilder } from 'discord.js';
-import { scaleOrdinal, schemeTableau10 } from 'd3';
-import sharp from 'sharp';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  createCanvas,
+  GlobalFonts,
+  loadImage,
+  type SKRSContext2D,
+} from '@napi-rs/canvas';
+import {
+  bin,
+  line,
+  scaleBand,
+  scaleLinear,
+  scaleOrdinal,
+  scaleTime,
+  schemeTableau10,
+} from 'd3';
 
 import { computeLmsrProbabilities } from '../core/math.js';
-import { compareMarketHistoryEvents, computeMarketSummary } from '../core/shared.js';
+import {
+  compareMarketHistoryEvents,
+  computeMarketSummary,
+  getMarketStatus,
+} from '../core/shared.js';
 import type { MarketWithRelations } from '../core/types.js';
 
-const width = 1100;
+const width = 1200;
 const height = 760;
-const background = '#323339';
-const panel = '#272a30';
-const panelAlt = '#202329';
-const border = '#454a53';
-const text = '#f5f7fa';
-const muted = '#b8bdc7';
-const grid = '#4b5563';
-const volumeColor = '#7aa2db';
-const fontStack = "'DejaVu Sans', 'Noto Sans', 'Liberation Sans', sans-serif";
+const background = '#15181d';
+const border = '#2b313a';
+const text = '#f4f7fb';
+const muted = '#a3adba';
+const quiet = '#66707d';
+const grid = '#2f3640';
+const gridStrong = '#404856';
+const panel = '#1c2128';
+const volumeColor = '#6f8fc0';
+const fontFamily = 'Public Sans';
+const fontStack = `'${fontFamily}', 'DejaVu Sans', 'Noto Sans', 'Liberation Sans', sans-serif`;
 const PROBABILITY_EPSILON = 1e-6;
+const VOLUME_BUCKET_COUNT = 28;
+
+const seriesPalette = schemeTableau10.concat([
+  '#7cb7ff',
+  '#ff9f43',
+  '#5fd0a5',
+  '#ff6b8a',
+  '#c490ff',
+  '#ffd166',
+  '#8ce99a',
+  '#7bdff2',
+]);
+
+const tablerIconNames = {
+  volume: 'coins',
+  trades: 'chart-histogram',
+  state: 'clock',
+  bonusBank: 'wallet',
+} as const;
+
+type LoadedImage = Awaited<ReturnType<typeof loadImage>>;
 
 type DiagramPayload = {
   attachment: AttachmentBuilder;
@@ -45,14 +89,263 @@ type HistoryEvent =
       liquidityParameter: number;
     };
 
-const escapeXml = (value: string): string => value
-  .replaceAll('&', '&amp;')
-  .replaceAll('<', '&lt;')
-  .replaceAll('>', '&gt;')
-  .replaceAll('"', '&quot;')
-  .replaceAll("'", '&#39;');
+export type ChartBounds = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
 
-const formatPercent = (value: number): string => `${(value * 100).toFixed(1)}%`;
+export type ProbabilityPoint = {
+  time: number;
+  probability: number;
+};
+
+export type ProbabilitySeries = {
+  outcomeId: string;
+  label: string;
+  color: string;
+  latestProbability: number;
+  points: ProbabilityPoint[];
+};
+
+export type VolumeBucket = {
+  index: number;
+  startTime: number;
+  endTime: number;
+  volume: number;
+  tradeCount: number;
+};
+
+export type MetadataItem = {
+  icon: keyof typeof tablerIconNames;
+  label: string;
+  value: string;
+  accent: string;
+};
+
+export type MarketChartModel = {
+  startTime: number;
+  endTime: number;
+  probabilitySeries: ProbabilitySeries[];
+  volumeBuckets: VolumeBucket[];
+  maxBucketVolume: number;
+  metadata: MetadataItem[];
+  liquidityMarkers: Array<{
+    time: number;
+    label: string;
+  }>;
+};
+
+const imageCache = new Map<string, Promise<LoadedImage>>();
+
+const axisDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+});
+
+const axisDateTimeFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+});
+
+const compactNumberFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1,
+  notation: 'compact',
+});
+const footerDateTimeFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+  timeZoneName: 'short',
+});
+
+let publicSansRegistered = false;
+
+const drawLabel = (
+  context: SKRSContext2D,
+  label: string,
+  x: number,
+  y: number,
+  options: {
+    font: string;
+    color: string;
+    align?: CanvasTextAlign;
+    baseline?: CanvasTextBaseline;
+  },
+): void => {
+  context.font = options.font;
+  context.fillStyle = options.color;
+  context.textAlign = options.align ?? 'left';
+  context.textBaseline = options.baseline ?? 'alphabetic';
+  context.fillText(label, x, y);
+};
+
+const truncateToWidth = (
+  context: SKRSContext2D,
+  label: string,
+  maxWidth: number,
+): string => {
+  if (context.measureText(label).width <= maxWidth) {
+    return label;
+  }
+
+  let value = label;
+  while (value.length > 1 && context.measureText(`${value}...`).width > maxWidth) {
+    value = value.slice(0, -1);
+  }
+
+  return `${value}...`;
+};
+
+const wrapText = (
+  context: SKRSContext2D,
+  label: string,
+  maxWidth: number,
+  maxLines: number,
+): string[] => {
+  const words = label.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) {
+    return [''];
+  }
+
+  const lines: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (context.measureText(next).width <= maxWidth) {
+      current = next;
+      continue;
+    }
+
+    if (current) {
+      lines.push(current);
+    }
+    current = word;
+
+    if (lines.length === maxLines - 1) {
+      break;
+    }
+  }
+
+  if (lines.length < maxLines) {
+    lines.push(current);
+  }
+
+  const consumedWordCount = lines.join(' ').trim().split(/\s+/).filter(Boolean).length;
+  if (consumedWordCount < words.length) {
+    const lastLine = lines[lines.length - 1] ?? '';
+    lines[lines.length - 1] = truncateToWidth(context, `${lastLine} ${words.slice(consumedWordCount).join(' ')}`.trim(), maxWidth);
+  }
+
+  return lines.slice(0, maxLines);
+};
+
+const formatPercent = (value: number, digits = 1): string => `${(value * 100).toFixed(digits)}%`;
+
+const formatPoints = (value: number): string => {
+  const rounded = Math.round(value);
+  if (Math.abs(value - rounded) < 0.01) {
+    return `${rounded} pts`;
+  }
+
+  return `${value.toFixed(1)} pts`;
+};
+
+const formatCompactPoints = (value: number): string => `${compactNumberFormatter.format(value)} pts`;
+
+const formatAxisTime = (value: number, startTime: number, endTime: number): string => (
+  endTime - startTime <= 36 * 60 * 60 * 1_000
+    ? axisDateTimeFormatter
+    : axisDateFormatter
+).format(new Date(value));
+
+const formatFooterTimestamp = (value: Date): string => footerDateTimeFormatter.format(value);
+
+const resolvePublicSansPath = (
+  weight: 400 | 500 | 700,
+  moduleUrl: string = import.meta.url,
+): string => {
+  const relativePath = `files/public-sans-latin-${weight}-normal.woff2`;
+  const candidates = [
+    resolve(process.cwd(), 'node_modules', '@fontsource', 'public-sans', relativePath),
+    fileURLToPath(new URL(`../../../../node_modules/@fontsource/public-sans/${relativePath}`, moduleUrl)),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return candidates[0]!;
+};
+
+const ensurePublicSansLoaded = (): void => {
+  if (publicSansRegistered) {
+    return;
+  }
+
+  GlobalFonts.registerFromPath(resolvePublicSansPath(400), fontFamily);
+  GlobalFonts.registerFromPath(resolvePublicSansPath(500), fontFamily);
+  GlobalFonts.registerFromPath(resolvePublicSansPath(700), fontFamily);
+  publicSansRegistered = true;
+};
+
+const resolveTablerIconPath = (
+  iconName: string,
+  moduleUrl: string = import.meta.url,
+): string => {
+  const relativePath = `icons/outline/${iconName}.svg`;
+  const candidates = [
+    resolve(process.cwd(), 'node_modules', '@tabler', 'icons', relativePath),
+    fileURLToPath(new URL(`../../../../node_modules/@tabler/icons/${relativePath}`, moduleUrl)),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return candidates[0]!;
+};
+
+const loadCachedImage = (file: string): Promise<LoadedImage> => {
+  const cached = imageCache.get(file);
+  if (cached) {
+    return cached;
+  }
+
+  const pending = readFile(file).then((buffer) => loadImage(buffer));
+  imageCache.set(file, pending);
+  return pending;
+};
+
+const loadTablerIcon = async (
+  iconName: keyof typeof tablerIconNames,
+  size: number,
+  tint: string,
+): Promise<LoadedImage> => {
+  const file = resolveTablerIconPath(tablerIconNames[iconName]);
+  const cacheKey = `${file}:${size}:${tint}`;
+  const cached = imageCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const pending = readFile(file, 'utf8')
+    .then((svg) => svg
+      .replace('<svg ', `<svg width="${size}" height="${size}" `)
+      .replaceAll('currentColor', tint))
+    .then((svg) => loadImage(Buffer.from(svg)));
+
+  imageCache.set(cacheKey, pending);
+  return pending;
+};
 
 export const resolveMarketDiagramEndTime = (market: MarketWithRelations, now = new Date()): Date => {
   if (market.resolvedAt) {
@@ -67,10 +360,16 @@ export const resolveMarketDiagramEndTime = (market: MarketWithRelations, now = n
     return market.tradingClosedAt;
   }
 
-  return now;
+  const latestHistoryTime = Math.max(
+    market.createdAt.getTime(),
+    ...market.trades.map((trade) => trade.createdAt.getTime()),
+    ...market.liquidityEvents.map((event) => event.createdAt.getTime()),
+  );
+
+  return new Date(Math.max(now.getTime(), latestHistoryTime));
 };
 
-const buildSnapshots = (market: MarketWithRelations, now = new Date()): Snapshot[] => {
+export const buildSnapshots = (market: MarketWithRelations, now = new Date()): Snapshot[] => {
   const pricingShares = market.outcomes.map(() => 0);
   let liquidityParameter = market.baseLiquidityParameter;
   const initialProbabilities = computeLmsrProbabilities(pricingShares, liquidityParameter);
@@ -153,115 +452,591 @@ const buildSnapshots = (market: MarketWithRelations, now = new Date()): Snapshot
   return snapshots;
 };
 
-const buildLinePath = (
-  points: Array<{ x: number; y: number }>,
-): string => points.map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x.toFixed(2)} ${point.y.toFixed(2)}`).join(' ');
+export const bucketTradeVolumes = (
+  market: MarketWithRelations,
+  startTime: number,
+  endTime: number,
+  bucketCount = VOLUME_BUCKET_COUNT,
+): VolumeBucket[] => {
+  if (bucketCount <= 0) {
+    return [];
+  }
 
-const buildSvg = (market: MarketWithRelations): string => {
-  const snapshots = buildSnapshots(market);
+  const safeEndTime = Math.max(startTime + 1, endTime);
+  const bucketSpan = (safeEndTime - startTime) / bucketCount;
+  const thresholds = Array.from({ length: bucketCount + 1 }, (_, index) => (
+    index === bucketCount ? safeEndTime : startTime + (bucketSpan * index)
+  ));
+  let previousCumulativeVolume = 0;
+  const tradeDeltas = market.trades.map((trade) => {
+    const delta = Math.max(0, trade.cumulativeVolume - previousCumulativeVolume);
+    previousCumulativeVolume = trade.cumulativeVolume;
+    return {
+      time: trade.createdAt.getTime(),
+      volume: delta,
+    };
+  });
+  const histogram = bin<{ time: number; volume: number }, number>()
+    .value((trade) => trade.time)
+    .domain([startTime, safeEndTime])
+    .thresholds(thresholds);
+  const bins = histogram(tradeDeltas);
+
+  return Array.from({ length: bucketCount }, (_, index) => {
+    const bucket = bins[index];
+    return {
+      index,
+      startTime: thresholds[index] ?? startTime,
+      endTime: thresholds[index + 1] ?? safeEndTime,
+      volume: bucket?.reduce((sum, trade) => sum + trade.volume, 0) ?? 0,
+      tradeCount: bucket?.length ?? 0,
+    };
+  });
+};
+
+const buildMetadata = (market: MarketWithRelations): MetadataItem[] => {
+  const status = getMarketStatus(market);
+  const stateAccent = status === 'resolved'
+    ? '#5fd0a5'
+    : status === 'cancelled'
+      ? '#ff7d7d'
+      : status === 'closed'
+        ? '#ffb454'
+        : '#7cb7ff';
+
+  const stateLabel = status === 'open'
+    ? `Closes ${axisDateFormatter.format(market.closeAt)}`
+    : status === 'closed'
+      ? `Closed ${axisDateFormatter.format(market.tradingClosedAt ?? market.closeAt)}`
+      : status === 'resolved'
+        ? `Resolved ${axisDateFormatter.format(market.resolvedAt ?? market.closeAt)}`
+        : `Cancelled ${axisDateFormatter.format(market.cancelledAt ?? market.closeAt)}`;
+
+  return [
+    {
+      icon: 'volume',
+      value: formatCompactPoints(market.totalVolume),
+      label: 'Total volume',
+      accent: text,
+    },
+    {
+      icon: 'trades',
+      value: compactNumberFormatter.format(market.trades.length),
+      label: 'Trades',
+      accent: text,
+    },
+    {
+      icon: 'state',
+      value: status.charAt(0).toUpperCase() + status.slice(1),
+      label: stateLabel,
+      accent: stateAccent,
+    },
+    {
+      icon: 'bonusBank',
+      value: formatCompactPoints(market.supplementaryBonusPool ?? 0),
+      label: 'Bonus bank',
+      accent: text,
+    },
+  ];
+};
+
+export const buildMarketChartModel = (
+  market: MarketWithRelations,
+  now = new Date(),
+): MarketChartModel => {
+  const snapshots = buildSnapshots(market, now);
+  const summary = computeMarketSummary(market);
   const colorScale = scaleOrdinal<string, string>()
-    .domain(market.outcomes.map((outcome) => outcome.id))
-    .range(schemeTableau10.concat(['#57f287', '#eb459e']));
-
-  const minTime = snapshots[0]?.at.getTime() ?? Date.now();
-  const maxTime = Math.max(
-    snapshots[snapshots.length - 1]?.at.getTime() ?? minTime,
-    minTime + 1,
+    .domain(summary.probabilities.map((entry) => entry.outcomeId))
+    .range(seriesPalette);
+  const startTime = snapshots[0]?.at.getTime() ?? market.createdAt.getTime();
+  const endTime = Math.max(
+    resolveMarketDiagramEndTime(market, now).getTime(),
+    snapshots[snapshots.length - 1]?.at.getTime() ?? startTime + 1,
+    startTime + 1,
   );
-  const maxVolume = Math.max(...snapshots.map((snapshot) => snapshot.cumulativeVolume), 1);
+  const volumeBuckets = bucketTradeVolumes(market, startTime, endTime);
+  const maxBucketVolume = Math.max(...volumeBuckets.map((bucket) => bucket.volume), 1);
 
-  const probabilityChart = {
-    x: 80,
-    y: 120,
-    width: 940,
-    height: 320,
+  return {
+    startTime,
+    endTime,
+    probabilitySeries: summary.probabilities.map((entry, index) => ({
+      outcomeId: entry.outcomeId,
+      label: entry.label,
+      color: colorScale(entry.outcomeId) ?? seriesPalette[index % seriesPalette.length] ?? seriesPalette[0]!,
+      latestProbability: entry.probability,
+      points: snapshots.map((snapshot) => ({
+        time: snapshot.at.getTime(),
+        probability: snapshot.probabilities[index] ?? 0,
+      })),
+    })),
+    volumeBuckets,
+    maxBucketVolume,
+    metadata: buildMetadata(market),
+    liquidityMarkers: market.liquidityEvents.map((event) => ({
+      time: event.createdAt.getTime(),
+      label: `b=${event.nextLiquidityParameter.toFixed(0)}`,
+    })),
   };
-  const volumeChart = {
-    x: 80,
-    y: 500,
-    width: 940,
-    height: 170,
+};
+
+const fillCircle = (
+  context: SKRSContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  fillStyle: string,
+): void => {
+  context.beginPath();
+  context.arc(x, y, radius, 0, Math.PI * 2);
+  context.fillStyle = fillStyle;
+  context.fill();
+};
+
+const drawRoundedRect = (
+  context: SKRSContext2D,
+  x: number,
+  y: number,
+  rectWidth: number,
+  rectHeight: number,
+  radius: number,
+): void => {
+  const clamped = Math.min(radius, rectWidth / 2, rectHeight / 2);
+  context.beginPath();
+  context.moveTo(x + clamped, y);
+  context.lineTo(x + rectWidth - clamped, y);
+  context.arcTo(x + rectWidth, y, x + rectWidth, y + clamped, clamped);
+  context.lineTo(x + rectWidth, y + rectHeight - clamped);
+  context.arcTo(x + rectWidth, y + rectHeight, x + rectWidth - clamped, y + rectHeight, clamped);
+  context.lineTo(x + clamped, y + rectHeight);
+  context.arcTo(x, y + rectHeight, x, y + rectHeight - clamped, clamped);
+  context.lineTo(x, y + clamped);
+  context.arcTo(x, y, x + clamped, y, clamped);
+  context.closePath();
+};
+
+const getProbabilityDomain = (series: ProbabilitySeries[]): [number, number] => {
+  const values = series.flatMap((entry) => entry.points.map((point) => point.probability));
+  const min = Math.min(...values, 0.5);
+  const max = Math.max(...values, 0.5);
+  const span = max - min;
+  const paddedSpan = Math.max(0.14, span + 0.08);
+  const midpoint = (min + max) / 2;
+  const lower = Math.max(0, midpoint - (paddedSpan / 2));
+  const upper = Math.min(1, midpoint + (paddedSpan / 2));
+
+  if (upper - lower >= 0.14) {
+    return [lower, upper];
+  }
+
+  if (lower <= 0) {
+    return [0, Math.min(1, 0.14)];
+  }
+
+  return [Math.max(0, 1 - 0.14), 1];
+};
+
+const drawProbabilityGrid = (
+  context: SKRSContext2D,
+  bounds: ChartBounds,
+  domain: [number, number],
+): void => {
+  const scale = scaleLinear()
+    .domain(domain)
+    .range([bounds.y + bounds.height, bounds.y]);
+  const ticks = scale.ticks(5);
+  context.lineWidth = 1;
+
+  for (const tick of ticks) {
+    const y = scale(tick);
+    context.strokeStyle = tick === 0 || tick === 1 ? gridStrong : grid;
+    context.beginPath();
+    context.moveTo(bounds.x, y);
+    context.lineTo(bounds.x + bounds.width, y);
+    context.stroke();
+
+    drawLabel(context, formatPercent(tick, 0), bounds.x - 16, y, {
+      font: `13px ${fontStack}`,
+      color: muted,
+      align: 'right',
+      baseline: 'middle',
+    });
+  }
+};
+
+const drawVolumeGrid = (
+  context: SKRSContext2D,
+  bounds: ChartBounds,
+  maxBucketVolume: number,
+): void => {
+  const scale = scaleLinear()
+    .domain([0, Math.max(1, maxBucketVolume)])
+    .range([bounds.y + bounds.height, bounds.y]);
+  const ticks = scale.ticks(2);
+  const topY = scale(maxBucketVolume);
+  const bottomY = scale(0);
+
+  context.lineWidth = 1;
+  context.strokeStyle = gridStrong;
+  context.beginPath();
+  context.moveTo(bounds.x, topY);
+  context.lineTo(bounds.x + bounds.width, topY);
+  context.stroke();
+
+  context.strokeStyle = grid;
+  context.beginPath();
+  context.moveTo(bounds.x, bottomY);
+  context.lineTo(bounds.x + bounds.width, bottomY);
+  context.stroke();
+
+  ticks.forEach((tick) => {
+    const y = scale(tick);
+    if (tick > 0 && tick < maxBucketVolume) {
+      context.strokeStyle = grid;
+      context.beginPath();
+      context.moveTo(bounds.x, y);
+      context.lineTo(bounds.x + bounds.width, y);
+      context.stroke();
+    }
+
+    drawLabel(context, compactNumberFormatter.format(tick), bounds.x - 16, y, {
+      font: `13px ${fontStack}`,
+      color: muted,
+      align: 'right',
+      baseline: 'middle',
+    });
+  });
+};
+
+const drawStepSeries = (
+  context: SKRSContext2D,
+  bounds: ChartBounds,
+  series: ProbabilitySeries,
+  startTime: number,
+  endTime: number,
+  domain: [number, number],
+): void => {
+  if (series.points.length === 0) {
+    return;
+  }
+
+  const xScale = scaleTime<number, number>()
+    .domain([new Date(startTime), new Date(endTime)])
+    .range([bounds.x, bounds.x + bounds.width]);
+  const yScale = scaleLinear()
+    .domain(domain)
+    .range([bounds.y + bounds.height, bounds.y]);
+  const lineGenerator = line<ProbabilityPoint>()
+    .x((point) => xScale(new Date(point.time)))
+    .y((point) => yScale(point.probability))
+    .context(context as never);
+
+  context.save();
+  context.beginPath();
+  context.rect(bounds.x, bounds.y, bounds.width, bounds.height);
+  context.clip();
+  context.lineWidth = 3;
+  context.strokeStyle = series.color;
+  context.lineCap = 'round';
+  context.lineJoin = 'round';
+  context.beginPath();
+  lineGenerator(series.points);
+  context.stroke();
+
+  const latest = series.points[series.points.length - 1]!;
+  fillCircle(
+    context,
+    xScale(new Date(latest.time)),
+    yScale(latest.probability),
+    5.5,
+    series.color,
+  );
+  context.lineWidth = 2;
+  context.strokeStyle = background;
+  context.beginPath();
+  context.arc(xScale(new Date(latest.time)), yScale(latest.probability), 5.5, 0, Math.PI * 2);
+  context.stroke();
+  context.restore();
+};
+
+const drawLiquidityMarkers = (
+  context: SKRSContext2D,
+  bounds: ChartBounds,
+  startTime: number,
+  endTime: number,
+  markers: Array<{ time: number; label: string }>,
+): void => {
+  if (markers.length === 0) {
+    return;
+  }
+
+  const xScale = scaleTime<number, number>()
+    .domain([new Date(startTime), new Date(endTime)])
+    .range([bounds.x, bounds.x + bounds.width]);
+
+  markers.forEach((marker, index) => {
+    const x = xScale(new Date(marker.time));
+    const chipY = bounds.y + 10 + ((index % 2) * 18);
+
+    context.save();
+    context.strokeStyle = 'rgba(163, 173, 186, 0.28)';
+    context.lineWidth = 1;
+    context.setLineDash([5, 5]);
+    context.beginPath();
+    context.moveTo(x, bounds.y);
+    context.lineTo(x, bounds.y + bounds.height);
+    context.stroke();
+    context.setLineDash([]);
+
+    context.beginPath();
+    context.arc(x, chipY + 1, 3, 0, Math.PI * 2);
+    context.fillStyle = '#8ea1b8';
+    context.fill();
+
+    drawLabel(context, marker.label, x + 8, chipY + 4, {
+      font: `600 12px ${fontStack}`,
+      color: muted,
+      baseline: 'middle',
+    });
+    context.restore();
+  });
+};
+
+const drawVolumeHistogram = (
+  context: SKRSContext2D,
+  bounds: ChartBounds,
+  buckets: VolumeBucket[],
+  maxBucketVolume: number,
+): void => {
+  if (buckets.length === 0) {
+    return;
+  }
+
+  const xScale = scaleBand<string>()
+    .domain(buckets.map((bucket) => bucket.index.toString()))
+    .range([bounds.x, bounds.x + bounds.width])
+    .paddingInner(0.14)
+    .paddingOuter(0.04);
+  const yScale = scaleLinear()
+    .domain([0, Math.max(1, maxBucketVolume)])
+    .range([bounds.y + bounds.height, bounds.y]);
+
+  buckets.forEach((bucket) => {
+    const x = xScale(bucket.index.toString());
+    if (x === undefined) {
+      return;
+    }
+    const y = yScale(bucket.volume);
+    const barWidth = xScale.bandwidth();
+    const barHeight = Math.max(1.5, (bounds.y + bounds.height) - y);
+
+    context.fillStyle = bucket.volume > 0 ? volumeColor : 'rgba(111, 143, 192, 0.18)';
+    context.fillRect(x, y, Math.max(1, barWidth), barHeight);
+  });
+};
+
+const drawTimeAxis = (
+  context: SKRSContext2D,
+  bounds: ChartBounds,
+  startTime: number,
+  endTime: number,
+): void => {
+  const scale = scaleTime<number, number>()
+    .domain([new Date(startTime), new Date(endTime)])
+    .range([bounds.x, bounds.x + bounds.width]);
+  const ticks = scale.ticks(4);
+  ticks.forEach((tick, index) => {
+    const x = scale(tick);
+    drawLabel(context, formatAxisTime(tick.getTime(), startTime, endTime), x, bounds.y + bounds.height + 28, {
+      font: `13px ${fontStack}`,
+      color: muted,
+      align: index === 0 ? 'left' : index === ticks.length - 1 ? 'right' : 'center',
+    });
+  });
+};
+
+const drawMetadataItem = async (
+  context: SKRSContext2D,
+  item: MetadataItem,
+  x: number,
+  y: number,
+): Promise<void> => {
+  const icon = await loadTablerIcon(item.icon, 20, item.accent);
+  context.drawImage(icon, x, y + 4, 20, 20);
+
+  drawLabel(context, item.value, x + 30, y + 15, {
+    font: `700 20px ${fontStack}`,
+    color: item.accent,
+  });
+  drawLabel(context, item.label, x + 30, y + 38, {
+    font: `14px ${fontStack}`,
+    color: muted,
+  });
+};
+
+const drawLegend = (
+  context: SKRSContext2D,
+  series: ProbabilitySeries[],
+  x: number,
+  y: number,
+  maxWidth: number,
+): void => {
+  const columns = series.length > 3 ? 2 : Math.max(1, series.length);
+  const columnGap = 18;
+  const itemWidth = Math.floor((maxWidth - (columnGap * (columns - 1))) / columns);
+  const rowHeight = 22;
+
+  series.forEach((entry, index) => {
+    const column = index % columns;
+    const row = Math.floor(index / columns);
+    const itemX = x + (column * (itemWidth + columnGap));
+    const itemY = y + (row * rowHeight);
+
+    context.strokeStyle = entry.color;
+    context.lineWidth = 3;
+    context.beginPath();
+    context.moveTo(itemX, itemY + 9);
+    context.lineTo(itemX + 18, itemY + 9);
+    context.stroke();
+    fillCircle(context, itemX + 9, itemY + 9, 4, entry.color);
+
+    const labelX = itemX + 28;
+    const labelY = itemY + 14;
+    context.font = `700 14px ${fontStack}`;
+    const value = formatPercent(entry.latestProbability, 1);
+    const valueWidth = context.measureText(value).width;
+    const label = truncateToWidth(context, entry.label, Math.max(46, itemWidth - 44 - valueWidth - 8));
+    drawLabel(context, label, labelX, labelY, {
+      font: `15px ${fontStack}`,
+      color: text,
+    });
+    const labelWidth = context.measureText(label).width;
+    drawLabel(context, value, labelX + labelWidth + 8, labelY, {
+      font: `700 14px ${fontStack}`,
+      color: muted,
+    });
+  });
+};
+
+const getLegendMetrics = (
+  series: ProbabilitySeries[],
+): {
+  columns: number;
+  rowCount: number;
+} => {
+  const columns = series.length > 3 ? 2 : Math.max(1, series.length);
+  return {
+    columns,
+    rowCount: Math.ceil(series.length / columns),
+  };
+};
+
+const buildCanvas = async (market: MarketWithRelations): Promise<Buffer> => {
+  ensurePublicSansLoaded();
+  const canvas = createCanvas(width, height);
+  const context = canvas.getContext('2d');
+  const generatedAt = new Date();
+  const model = buildMarketChartModel(market);
+  const probabilityDomain = getProbabilityDomain(model.probabilitySeries);
+
+  context.fillStyle = background;
+  context.fillRect(0, 0, width, height);
+
+  context.lineWidth = 1;
+  context.strokeStyle = border;
+  context.strokeRect(28, 28, width - 56, height - 56);
+
+  context.font = `700 34px ${fontStack}`;
+  const titleLines = wrapText(context, market.title, 620, 2);
+
+  titleLines.forEach((line, index) => {
+    drawLabel(context, line, 68, 74 + (index * 40), {
+      font: `700 34px ${fontStack}`,
+      color: text,
+    });
+  });
+
+  const titleBlockHeight = 40 * titleLines.length;
+  const subtitleY = 58 + titleBlockHeight;
+  drawLabel(context, 'Market probabilities over time', 68, subtitleY, {
+    font: `17px ${fontStack}`,
+    color: muted,
+  });
+
+  const statsX = 782;
+  const statsY = 62;
+  await Promise.all(model.metadata.map((item, index) => drawMetadataItem(
+    context,
+    item,
+    statsX + ((index % 2) * 184),
+    statsY + (Math.floor(index / 2) * 58),
+  )));
+
+  const legendX = 68;
+  const legendMaxWidth = 560;
+  const legendY = subtitleY + 28;
+  const legendMetrics = getLegendMetrics(model.probabilitySeries);
+  const legendHeight = (legendMetrics.rowCount * 22);
+  drawLegend(context, model.probabilitySeries, legendX, legendY, legendMaxWidth);
+
+  const probabilityBounds: ChartBounds = {
+    x: 116,
+    y: legendY + legendHeight + 24,
+    width: 1000,
+    height: 272,
+  };
+  const volumeBounds: ChartBounds = {
+    x: probabilityBounds.x,
+    y: probabilityBounds.y + probabilityBounds.height + 56,
+    width: probabilityBounds.width,
+    height: 86,
   };
 
-  const toX = (time: number): number =>
-    probabilityChart.x + (((time - minTime) / Math.max(1, maxTime - minTime)) * probabilityChart.width);
-  const toProbabilityY = (probability: number): number =>
-    probabilityChart.y + ((1 - probability) * probabilityChart.height);
-  const toVolumeY = (volume: number): number =>
-    volumeChart.y + volumeChart.height - ((volume / maxVolume) * volumeChart.height);
+  drawLabel(context, 'PROBABILITY', probabilityBounds.x, probabilityBounds.y - 18, {
+    font: `700 12px ${fontStack}`,
+    color: quiet,
+  });
+  drawLabel(context, 'TRADING VOLUME', volumeBounds.x, volumeBounds.y - 18, {
+    font: `700 12px ${fontStack}`,
+    color: quiet,
+  });
 
-  const probabilityGrid = [0, 0.25, 0.5, 0.75, 1].map((tick) => {
-    const y = toProbabilityY(tick);
-    return `
-      <line x1="${probabilityChart.x}" y1="${y}" x2="${probabilityChart.x + probabilityChart.width}" y2="${y}" stroke="${grid}" stroke-width="1" stroke-dasharray="6 6"/>
-      <text x="${probabilityChart.x - 14}" y="${y + 6}" fill="${muted}" font-size="16" text-anchor="end">${escapeXml(formatPercent(tick))}</text>
-    `;
-  }).join('');
+  drawProbabilityGrid(context, probabilityBounds, probabilityDomain);
+  drawVolumeGrid(context, volumeBounds, model.maxBucketVolume);
+  drawLiquidityMarkers(context, probabilityBounds, model.startTime, model.endTime, model.liquidityMarkers);
 
-  const volumeGrid = [0, 0.5, 1].map((tick) => {
-    const y = toVolumeY(maxVolume * tick);
-    return `
-      <line x1="${volumeChart.x}" y1="${y}" x2="${volumeChart.x + volumeChart.width}" y2="${y}" stroke="${grid}" stroke-width="1" stroke-dasharray="6 6"/>
-      <text x="${volumeChart.x - 14}" y="${y + 6}" fill="${muted}" font-size="16" text-anchor="end">${Math.round(maxVolume * tick)}</text>
-    `;
-  }).join('');
+  context.strokeStyle = gridStrong;
+  context.lineWidth = 1;
+  context.beginPath();
+  context.moveTo(probabilityBounds.x, probabilityBounds.y + probabilityBounds.height + 42);
+  context.lineTo(probabilityBounds.x + probabilityBounds.width, probabilityBounds.y + probabilityBounds.height + 42);
+  context.stroke();
 
-  const lines = market.outcomes.map((outcome, outcomeIndex) => {
-    const points = snapshots.map((snapshot) => ({
-      x: toX(snapshot.at.getTime()),
-      y: toProbabilityY(snapshot.probabilities[outcomeIndex] ?? 0),
-    }));
-    const latest = points[points.length - 1];
-    return `
-      <path d="${buildLinePath(points)}" fill="none" stroke="${colorScale(outcome.id)}" stroke-width="4" stroke-linejoin="round" stroke-linecap="round"/>
-      <circle cx="${latest?.x ?? 0}" cy="${latest?.y ?? 0}" r="6" fill="${colorScale(outcome.id)}"/>
-    `;
-  }).join('');
+  model.probabilitySeries.forEach((series) => {
+    drawStepSeries(context, probabilityBounds, series, model.startTime, model.endTime, probabilityDomain);
+  });
+  drawVolumeHistogram(context, volumeBounds, model.volumeBuckets, model.maxBucketVolume);
+  drawTimeAxis(context, volumeBounds, model.startTime, model.endTime);
 
-  const bars = snapshots.slice(1).map((snapshot, index, array) => {
-    const previousTime = index === 0
-      ? minTime
-      : array[index - 1]?.at.getTime() ?? minTime;
-    const x = toX(snapshot.at.getTime());
-    const previousX = toX(previousTime);
-    const barWidth = Math.max(6, x - previousX - 2);
-    const volume = snapshot.cumulativeVolume - (snapshots[index]?.cumulativeVolume ?? 0);
-    const y = toVolumeY(Math.max(volume, 0));
-    return `<rect x="${Math.max(volumeChart.x, x - barWidth / 2)}" y="${y}" width="${barWidth}" height="${volumeChart.y + volumeChart.height - y}" rx="6" fill="${volumeColor}" fill-opacity="0.85"/>`;
-  }).join('');
+  drawLabel(context, `Market ID ${market.id}`, 68, height - 12, {
+    font: `13px ${fontStack}`,
+    color: quiet,
+    baseline: 'bottom',
+  });
+  drawLabel(context, `Generated ${formatFooterTimestamp(generatedAt)}`, width - 68, height - 12, {
+    font: `13px ${fontStack}`,
+    color: quiet,
+    align: 'right',
+    baseline: 'bottom',
+  });
 
-  const legend = market.outcomes.map((outcome, index) => `
-    <g transform="translate(${80 + ((index % 2) * 260)} ${52 + (Math.floor(index / 2) * 26)})">
-      <circle cx="0" cy="0" r="6" fill="${colorScale(outcome.id)}"/>
-      <text x="14" y="6" fill="${text}" font-size="18">${escapeXml(outcome.label)}</text>
-    </g>
-  `).join('');
-
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">
-  <style>
-    text { font-family: ${fontStack}; text-rendering: geometricPrecision; }
-  </style>
-  <rect width="${width}" height="${height}" rx="28" fill="${background}"/>
-  <rect x="40" y="90" width="${width - 80}" height="380" rx="24" fill="${panel}" stroke="${border}"/>
-  <rect x="40" y="480" width="${width - 80}" height="220" rx="24" fill="${panelAlt}" stroke="${border}"/>
-  <text x="80" y="42" fill="${text}" font-size="34" font-weight="700">${escapeXml(market.title)}</text>
-  <text x="80" y="88" fill="${muted}" font-size="18">Probability over time</text>
-  ${legend}
-  <text x="80" y="526" fill="${muted}" font-size="18">Trading volume</text>
-  ${probabilityGrid}
-  ${volumeGrid}
-  ${lines}
-  ${bars}
-</svg>`;
+  return canvas.encode('png');
 };
 
 export const buildMarketDiagram = async (market: MarketWithRelations): Promise<DiagramPayload> => {
   const fileName = `market-${market.id}.png`;
-  const svg = buildSvg(market);
-  const buffer = await sharp(Buffer.from(svg))
-    .png()
-    .toBuffer();
+  const buffer = await buildCanvas(market);
 
   return {
     fileName,

--- a/src/features/markets/ui/visualize.ts
+++ b/src/features/markets/ui/visualize.ts
@@ -36,7 +36,6 @@ const muted = '#a3adba';
 const quiet = '#66707d';
 const grid = '#2f3640';
 const gridStrong = '#404856';
-const panel = '#1c2128';
 const volumeColor = '#6f8fc0';
 const fontFamily = 'Public Sans';
 const fontStack = `'${fontFamily}', 'DejaVu Sans', 'Noto Sans', 'Liberation Sans', sans-serif`;
@@ -137,7 +136,7 @@ export type MarketChartModel = {
   }>;
 };
 
-const imageCache = new Map<string, Promise<LoadedImage>>();
+const imageCache = new Map<string, Promise<LoadedImage | null>>();
 
 const axisDateFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'short',
@@ -268,7 +267,7 @@ const formatFooterTimestamp = (value: Date): string => footerDateTimeFormatter.f
 const resolvePublicSansPath = (
   weight: 400 | 500 | 700,
   moduleUrl: string = import.meta.url,
-): string => {
+): string | null => {
   const relativePath = `files/public-sans-latin-${weight}-normal.woff2`;
   const candidates = [
     resolve(process.cwd(), 'node_modules', '@fontsource', 'public-sans', relativePath),
@@ -281,7 +280,7 @@ const resolvePublicSansPath = (
     }
   }
 
-  return candidates[0]!;
+  return null;
 };
 
 const ensurePublicSansLoaded = (): void => {
@@ -289,16 +288,20 @@ const ensurePublicSansLoaded = (): void => {
     return;
   }
 
-  GlobalFonts.registerFromPath(resolvePublicSansPath(400), fontFamily);
-  GlobalFonts.registerFromPath(resolvePublicSansPath(500), fontFamily);
-  GlobalFonts.registerFromPath(resolvePublicSansPath(700), fontFamily);
+  for (const weight of [400, 500, 700] as const) {
+    const path = resolvePublicSansPath(weight);
+    if (path) {
+      GlobalFonts.registerFromPath(path, fontFamily);
+    }
+  }
+
   publicSansRegistered = true;
 };
 
 const resolveTablerIconPath = (
   iconName: string,
   moduleUrl: string = import.meta.url,
-): string => {
+): string | null => {
   const relativePath = `icons/outline/${iconName}.svg`;
   const candidates = [
     resolve(process.cwd(), 'node_modules', '@tabler', 'icons', relativePath),
@@ -311,26 +314,19 @@ const resolveTablerIconPath = (
     }
   }
 
-  return candidates[0]!;
-};
-
-const loadCachedImage = (file: string): Promise<LoadedImage> => {
-  const cached = imageCache.get(file);
-  if (cached) {
-    return cached;
-  }
-
-  const pending = readFile(file).then((buffer) => loadImage(buffer));
-  imageCache.set(file, pending);
-  return pending;
+  return null;
 };
 
 const loadTablerIcon = async (
   iconName: keyof typeof tablerIconNames,
   size: number,
   tint: string,
-): Promise<LoadedImage> => {
+) : Promise<LoadedImage | null> => {
   const file = resolveTablerIconPath(tablerIconNames[iconName]);
+  if (!file) {
+    return null;
+  }
+
   const cacheKey = `${file}:${size}:${tint}`;
   const cached = imageCache.get(cacheKey);
   if (cached) {
@@ -360,11 +356,15 @@ export const resolveMarketDiagramEndTime = (market: MarketWithRelations, now = n
     return market.tradingClosedAt;
   }
 
-  const latestHistoryTime = Math.max(
-    market.createdAt.getTime(),
-    ...market.trades.map((trade) => trade.createdAt.getTime()),
-    ...market.liquidityEvents.map((event) => event.createdAt.getTime()),
-  );
+  let latestHistoryTime = market.createdAt.getTime();
+
+  for (const trade of market.trades) {
+    latestHistoryTime = Math.max(latestHistoryTime, trade.createdAt.getTime());
+  }
+
+  for (const event of market.liquidityEvents) {
+    latestHistoryTime = Math.max(latestHistoryTime, event.createdAt.getTime());
+  }
 
   return new Date(Math.max(now.getTime(), latestHistoryTime));
 };
@@ -467,8 +467,11 @@ export const bucketTradeVolumes = (
   const thresholds = Array.from({ length: bucketCount + 1 }, (_, index) => (
     index === bucketCount ? safeEndTime : startTime + (bucketSpan * index)
   ));
+  const sortedTrades = [...market.trades].sort((left, right) => (
+    left.createdAt.getTime() - right.createdAt.getTime()
+  ));
   let previousCumulativeVolume = 0;
-  const tradeDeltas = market.trades.map((trade) => {
+  const tradeDeltas = sortedTrades.map((trade) => {
     const delta = Math.max(0, trade.cumulativeVolume - previousCumulativeVolume);
     previousCumulativeVolume = trade.cumulativeVolume;
     return {
@@ -592,28 +595,6 @@ const fillCircle = (
   context.arc(x, y, radius, 0, Math.PI * 2);
   context.fillStyle = fillStyle;
   context.fill();
-};
-
-const drawRoundedRect = (
-  context: SKRSContext2D,
-  x: number,
-  y: number,
-  rectWidth: number,
-  rectHeight: number,
-  radius: number,
-): void => {
-  const clamped = Math.min(radius, rectWidth / 2, rectHeight / 2);
-  context.beginPath();
-  context.moveTo(x + clamped, y);
-  context.lineTo(x + rectWidth - clamped, y);
-  context.arcTo(x + rectWidth, y, x + rectWidth, y + clamped, clamped);
-  context.lineTo(x + rectWidth, y + rectHeight - clamped);
-  context.arcTo(x + rectWidth, y + rectHeight, x + rectWidth - clamped, y + rectHeight, clamped);
-  context.lineTo(x + clamped, y + rectHeight);
-  context.arcTo(x, y + rectHeight, x, y + rectHeight - clamped, clamped);
-  context.lineTo(x, y + clamped);
-  context.arcTo(x, y, x + clamped, y, clamped);
-  context.closePath();
 };
 
 const getProbabilityDomain = (series: ProbabilitySeries[]): [number, number] => {
@@ -863,13 +844,16 @@ const drawMetadataItem = async (
   y: number,
 ): Promise<void> => {
   const icon = await loadTablerIcon(item.icon, 20, item.accent);
-  context.drawImage(icon, x, y + 4, 20, 20);
+  const textX = icon ? x + 30 : x;
+  if (icon) {
+    context.drawImage(icon, x, y + 4, 20, 20);
+  }
 
-  drawLabel(context, item.value, x + 30, y + 15, {
+  drawLabel(context, item.value, textX, y + 15, {
     font: `700 20px ${fontStack}`,
     color: item.accent,
   });
-  drawLabel(context, item.label, x + 30, y + 38, {
+  drawLabel(context, item.label, textX, y + 38, {
     font: `14px ${fontStack}`,
     color: muted,
   });

--- a/tests/market-visualize.test.ts
+++ b/tests/market-visualize.test.ts
@@ -106,6 +106,28 @@ describe('market visualize', () => {
     expect(buckets.map((bucket) => bucket.tradeCount)).toEqual([1, 1, 0, 1]);
   });
 
+  it('sorts trades by createdAt before computing bucket deltas', () => {
+    const market = {
+      ...baseMarket,
+      totalVolume: 20,
+      trades: [
+        createTrade('trade_2', 'outcome_no', 13, '2099-03-29T11:00:00.000Z'),
+        createTrade('trade_1', 'outcome_yes', 5, '2099-03-29T01:00:00.000Z'),
+        createTrade('trade_3', 'outcome_yes', 20, '2099-03-29T23:00:00.000Z'),
+      ],
+    } satisfies MarketWithRelations;
+
+    const buckets = bucketTradeVolumes(
+      market,
+      new Date('2099-03-29T00:00:00.000Z').getTime(),
+      new Date('2099-03-30T00:00:00.000Z').getTime(),
+      4,
+    );
+
+    expect(buckets.map((bucket) => bucket.volume)).toEqual([5, 8, 0, 7]);
+    expect(buckets.map((bucket) => bucket.tradeCount)).toEqual([1, 1, 0, 1]);
+  });
+
   it('does not create a fake trailing volume spike from the terminal probability snapshot', () => {
     const market = {
       ...baseMarket,

--- a/tests/market-visualize.test.ts
+++ b/tests/market-visualize.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveMarketDiagramEndTime } from '../src/features/markets/ui/visualize.js';
+import type { MarketWithRelations } from '../src/features/markets/core/types.js';
+import {
+  buildMarketChartModel,
+  bucketTradeVolumes,
+  resolveMarketDiagramEndTime,
+} from '../src/features/markets/ui/visualize.js';
 
 const baseMarket = {
   id: 'market_1',
@@ -44,6 +49,25 @@ const baseMarket = {
   liquidityEvents: [],
 };
 
+const createTrade = (
+  id: string,
+  outcomeId: string,
+  cumulativeVolume: number,
+  createdAt: string,
+) => ({
+  id,
+  marketId: 'market_1',
+  outcomeId,
+  userId: `user_${id}`,
+  side: 'buy' as const,
+  shareDelta: 2,
+  cashDelta: -10,
+  feeCharged: 0,
+  probabilitySnapshot: 0.5,
+  cumulativeVolume,
+  createdAt: new Date(createdAt),
+});
+
 describe('market visualize', () => {
   it('uses now as the chart endpoint for open markets', () => {
     const now = new Date('2099-03-29T12:00:00.000Z');
@@ -58,5 +82,78 @@ describe('market visualize', () => {
       ...baseMarket,
       tradingClosedAt: closedAt,
     }, new Date('2099-03-29T20:00:00.000Z')).toISOString()).toBe(closedAt.toISOString());
+  });
+
+  it('buckets trade volume by time instead of stretching a sparse trade across the footer', () => {
+    const market = {
+      ...baseMarket,
+      totalVolume: 20,
+      trades: [
+        createTrade('trade_1', 'outcome_yes', 5, '2099-03-29T01:00:00.000Z'),
+        createTrade('trade_2', 'outcome_no', 13, '2099-03-29T11:00:00.000Z'),
+        createTrade('trade_3', 'outcome_yes', 20, '2099-03-29T23:00:00.000Z'),
+      ],
+    } satisfies MarketWithRelations;
+
+    const buckets = bucketTradeVolumes(
+      market,
+      new Date('2099-03-29T00:00:00.000Z').getTime(),
+      new Date('2099-03-30T00:00:00.000Z').getTime(),
+      4,
+    );
+
+    expect(buckets.map((bucket) => bucket.volume)).toEqual([5, 8, 0, 7]);
+    expect(buckets.map((bucket) => bucket.tradeCount)).toEqual([1, 1, 0, 1]);
+  });
+
+  it('does not create a fake trailing volume spike from the terminal probability snapshot', () => {
+    const market = {
+      ...baseMarket,
+      totalVolume: 40,
+      resolvedAt: new Date('2099-03-30T12:00:00.000Z'),
+      winningOutcomeId: 'outcome_yes',
+      trades: [
+        createTrade('trade_1', 'outcome_yes', 40, '2099-03-29T01:00:00.000Z'),
+      ],
+    } satisfies MarketWithRelations;
+
+    const model = buildMarketChartModel(market, new Date('2099-03-30T18:00:00.000Z'));
+
+    expect(model.volumeBuckets.reduce((sum, bucket) => sum + bucket.volume, 0)).toBe(40);
+    expect(model.volumeBuckets.at(-1)?.volume ?? 0).toBe(0);
+    expect(model.endTime).toBe(new Date('2099-03-30T12:00:00.000Z').getTime());
+  });
+
+  it('builds a probability series for every outcome in outcome order', () => {
+    const market = {
+      ...baseMarket,
+      outcomes: [
+        ...baseMarket.outcomes,
+        {
+          id: 'outcome_maybe',
+          marketId: 'market_1',
+          label: 'Maybe',
+          sortOrder: 2,
+          outstandingShares: 0,
+          pricingShares: 0,
+          settlementValue: null,
+          resolvedAt: null,
+          resolvedByUserId: null,
+          resolutionNote: null,
+          resolutionEvidenceUrl: null,
+          createdAt: new Date('2099-03-29T00:00:00.000Z'),
+        },
+      ],
+    } satisfies MarketWithRelations;
+
+    const model = buildMarketChartModel(market, new Date('2099-03-29T12:00:00.000Z'));
+
+    expect(model.probabilitySeries).toHaveLength(3);
+    expect(model.probabilitySeries.map((entry) => entry.label)).toEqual(['Yes', 'No', 'Maybe']);
+    expect(model.probabilitySeries.every((entry) => entry.points.length >= 2)).toBe(true);
+
+    const totalProbability = model.probabilitySeries
+      .reduce((sum, entry) => sum + entry.latestProbability, 0);
+    expect(totalProbability).toBeCloseTo(1, 6);
   });
 });


### PR DESCRIPTION
## Summary
- replace the market visualizer with a server-side canvas renderer using D3-driven chart primitives
- improve market chart layout, typography, metadata, and footer details for exported PNGs
- add coverage for volume bucketing and chart model behavior in market visualizer tests

## Verification
- pnpm build
- pnpm lint
- pnpm test -- tests/market-visualize.test.ts