### PR TITLE
Refactor market interaction sessions and enrich forecast profiles

### DIFF
--- a/src/features/markets/core/types.ts
+++ b/src/features/markets/core/types.ts
@@ -1,246 +1,320 @@
 import type {
-  Market,
-  MarketAccount,
-  MarketButtonStyle,
-  MarketForecastRecord,
-  MarketLossProtection,
-  MarketLiquidityEvent,
-  MarketOutcome,
-  MarketPositionSide,
-  MarketPosition,
-  MarketTrade,
-} from '@prisma/client';
+	Market,
+	MarketAccount,
+	MarketButtonStyle,
+	MarketForecastRecord,
+	MarketLossProtection,
+	MarketLiquidityEvent,
+	MarketOutcome,
+	MarketPositionSide,
+	MarketPosition,
+	MarketTrade,
+} from "@prisma/client";
 
 export type MarketWithRelations = Market & {
-  outcomes: MarketOutcome[];
-  trades: MarketTrade[];
-  positions: MarketPosition[];
-  lossProtections?: MarketLossProtection[];
-  winningOutcome: MarketOutcome | null;
-  liquidityEvents: MarketLiquidityEvent[];
+	outcomes: MarketOutcome[];
+	trades: MarketTrade[];
+	positions: MarketPosition[];
+	lossProtections?: MarketLossProtection[];
+	winningOutcome: MarketOutcome | null;
+	liquidityEvents: MarketLiquidityEvent[];
 };
 
 export type MarketPositionWithProtection = MarketPosition & {
-  market: Market;
-  outcome: MarketOutcome;
-  insuredCostBasis?: number;
-  premiumPaid?: number;
-  coverageRatio?: number;
-  uninsuredCostBasis?: number;
+	market: Market;
+	outcome: MarketOutcome;
+	insuredCostBasis?: number;
+	premiumPaid?: number;
+	coverageRatio?: number;
+	uninsuredCostBasis?: number;
 };
 
 export type MarketAccountWithOpenPositions = MarketAccount & {
-  lockedCollateral: number;
-  openPositions: MarketPositionWithProtection[];
+	lockedCollateral: number;
+	openPositions: MarketPositionWithProtection[];
 };
 
-export type MarketStatus = 'open' | 'closed' | 'resolved' | 'cancelled';
+export type MarketStatus = "open" | "closed" | "resolved" | "cancelled";
 
 export type MarketCreationInput = {
-  guildId: string;
-  creatorId: string;
-  originChannelId: string;
-  marketChannelId: string;
-  title: string;
-  description: string | null;
-  buttonStyle: MarketButtonStyle;
-  outcomes: string[];
-  tags: string[];
-  closeAt: Date;
+	guildId: string;
+	creatorId: string;
+	originChannelId: string;
+	marketChannelId: string;
+	title: string;
+	description: string | null;
+	buttonStyle: MarketButtonStyle;
+	outcomes: string[];
+	tags: string[];
+	closeAt: Date;
 };
 
 export type MarketTradeResult = {
-  market: MarketWithRelations;
-  outcome: MarketOutcome;
-  account: MarketAccount;
-  positionSide: MarketPositionSide;
-  shareDelta: number;
-  cashAmount: number;
-  grossCashAmount: number;
-  netCashAmount: number;
-  feeCharged: number;
-  realizedProfitDelta: number;
+	market: MarketWithRelations;
+	outcome: MarketOutcome;
+	account: MarketAccount;
+	positionSide: MarketPositionSide;
+	shareDelta: number;
+	cashAmount: number;
+	grossCashAmount: number;
+	netCashAmount: number;
+	feeCharged: number;
+	realizedProfitDelta: number;
 };
 
-export type MarketTradeQuoteAction = 'buy' | 'short';
+export type MarketTradeQuoteAction = "buy" | "sell" | "short" | "cover";
 
 export type MarketTradeQuote = {
-  action: MarketTradeQuoteAction;
-  marketId: string;
-  marketTitle: string;
-  outcomeId: string;
-  outcomeLabel: string;
-  userId: string;
-  guildId: string;
-  amount: number;
-  amountMode: 'points' | 'shares';
-  rawAmount: string;
-  shares: number;
-  averagePrice: number | null;
-  immediateCash: number;
-  grossImmediateCash: number;
-  netImmediateCash: number;
-  feeCharged: number;
-  collateralLocked: number;
-  netBankrollChange: number;
-  settlementIfChosen: number;
-  settlementIfNotChosen: number;
-  maxProfitIfChosen: number;
-  maxProfitIfNotChosen: number;
-  maxLossIfChosen: number;
-  maxLossIfNotChosen: number;
+	action: MarketTradeQuoteAction;
+	marketId: string;
+	marketTitle: string;
+	outcomeId: string;
+	outcomeLabel: string;
+	userId: string;
+	guildId: string;
+	amount: number;
+	amountMode: "points" | "shares";
+	rawAmount: string;
+	shares: number;
+	averagePrice: number | null;
+	currentProbability: number;
+	nextProbability: number;
+	immediateCash: number;
+	grossImmediateCash: number;
+	netImmediateCash: number;
+	feeCharged: number;
+	collateralLocked: number;
+	collateralReleased: number;
+	netBankrollChange: number;
+	bankrollAfter: number;
+	positionSide: MarketPositionSide;
+	positionSharesAfter: number;
+	positionCostBasisAfter: number;
+	positionProceedsAfter: number;
+	positionCollateralAfter: number;
+	realizedProfitDelta: number;
+	settlementIfChosen: number;
+	settlementIfNotChosen: number;
+	maxProfitIfChosen: number;
+	maxProfitIfNotChosen: number;
+	maxLossIfChosen: number;
+	maxLossIfNotChosen: number;
 };
 
 export type MarketTradeQuoteSession = {
-  kind: 'trade';
-  sessionId: string;
-  action: MarketTradeQuoteAction;
-  guildId: string;
-  marketId: string;
-  marketTitle: string;
-  outcomeId: string;
-  outcomeLabel: string;
-  userId: string;
-  rawAmount: string;
-  amount: number;
-  amountMode: 'points' | 'shares';
-  shares: number;
-  averagePrice: number | null;
-  immediateCash: number;
-  grossImmediateCash: number;
-  netImmediateCash: number;
-  feeCharged: number;
-  collateralLocked: number;
-  netBankrollChange: number;
-  settlementIfChosen: number;
-  settlementIfNotChosen: number;
-  maxProfitIfChosen: number;
-  maxProfitIfNotChosen: number;
-  maxLossIfChosen: number;
-  maxLossIfNotChosen: number;
-  expiresAt: string;
+	kind: "trade";
+	sessionId: string;
+	action: MarketTradeQuoteAction;
+	guildId: string;
+	marketId: string;
+	marketTitle: string;
+	outcomeId: string;
+	outcomeLabel: string;
+	userId: string;
+	rawAmount: string;
+	amount: number;
+	amountMode: "points" | "shares";
+	shares: number;
+	averagePrice: number | null;
+	currentProbability: number;
+	nextProbability: number;
+	immediateCash: number;
+	grossImmediateCash: number;
+	netImmediateCash: number;
+	feeCharged: number;
+	collateralLocked: number;
+	collateralReleased: number;
+	netBankrollChange: number;
+	bankrollAfter: number;
+	positionSide: MarketPositionSide;
+	positionSharesAfter: number;
+	positionCostBasisAfter: number;
+	positionProceedsAfter: number;
+	positionCollateralAfter: number;
+	realizedProfitDelta: number;
+	settlementIfChosen: number;
+	settlementIfNotChosen: number;
+	maxProfitIfChosen: number;
+	maxProfitIfNotChosen: number;
+	maxLossIfChosen: number;
+	maxLossIfNotChosen: number;
+	expiresAt: string;
 };
 
 export type MarketLossProtectionQuote = {
-  marketId: string;
-  marketTitle: string;
-  outcomeId: string;
-  outcomeLabel: string;
-  guildId: string;
-  userId: string;
-  currentProbability: number;
-  currentLongCostBasis: number;
-  alreadyInsuredCostBasis: number;
-  targetCoverage: number;
-  targetInsuredCostBasis: number;
-  incrementalInsuredCostBasis: number;
-  premium: number;
-  payoutIfLoses: number;
+	marketId: string;
+	marketTitle: string;
+	outcomeId: string;
+	outcomeLabel: string;
+	guildId: string;
+	userId: string;
+	currentProbability: number;
+	currentLongCostBasis: number;
+	alreadyInsuredCostBasis: number;
+	targetCoverage: number;
+	targetInsuredCostBasis: number;
+	incrementalInsuredCostBasis: number;
+	premium: number;
+	payoutIfLoses: number;
 };
 
 export type MarketLossProtectionQuoteSession = MarketLossProtectionQuote & {
-  kind: 'protection';
-  sessionId: string;
-  expiresAt: string;
+	kind: "protection";
+	sessionId: string;
+	expiresAt: string;
 };
 
-export type MarketQuoteSession = MarketTradeQuoteSession | MarketLossProtectionQuoteSession;
+export type MarketQuoteSession =
+	| MarketTradeQuoteSession
+	| MarketLossProtectionQuoteSession;
+
+export type MarketInteractionSessionAction = MarketTradeQuoteAction | "protect";
+
+export type MarketInteractionSession = {
+	sessionId: string;
+	userId: string;
+	marketId: string;
+	mode: "trade" | "manage";
+	selectedOutcomeId: string | null;
+	selectedAction: MarketInteractionSessionAction | null;
+	amountInput: string | null;
+	targetCoverage: number | null;
+	preview:
+		| {
+				kind: "trade";
+				quote: MarketTradeQuote;
+		  }
+		| {
+				kind: "protection";
+				quote: MarketLossProtectionQuote;
+		  }
+		| null;
+	expiresAt: string;
+};
 
 export type MarketLossProtectionPurchaseResult = {
-  market: MarketWithRelations;
-  outcome: MarketOutcome;
-  account: MarketAccount;
-  insuredCostBasis: number;
-  premiumPaid: number;
-  coverageRatio: number;
-  uninsuredCostBasis: number;
-  premiumCharged: number;
+	market: MarketWithRelations;
+	outcome: MarketOutcome;
+	account: MarketAccount;
+	insuredCostBasis: number;
+	premiumPaid: number;
+	coverageRatio: number;
+	uninsuredCostBasis: number;
+	premiumCharged: number;
 };
 
 export type MarketForecastVectorEntry = {
-  outcomeId: string;
-  probability: number;
+	outcomeId: string;
+	probability: number;
 };
 
 export type MarketForecastProfile = {
-  userId: string;
-  allTimeMeanBrier: number | null;
-  thirtyDayMeanBrier: number | null;
-  allTimeSampleCount: number;
-  thirtyDaySampleCount: number;
-  percentileRank: number | null;
-  rank: number | null;
-  rankedUserCount: number;
-  currentCorrectPickStreak: number;
-  bestCorrectPickStreak: number;
-  currentProfitableMarketStreak: number;
-  bestProfitableMarketStreak: number;
-  calibrationBuckets: Array<{
-    label: string;
-    sampleCount: number;
-    averageConfidence: number;
-    actualRate: number;
-  }>;
-  topTags: Array<{
-    tag: string;
-    meanBrier: number;
-    sampleCount: number;
-  }>;
+	userId: string;
+	allTimeMeanBrier: number | null;
+	thirtyDayMeanBrier: number | null;
+	allTimeSampleCount: number;
+	thirtyDaySampleCount: number;
+	percentileRank: number | null;
+	rank: number | null;
+	rankedUserCount: number;
+	currentCorrectPickStreak: number;
+	bestCorrectPickStreak: number;
+	currentProfitableMarketStreak: number;
+	bestProfitableMarketStreak: number;
+	calibrationBuckets: Array<{
+		label: string;
+		sampleCount: number;
+		averageConfidence: number;
+		actualRate: number;
+	}>;
+	topTags: Array<{
+		tag: string;
+		meanBrier: number;
+		sampleCount: number;
+	}>;
+};
+
+export type MarketForecastProfileRecentRecord = {
+	marketId: string;
+	marketTitle: string;
+	resolvedAt: Date;
+	brierScore: number;
+	realizedProfit: number;
+	wasCorrect: boolean;
+	predictedOutcomeId: string;
+	winningOutcomeId: string;
+	winningOutcomeProbability: number;
+	tradeCount: number;
+	stakeWeight: number;
+	tags: string[];
+};
+
+export type MarketForecastProfileTrendPoint = {
+	time: number;
+	brierScore: number;
+	realizedProfit: number;
+	cumulativeProfit: number;
+};
+
+export type MarketForecastProfileDetails = MarketForecastProfile & {
+	recentRecords: MarketForecastProfileRecentRecord[];
+	brierTrend: MarketForecastProfileTrendPoint[];
+	profitTrend: MarketForecastProfileTrendPoint[];
 };
 
 export type MarketForecastLeaderboardEntry = {
-  userId: string;
-  meanBrier: number;
-  sampleCount: number;
-  correctPickRate: number;
-  currentCorrectPickStreak: number;
+	userId: string;
+	meanBrier: number;
+	sampleCount: number;
+	correctPickRate: number;
+	currentCorrectPickStreak: number;
 };
 
 export type MarketTraderSummaryEntry = {
-  userId: string;
-  amountSpent: number;
-  tradeCount: number;
-  lastTradedAt: Date;
+	userId: string;
+	amountSpent: number;
+	tradeCount: number;
+	lastTradedAt: Date;
 };
 
 export type MarketTraderSummary = {
-  marketId: string;
-  marketTitle: string;
-  traderCount: number;
-  totalSpent: number;
-  entries: MarketTraderSummaryEntry[];
+	marketId: string;
+	marketTitle: string;
+	traderCount: number;
+	totalSpent: number;
+	entries: MarketTraderSummaryEntry[];
 };
 
 export type MarketForecastRecordWithVector = MarketForecastRecord & {
-  forecastVector: MarketForecastVectorEntry[];
+	forecastVector: MarketForecastVectorEntry[];
 };
 
 export type MarketResolutionResult = {
-  market: MarketWithRelations;
-  payouts: Array<{
-    userId: string;
-    payout: number;
-    profit: number;
-    bonus: number;
-    positions: Array<{
-      outcomeId: string;
-      outcomeLabel: string;
-      side: MarketPositionSide;
-      shares: number;
-      costBasis: number;
-      proceeds: number;
-      collateralLocked: number;
-    }>;
-  }>;
+	market: MarketWithRelations;
+	payouts: Array<{
+		userId: string;
+		payout: number;
+		profit: number;
+		bonus: number;
+		positions: Array<{
+			outcomeId: string;
+			outcomeLabel: string;
+			side: MarketPositionSide;
+			shares: number;
+			costBasis: number;
+			proceeds: number;
+			collateralLocked: number;
+		}>;
+	}>;
 };
 
 export type MarketOutcomeResolutionResult = {
-  market: MarketWithRelations;
-  outcome: MarketOutcome;
-  payouts: Array<{
-    userId: string;
-    payout: number;
-    profit: number;
-    bonus: number;
-  }>;
+	market: MarketWithRelations;
+	outcome: MarketOutcome;
+	payouts: Array<{
+		userId: string;
+		payout: number;
+		profit: number;
+		bonus: number;
+	}>;
 };

--- a/src/features/markets/handlers/interactions/buttons.ts
+++ b/src/features/markets/handlers/interactions/buttons.ts
@@ -1,249 +1,585 @@
-import { MessageFlags, type ButtonInteraction } from 'discord.js';
+import { MessageFlags, type ButtonInteraction } from "discord.js";
 
-import { redis } from '../../../../lib/redis.js';
+import { redis } from "../../../../lib/redis.js";
 import {
-  buildMarketCancelModal,
-  buildMarketOutcomeTradePrompt,
-  buildMarketTradeModal,
-  buildMarketTradeSelector,
-} from '../../ui/render/trades.js';
-import { buildMarketStatusEmbed } from '../../ui/render/market.js';
-import { buildPortfolioMessage } from '../../ui/render/portfolio.js';
+	buildMarketCancelModal,
+	buildMarketOutcomeTradePrompt,
+	buildMarketSessionAmountModal,
+	buildMarketTradeModal,
+	buildMarketTradeSelector,
+} from "../../ui/render/trades.js";
+import { buildMarketStatusEmbed } from "../../ui/render/market.js";
+import { buildPortfolioMessage } from "../../ui/render/portfolio.js";
+import { buildMarketResolveModal } from "../../ui/render/trades.js";
 import {
-  buildMarketResolveModal,
-} from '../../ui/render/trades.js';
+	deleteMarketTradeQuoteSession,
+	getMarketTradeQuoteSession,
+} from "../../state/quote-session-store.js";
 import {
-  deleteMarketTradeQuoteSession,
-  getMarketTradeQuoteSession,
-} from '../../state/quote-session-store.js';
-import { buildMarketViewResponse, refreshMarketMessage } from '../../services/lifecycle.js';
-import { getMarketAccountSummary } from '../../services/account.js';
-import { getMarketById } from '../../services/records.js';
-import { scheduleMarketRefresh } from '../../services/scheduler.js';
-import { executeMarketTrade } from '../../services/trading/execution.js';
-import { purchaseLossProtection } from '../../services/trading/protection.js';
-import { buildProtectionEntryMessage, createLossProtectionQuotePreview } from './protection.js';
+	buildMarketViewResponse,
+	refreshMarketMessage,
+} from "../../services/lifecycle.js";
+import { getMarketAccountSummary } from "../../services/account.js";
+import { getMarketById } from "../../services/records.js";
+import { scheduleMarketRefresh } from "../../services/scheduler.js";
+import { executeMarketTrade } from "../../services/trading/execution.js";
+import { purchaseLossProtection } from "../../services/trading/protection.js";
 import {
-  buildTradeExecutionDescription,
-  parseProtectionCoverageCustomId,
-  getTradeFeedback,
-  parseMarketOutcomeCustomId,
-  parseQuickTradeCustomId,
-  parseQuoteSessionId,
-  parseSimpleMarketId,
-  parseTradeCustomId,
-} from './shared.js';
+	buildProtectionEntryMessage,
+	createLossProtectionQuotePreview,
+} from "./protection.js";
+import {
+	buildExpiredMarketInteractionResponse,
+	buildRootMarketInteractionSessionResponse,
+	createRootMarketInteractionSession,
+	deleteRootMarketInteractionSession,
+	getRootMarketInteractionSession,
+	refreshRootMarketInteractionSessionPreview,
+} from "./session.js";
+import {
+	buildTradeExecutionDescription,
+	parseMarketSessionActionCustomId,
+	parseMarketSessionCoverageCustomId,
+	parseMarketSessionId,
+	parseMarketSessionQuickAmountCustomId,
+	parseMarketSessionSideCustomId,
+	parseProtectionCoverageCustomId,
+	getTradeFeedback,
+	parseMarketOutcomeCustomId,
+	parseQuickTradeCustomId,
+	parseQuoteSessionId,
+	parseSimpleMarketId,
+	parseTradeCustomId,
+} from "./shared.js";
+
+const updateInteractionFromSessionPreview = async (
+	interaction: ButtonInteraction,
+	sessionId: string,
+	session: Awaited<ReturnType<typeof getRootMarketInteractionSession>>,
+): Promise<void> => {
+	if (session.preview.kind === "trade") {
+		const result = await executeMarketTrade({
+			marketId: session.preview.quote.marketId,
+			userId: session.userId,
+			outcomeId: session.preview.quote.outcomeId,
+			action: session.preview.quote.action,
+			amount: session.preview.quote.amount,
+			amountMode: session.preview.quote.amountMode,
+		});
+		await deleteRootMarketInteractionSession(sessionId);
+		await scheduleMarketRefresh(session.marketId);
+		const feedback = getTradeFeedback(session.preview.quote.action);
+		await interaction.update({
+			embeds: [
+				buildMarketStatusEmbed(
+					feedback.title,
+					buildTradeExecutionDescription(
+						session.preview.quote.action,
+						session.preview.quote.outcomeLabel,
+						result,
+					),
+					feedback.color,
+				),
+			],
+			components: [],
+		});
+		return;
+	}
+
+	const result = await purchaseLossProtection({
+		marketId: session.preview.quote.marketId,
+		userId: session.userId,
+		outcomeId: session.preview.quote.outcomeId,
+		targetCoverage: session.preview.quote.targetCoverage,
+	});
+	await deleteRootMarketInteractionSession(sessionId);
+	await scheduleMarketRefresh(session.marketId);
+	await interaction.update({
+		embeds: [
+			buildMarketStatusEmbed(
+				"Protection Purchased",
+				[
+					`Outcome: **${session.preview.quote.outcomeLabel}**`,
+					`Premium paid: **${result.premiumCharged.toFixed(2)} pts**`,
+					`Insured basis: **${result.insuredCostBasis.toFixed(2)} pts**`,
+					`Remaining uninsured basis: **${result.uninsuredCostBasis.toFixed(2)} pts**`,
+					`Bankroll: **${result.account.bankroll.toFixed(2)} pts**`,
+				].join("\n"),
+				0x57f287,
+			),
+		],
+		components: [],
+	});
+};
 
 export const handleMarketButton = async (
-  interaction: ButtonInteraction,
+	interaction: ButtonInteraction,
 ): Promise<void> => {
-  const confirmSessionId = parseQuoteSessionId('market:quote-confirm', interaction.customId);
-  if (confirmSessionId) {
-    const session = await getMarketTradeQuoteSession(redis, confirmSessionId);
-    if (!session) {
-      await interaction.update({
-        embeds: [buildMarketStatusEmbed('Quote Expired', 'Quote expired, request a new quote.', 0xef4444)],
-        components: [],
-      });
-      return;
-    }
+	const confirmInteractionSessionId = parseMarketSessionId(
+		"market:session-confirm",
+		interaction.customId,
+	);
+	if (confirmInteractionSessionId) {
+		const session = await getRootMarketInteractionSession(
+			confirmInteractionSessionId,
+			interaction.user.id,
+		).catch(() => null);
+		if (!session) {
+			await interaction.update(buildExpiredMarketInteractionResponse());
+			return;
+		}
 
-    if (session.userId !== interaction.user.id) {
-      throw new Error('That quote belongs to a different user.');
-    }
+		if (!session.preview) {
+			throw new Error("Preview that action before confirming it.");
+		}
 
-    if (session.kind !== 'protection') {
-      const result = await executeMarketTrade({
-        marketId: session.marketId,
-        userId: session.userId,
-        outcomeId: session.outcomeId,
-        action: session.action,
-        amount: session.amount,
-        amountMode: session.amountMode,
-      });
-      await deleteMarketTradeQuoteSession(redis, confirmSessionId);
-      await scheduleMarketRefresh(session.marketId);
-      const feedback = getTradeFeedback(session.action);
-      await interaction.update({
-        embeds: [
-          buildMarketStatusEmbed(
-            feedback.title,
-            buildTradeExecutionDescription(session.action, session.outcomeLabel, result),
-            feedback.color,
-          ),
-        ],
-        components: [],
-      });
-      return;
-    }
+		await updateInteractionFromSessionPreview(
+			interaction,
+			confirmInteractionSessionId,
+			session,
+		);
+		return;
+	}
 
-    const result = await purchaseLossProtection({
-      marketId: session.marketId,
-      userId: session.userId,
-      outcomeId: session.outcomeId,
-      targetCoverage: session.targetCoverage,
-    });
-    await deleteMarketTradeQuoteSession(redis, confirmSessionId);
-    await scheduleMarketRefresh(session.marketId);
-    await interaction.update({
-      embeds: [
-        buildMarketStatusEmbed(
-          'Protection Purchased',
-          [
-            `Outcome: **${session.outcomeLabel}**`,
-            `Premium paid: **${result.premiumCharged.toFixed(2)} pts**`,
-            `Insured basis: **${result.insuredCostBasis.toFixed(2)} pts**`,
-            `Remaining uninsured basis: **${result.uninsuredCostBasis.toFixed(2)} pts**`,
-            `Bankroll: **${result.account.bankroll.toFixed(2)} pts**`,
-          ].join('\n'),
-          0x57f287,
-        ),
-      ],
-      components: [],
-    });
-    return;
-  }
+	const cancelInteractionSessionId = parseMarketSessionId(
+		"market:session-cancel",
+		interaction.customId,
+	);
+	if (cancelInteractionSessionId) {
+		await deleteRootMarketInteractionSession(cancelInteractionSessionId);
+		await interaction.update({
+			embeds: [
+				buildMarketStatusEmbed(
+					"Session Cancelled",
+					"Cancelled that session.",
+					0x60a5fa,
+				),
+			],
+			components: [],
+		});
+		return;
+	}
 
-  const cancelSessionId = parseQuoteSessionId('market:quote-cancel', interaction.customId);
-  if (cancelSessionId) {
-    await deleteMarketTradeQuoteSession(redis, cancelSessionId);
-    await interaction.update({
-      embeds: [buildMarketStatusEmbed('Preview Cancelled', 'Cancelled that preview.', 0x60a5fa)],
-      components: [],
-    });
-    return;
-  }
+	const amountInteractionSessionId = parseMarketSessionId(
+		"market:session-amount",
+		interaction.customId,
+	);
+	if (amountInteractionSessionId) {
+		const session = await getRootMarketInteractionSession(
+			amountInteractionSessionId,
+			interaction.user.id,
+		).catch(() => null);
+		if (!session) {
+			await interaction.update(buildExpiredMarketInteractionResponse());
+			return;
+		}
 
-  const quickTrade = parseQuickTradeCustomId(interaction.customId);
-  if (quickTrade) {
-    await interaction.showModal(buildMarketTradeModal(
-      quickTrade.action,
-      quickTrade.marketId,
-      quickTrade.outcomeId,
-    ));
-    return;
-  }
+		if (!session.selectedAction || session.selectedAction === "protect") {
+			throw new Error("Choose a trade action first.");
+		}
 
-  const marketOutcome = parseMarketOutcomeCustomId(interaction.customId);
-  if (marketOutcome) {
-    const market = await getMarketById(marketOutcome.marketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+		await interaction.showModal(
+			buildMarketSessionAmountModal(
+				session.sessionId,
+				session.selectedAction,
+				session.amountInput,
+			),
+		);
+		return;
+	}
 
-    await interaction.reply({
-      flags: MessageFlags.Ephemeral,
-      ...buildMarketOutcomeTradePrompt(market, marketOutcome.outcomeId),
-      allowedMentions: {
-        parse: [],
-      },
-    });
-    return;
-  }
+	const sessionSide = parseMarketSessionSideCustomId(interaction.customId);
+	if (sessionSide) {
+		const session = await getRootMarketInteractionSession(
+			sessionSide.sessionId,
+			interaction.user.id,
+		).catch(() => null);
+		if (!session) {
+			await interaction.update(buildExpiredMarketInteractionResponse());
+			return;
+		}
 
-  const tradeAction = parseTradeCustomId(interaction.customId);
-  if (tradeAction) {
-    const market = await getMarketById(tradeAction.marketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+		const nextSession = await refreshRootMarketInteractionSessionPreview({
+			...session,
+			selectedAction: sessionSide.action,
+			targetCoverage: null,
+		});
+		await interaction.update(
+			await buildRootMarketInteractionSessionResponse(nextSession),
+		);
+		return;
+	}
 
-    await interaction.reply({
-      flags: MessageFlags.Ephemeral,
-      ...buildMarketTradeSelector(market, tradeAction.action),
-      allowedMentions: {
-        parse: [],
-      },
-    });
-    return;
-  }
+	const sessionAction = parseMarketSessionActionCustomId(interaction.customId);
+	if (sessionAction) {
+		const session = await getRootMarketInteractionSession(
+			sessionAction.sessionId,
+			interaction.user.id,
+		).catch(() => null);
+		if (!session) {
+			await interaction.update(buildExpiredMarketInteractionResponse());
+			return;
+		}
 
-  const portfolioMarketId = parseSimpleMarketId('market:portfolio', interaction.customId);
-  if (portfolioMarketId) {
-    const market = await getMarketById(portfolioMarketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+		const nextSession = await refreshRootMarketInteractionSessionPreview({
+			...session,
+			selectedAction: sessionAction.action,
+			targetCoverage:
+				sessionAction.action === "protect" ? session.targetCoverage : null,
+			preview: null,
+		});
+		await interaction.update(
+			await buildRootMarketInteractionSessionResponse(nextSession),
+		);
+		return;
+	}
 
-    const portfolio = await getMarketAccountSummary(market.guildId, interaction.user.id);
-    await interaction.reply({
-      flags: MessageFlags.Ephemeral,
-      ...buildPortfolioMessage(interaction.user.id, portfolio, true),
-      allowedMentions: {
-        parse: [],
-      },
-    });
-    return;
-  }
+	const sessionQuickAmount = parseMarketSessionQuickAmountCustomId(
+		interaction.customId,
+	);
+	if (sessionQuickAmount) {
+		const session = await getRootMarketInteractionSession(
+			sessionQuickAmount.sessionId,
+			interaction.user.id,
+		).catch(() => null);
+		if (!session) {
+			await interaction.update(buildExpiredMarketInteractionResponse());
+			return;
+		}
 
-  const protectMarketId = parseSimpleMarketId('market:protect', interaction.customId);
-  if (protectMarketId) {
-    const market = await getMarketById(protectMarketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+		const nextSession = await refreshRootMarketInteractionSessionPreview({
+			...session,
+			amountInput: `${sessionQuickAmount.amount}`,
+			targetCoverage: null,
+		});
+		await interaction.update(
+			await buildRootMarketInteractionSessionResponse(nextSession),
+		);
+		return;
+	}
 
-    await interaction.reply({
-      flags: MessageFlags.Ephemeral,
-      ...buildProtectionEntryMessage(market, interaction.user.id),
-      allowedMentions: {
-        parse: [],
-      },
-    });
-    return;
-  }
+	const sessionCoverage = parseMarketSessionCoverageCustomId(
+		interaction.customId,
+	);
+	if (sessionCoverage) {
+		const session = await getRootMarketInteractionSession(
+			sessionCoverage.sessionId,
+			interaction.user.id,
+		).catch(() => null);
+		if (!session) {
+			await interaction.update(buildExpiredMarketInteractionResponse());
+			return;
+		}
 
-  const protectionCoverage = parseProtectionCoverageCustomId(interaction.customId);
-  if (protectionCoverage) {
-    await interaction.update({
-      ...await createLossProtectionQuotePreview({
-        marketId: protectionCoverage.marketId,
-        userId: interaction.user.id,
-        outcomeId: protectionCoverage.outcomeId,
-        targetCoverage: protectionCoverage.targetCoverage,
-      }),
-      allowedMentions: {
-        parse: [],
-      },
-    });
-    return;
-  }
+		const nextSession = await refreshRootMarketInteractionSessionPreview({
+			...session,
+			selectedAction: "protect",
+			targetCoverage: sessionCoverage.targetCoverage,
+			amountInput: null,
+		});
+		await interaction.update(
+			await buildRootMarketInteractionSessionResponse(nextSession),
+		);
+		return;
+	}
 
-  const detailsMarketId = parseSimpleMarketId('market:details', interaction.customId);
-  if (detailsMarketId) {
-    const market = await getMarketById(detailsMarketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+	const confirmSessionId = parseQuoteSessionId(
+		"market:quote-confirm",
+		interaction.customId,
+	);
+	if (confirmSessionId) {
+		const session = await getMarketTradeQuoteSession(redis, confirmSessionId);
+		if (!session) {
+			await interaction.update({
+				embeds: [
+					buildMarketStatusEmbed(
+						"Quote Expired",
+						"Quote expired, request a new quote.",
+						0xef4444,
+					),
+				],
+				components: [],
+			});
+			return;
+		}
 
-    await interaction.reply({
-      flags: MessageFlags.Ephemeral,
-      ...(await buildMarketViewResponse(market)),
-      allowedMentions: {
-        parse: [],
-      },
-    });
-    return;
-  }
+		if (session.userId !== interaction.user.id) {
+			throw new Error("That quote belongs to a different user.");
+		}
 
-  const refreshMarketId = parseSimpleMarketId('market:refresh', interaction.customId);
-  if (refreshMarketId) {
-    await interaction.deferUpdate();
-    await refreshMarketMessage(interaction.client, refreshMarketId);
-    return;
-  }
+		if (session.kind !== "protection") {
+			const result = await executeMarketTrade({
+				marketId: session.marketId,
+				userId: session.userId,
+				outcomeId: session.outcomeId,
+				action: session.action,
+				amount: session.amount,
+				amountMode: session.amountMode,
+			});
+			await deleteMarketTradeQuoteSession(redis, confirmSessionId);
+			await scheduleMarketRefresh(session.marketId);
+			const feedback = getTradeFeedback(session.action);
+			await interaction.update({
+				embeds: [
+					buildMarketStatusEmbed(
+						feedback.title,
+						buildTradeExecutionDescription(
+							session.action,
+							session.outcomeLabel,
+							result,
+						),
+						feedback.color,
+					),
+				],
+				components: [],
+			});
+			return;
+		}
 
-  const resolveMarketId = parseSimpleMarketId('market:resolve', interaction.customId);
-  if (resolveMarketId) {
-    await interaction.showModal(buildMarketResolveModal(resolveMarketId));
-    return;
-  }
+		const result = await purchaseLossProtection({
+			marketId: session.marketId,
+			userId: session.userId,
+			outcomeId: session.outcomeId,
+			targetCoverage: session.targetCoverage,
+		});
+		await deleteMarketTradeQuoteSession(redis, confirmSessionId);
+		await scheduleMarketRefresh(session.marketId);
+		await interaction.update({
+			embeds: [
+				buildMarketStatusEmbed(
+					"Protection Purchased",
+					[
+						`Outcome: **${session.outcomeLabel}**`,
+						`Premium paid: **${result.premiumCharged.toFixed(2)} pts**`,
+						`Insured basis: **${result.insuredCostBasis.toFixed(2)} pts**`,
+						`Remaining uninsured basis: **${result.uninsuredCostBasis.toFixed(2)} pts**`,
+						`Bankroll: **${result.account.bankroll.toFixed(2)} pts**`,
+					].join("\n"),
+					0x57f287,
+				),
+			],
+			components: [],
+		});
+		return;
+	}
 
-  const cancelMarketId = parseSimpleMarketId('market:cancel', interaction.customId);
-  if (cancelMarketId) {
-    await interaction.showModal(buildMarketCancelModal(cancelMarketId));
-    return;
-  }
+	const cancelSessionId = parseQuoteSessionId(
+		"market:quote-cancel",
+		interaction.customId,
+	);
+	if (cancelSessionId) {
+		await deleteMarketTradeQuoteSession(redis, cancelSessionId);
+		await interaction.update({
+			embeds: [
+				buildMarketStatusEmbed(
+					"Preview Cancelled",
+					"Cancelled that preview.",
+					0x60a5fa,
+				),
+			],
+			components: [],
+		});
+		return;
+	}
 
-  throw new Error('Unknown market button action.');
+	const quickTrade = parseQuickTradeCustomId(interaction.customId);
+	if (quickTrade) {
+		await interaction.showModal(
+			buildMarketTradeModal(
+				quickTrade.action,
+				quickTrade.marketId,
+				quickTrade.outcomeId,
+			),
+		);
+		return;
+	}
+
+	const marketOutcome = parseMarketOutcomeCustomId(interaction.customId);
+	if (marketOutcome) {
+		const session = await createRootMarketInteractionSession({
+			marketId: marketOutcome.marketId,
+			userId: interaction.user.id,
+			mode: "trade",
+			selectedOutcomeId: marketOutcome.outcomeId,
+			selectedAction: "buy",
+		});
+
+		await interaction.reply({
+			flags: MessageFlags.Ephemeral,
+			...(await buildRootMarketInteractionSessionResponse(session)),
+			allowedMentions: {
+				parse: [],
+			},
+		});
+		return;
+	}
+
+	const tradeAction = parseTradeCustomId(interaction.customId);
+	if (tradeAction) {
+		const market = await getMarketById(tradeAction.marketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
+
+		await interaction.reply({
+			flags: MessageFlags.Ephemeral,
+			...buildMarketTradeSelector(market, tradeAction.action),
+			allowedMentions: {
+				parse: [],
+			},
+		});
+		return;
+	}
+
+	const portfolioMarketId = parseSimpleMarketId(
+		"market:portfolio",
+		interaction.customId,
+	);
+	if (portfolioMarketId) {
+		const market = await getMarketById(portfolioMarketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
+
+		const portfolio = await getMarketAccountSummary(
+			market.guildId,
+			interaction.user.id,
+		);
+		await interaction.reply({
+			flags: MessageFlags.Ephemeral,
+			...buildPortfolioMessage(interaction.user.id, portfolio, true),
+			allowedMentions: {
+				parse: [],
+			},
+		});
+		return;
+	}
+
+	const protectMarketId = parseSimpleMarketId(
+		"market:protect",
+		interaction.customId,
+	);
+	if (protectMarketId) {
+		const market = await getMarketById(protectMarketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
+
+		await interaction.reply({
+			flags: MessageFlags.Ephemeral,
+			...buildProtectionEntryMessage(market, interaction.user.id),
+			allowedMentions: {
+				parse: [],
+			},
+		});
+		return;
+	}
+
+	const protectionCoverage = parseProtectionCoverageCustomId(
+		interaction.customId,
+	);
+	if (protectionCoverage) {
+		await interaction.update({
+			...(await createLossProtectionQuotePreview({
+				marketId: protectionCoverage.marketId,
+				userId: interaction.user.id,
+				outcomeId: protectionCoverage.outcomeId,
+				targetCoverage: protectionCoverage.targetCoverage,
+			})),
+			allowedMentions: {
+				parse: [],
+			},
+		});
+		return;
+	}
+
+	const detailsMarketId = parseSimpleMarketId(
+		"market:details",
+		interaction.customId,
+	);
+	if (detailsMarketId) {
+		const market = await getMarketById(detailsMarketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
+
+		await interaction.reply({
+			flags: MessageFlags.Ephemeral,
+			...(await buildMarketViewResponse(market)),
+			allowedMentions: {
+				parse: [],
+			},
+		});
+		return;
+	}
+
+	const refreshMarketId = parseSimpleMarketId(
+		"market:refresh",
+		interaction.customId,
+	);
+	if (refreshMarketId) {
+		await interaction.deferUpdate();
+		await refreshMarketMessage(interaction.client, refreshMarketId);
+		return;
+	}
+
+	const resolveMarketId = parseSimpleMarketId(
+		"market:resolve",
+		interaction.customId,
+	);
+	if (resolveMarketId) {
+		await interaction.showModal(buildMarketResolveModal(resolveMarketId));
+		return;
+	}
+
+	const cancelMarketId = parseSimpleMarketId(
+		"market:cancel",
+		interaction.customId,
+	);
+	if (cancelMarketId) {
+		await interaction.showModal(buildMarketCancelModal(cancelMarketId));
+		return;
+	}
+
+	const tradeMarketId = parseSimpleMarketId(
+		"market:trade",
+		interaction.customId,
+	);
+	if (tradeMarketId) {
+		const session = await createRootMarketInteractionSession({
+			marketId: tradeMarketId,
+			userId: interaction.user.id,
+			mode: "trade",
+		});
+		await interaction.reply({
+			flags: MessageFlags.Ephemeral,
+			...(await buildRootMarketInteractionSessionResponse(session)),
+			allowedMentions: {
+				parse: [],
+			},
+		});
+		return;
+	}
+
+	const manageMarketId = parseSimpleMarketId(
+		"market:manage",
+		interaction.customId,
+	);
+	if (manageMarketId) {
+		const session = await createRootMarketInteractionSession({
+			marketId: manageMarketId,
+			userId: interaction.user.id,
+			mode: "manage",
+		});
+		await interaction.reply({
+			flags: MessageFlags.Ephemeral,
+			...(await buildRootMarketInteractionSessionResponse(session)),
+			allowedMentions: {
+				parse: [],
+			},
+		});
+		return;
+	}
+
+	throw new Error("Unknown market button action.");
 };

--- a/src/features/markets/handlers/interactions/buttons.ts
+++ b/src/features/markets/handlers/interactions/buttons.ts
@@ -3,7 +3,6 @@ import { MessageFlags, type ButtonInteraction } from "discord.js";
 import { redis } from "../../../../lib/redis.js";
 import {
 	buildMarketCancelModal,
-	buildMarketOutcomeTradePrompt,
 	buildMarketSessionAmountModal,
 	buildMarketTradeModal,
 	buildMarketTradeSelector,
@@ -57,25 +56,30 @@ const updateInteractionFromSessionPreview = async (
 	sessionId: string,
 	session: Awaited<ReturnType<typeof getRootMarketInteractionSession>>,
 ): Promise<void> => {
-	if (session.preview.kind === "trade") {
+	const preview = session.preview;
+	if (!preview) {
+		throw new Error("Preview that action before confirming it.");
+	}
+
+	if (preview.kind === "trade") {
 		const result = await executeMarketTrade({
-			marketId: session.preview.quote.marketId,
+			marketId: preview.quote.marketId,
 			userId: session.userId,
-			outcomeId: session.preview.quote.outcomeId,
-			action: session.preview.quote.action,
-			amount: session.preview.quote.amount,
-			amountMode: session.preview.quote.amountMode,
+			outcomeId: preview.quote.outcomeId,
+			action: preview.quote.action,
+			amount: preview.quote.amount,
+			amountMode: preview.quote.amountMode,
 		});
 		await deleteRootMarketInteractionSession(sessionId);
 		await scheduleMarketRefresh(session.marketId);
-		const feedback = getTradeFeedback(session.preview.quote.action);
+		const feedback = getTradeFeedback(preview.quote.action);
 		await interaction.update({
 			embeds: [
 				buildMarketStatusEmbed(
 					feedback.title,
 					buildTradeExecutionDescription(
-						session.preview.quote.action,
-						session.preview.quote.outcomeLabel,
+						preview.quote.action,
+						preview.quote.outcomeLabel,
 						result,
 					),
 					feedback.color,
@@ -87,10 +91,10 @@ const updateInteractionFromSessionPreview = async (
 	}
 
 	const result = await purchaseLossProtection({
-		marketId: session.preview.quote.marketId,
+		marketId: preview.quote.marketId,
 		userId: session.userId,
-		outcomeId: session.preview.quote.outcomeId,
-		targetCoverage: session.preview.quote.targetCoverage,
+		outcomeId: preview.quote.outcomeId,
+		targetCoverage: preview.quote.targetCoverage,
 	});
 	await deleteRootMarketInteractionSession(sessionId);
 	await scheduleMarketRefresh(session.marketId);
@@ -99,7 +103,7 @@ const updateInteractionFromSessionPreview = async (
 			buildMarketStatusEmbed(
 				"Protection Purchased",
 				[
-					`Outcome: **${session.preview.quote.outcomeLabel}**`,
+					`Outcome: **${preview.quote.outcomeLabel}**`,
 					`Premium paid: **${result.premiumCharged.toFixed(2)} pts**`,
 					`Insured basis: **${result.insuredCostBasis.toFixed(2)} pts**`,
 					`Remaining uninsured basis: **${result.uninsuredCostBasis.toFixed(2)} pts**`,

--- a/src/features/markets/handlers/interactions/commands.ts
+++ b/src/features/markets/handlers/interactions/commands.ts
@@ -1,13 +1,15 @@
+import type { InteractionReplyOptions } from 'discord.js';
 import { MessageFlags, type ChatInputCommandInteraction, type Client } from 'discord.js';
 
 import { logger } from '../../../../app/logger.js';
 import {
   buildLeaderboardEmbed,
   buildMarketForecastLeaderboardEmbed,
-  buildMarketForecastProfileEmbed,
+  buildMarketForecastProfileEmbeds,
   buildMarketListEmbed,
   buildMarketTradersEmbeds,
 } from '../../ui/render/analytics.js';
+import { buildMarketForecastProfileDiagram } from '../../ui/profile-visualize.js';
 import { buildMarketStatusEmbed } from '../../ui/render/market.js';
 import { buildPortfolioMessage } from '../../ui/render/portfolio.js';
 import { getMarketConfig } from '../../services/config.js';
@@ -26,7 +28,7 @@ import {
 } from '../../services/account.js';
 import {
   getMarketForecastLeaderboard,
-  getMarketForecastProfile,
+  getMarketForecastProfileDetails,
 } from '../../services/forecast/queries.js';
 import {
   appendMarketOutcomes,
@@ -449,13 +451,34 @@ export const handleMarketCommand = async (
     }
     case 'profile': {
       const user = interaction.options.getUser('user') ?? interaction.user;
-      const profile = await getMarketForecastProfile(interaction.guildId, user.id);
-      await interaction.reply({
-        flags: MessageFlags.Ephemeral,
-        embeds: [buildMarketForecastProfileEmbed(profile)],
+      const profile = await getMarketForecastProfileDetails(interaction.guildId, user.id);
+      const embeds = buildMarketForecastProfileEmbeds(profile);
+      const response: InteractionReplyOptions = {
+        embeds,
         allowedMentions: {
           parse: [],
         },
+      };
+
+      if (profile.allTimeSampleCount > 0) {
+        try {
+          const chart = await buildMarketForecastProfileDiagram(profile, {
+            displayName: user.displayName ?? user.globalName ?? user.username,
+            avatarUrl: user.displayAvatarURL({
+              extension: 'png',
+              forceStatic: true,
+              size: 256,
+            }),
+          });
+          embeds[0]?.setImage(`attachment://${chart.fileName}`);
+          response.files = [chart.attachment];
+        } catch (error) {
+          logger.warn({ err: error, userId: user.id, guildId: interaction.guildId }, 'Could not build market forecast profile diagram');
+        }
+      }
+
+      await interaction.reply({
+        ...response,
       });
       return;
     }

--- a/src/features/markets/handlers/interactions/modals.ts
+++ b/src/features/markets/handlers/interactions/modals.ts
@@ -1,140 +1,178 @@
-import { MessageFlags, type Client, type ModalSubmitInteraction } from 'discord.js';
+import {
+	MessageFlags,
+	type Client,
+	type ModalSubmitInteraction,
+} from "discord.js";
 
-import { buildMarketStatusEmbed } from '../../ui/render/market.js';
+import { buildMarketStatusEmbed } from "../../ui/render/market.js";
 import {
-  announceMarketUpdate,
-  clearMarketLifecycle,
-  notifyMarketResolved,
-  refreshMarketMessage,
-} from '../../services/lifecycle.js';
-import { getMarketById } from '../../services/records.js';
-import { scheduleMarketRefresh } from '../../services/scheduler.js';
-import { cancelMarket } from '../../services/trading/cancel.js';
-import { executeMarketTrade } from '../../services/trading/execution.js';
-import { resolveMarket } from '../../services/trading/resolution.js';
-import { parseOutcomeSelection } from '../../parsing/market.js';
-import { createTradeQuotePreview } from './quotes.js';
+	announceMarketUpdate,
+	clearMarketLifecycle,
+	notifyMarketResolved,
+	refreshMarketMessage,
+} from "../../services/lifecycle.js";
+import { getMarketById } from "../../services/records.js";
+import { scheduleMarketRefresh } from "../../services/scheduler.js";
+import { cancelMarket } from "../../services/trading/cancel.js";
+import { resolveMarket } from "../../services/trading/resolution.js";
+import { parseOutcomeSelection } from "../../parsing/market.js";
+import { createTradeQuotePreview } from "./quotes.js";
 import {
-  buildTradeExecutionDescription,
-  getTradeFeedback,
-  parseSimpleMarketId,
-  parseTradeInputAmount,
-  parseTradeModalCustomId,
-  validateEvidenceUrl,
-} from './shared.js';
+	buildRootMarketInteractionSessionResponse,
+	getRootMarketInteractionSession,
+	refreshRootMarketInteractionSessionPreview,
+} from "./session.js";
+import {
+	parseMarketSessionId,
+	parseSimpleMarketId,
+	parseTradeModalCustomId,
+	validateEvidenceUrl,
+} from "./shared.js";
 
 export const handleMarketModal = async (
-  client: Client,
-  interaction: ModalSubmitInteraction,
+	client: Client,
+	interaction: ModalSubmitInteraction,
 ): Promise<void> => {
-  const trade = parseTradeModalCustomId(interaction.customId);
-  if (trade) {
-    const market = await getMarketById(trade.marketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+	const amountSessionId = parseMarketSessionId(
+		"market:session-amount-modal",
+		interaction.customId,
+	);
+	if (amountSessionId) {
+		const session = await getRootMarketInteractionSession(
+			amountSessionId,
+			interaction.user.id,
+		);
+		if (!session.selectedAction || session.selectedAction === "protect") {
+			throw new Error("Choose a trade action before entering an amount.");
+		}
 
-    const rawAmount = interaction.fields.getTextInputValue('amount');
-    if (trade.action === 'buy' || trade.action === 'short') {
-      await interaction.reply({
-        flags: MessageFlags.Ephemeral,
-        ...await createTradeQuotePreview({
-          marketId: trade.marketId,
-          userId: interaction.user.id,
-          outcomeId: trade.outcomeId,
-          action: trade.action,
-          rawAmount,
-        }),
-        allowedMentions: {
-          parse: [],
-        },
-      });
-      return;
-    }
+		const nextSession = await refreshRootMarketInteractionSessionPreview({
+			...session,
+			amountInput: interaction.fields.getTextInputValue("amount"),
+			targetCoverage: null,
+		});
+		await interaction.reply({
+			flags: MessageFlags.Ephemeral,
+			...(await buildRootMarketInteractionSessionResponse(nextSession)),
+			allowedMentions: {
+				parse: [],
+			},
+		});
+		return;
+	}
 
-    const parsedAmount = parseTradeInputAmount(trade.action, rawAmount);
-    const result = await executeMarketTrade({
-      marketId: trade.marketId,
-      userId: interaction.user.id,
-      outcomeId: trade.outcomeId,
-      action: trade.action,
-      amount: parsedAmount.amount,
-      amountMode: parsedAmount.amountMode,
-    });
-    await scheduleMarketRefresh(trade.marketId);
-    const outcome = market.outcomes.find((entry) => entry.id === trade.outcomeId);
-    const feedback = getTradeFeedback(trade.action);
-    await interaction.reply({
-      flags: MessageFlags.Ephemeral,
-      embeds: [
-        buildMarketStatusEmbed(
-          feedback.title,
-          buildTradeExecutionDescription(trade.action, outcome?.label ?? 'Unknown', result),
-          feedback.color,
-        ),
-      ],
-    });
-    return;
-  }
+	const trade = parseTradeModalCustomId(interaction.customId);
+	if (trade) {
+		const market = await getMarketById(trade.marketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
 
-  const resolveMarketId = parseSimpleMarketId('market:resolve-modal', interaction.customId);
-  if (resolveMarketId) {
-    const market = await getMarketById(resolveMarketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+		const rawAmount = interaction.fields.getTextInputValue("amount");
+		await interaction.reply({
+			flags: MessageFlags.Ephemeral,
+			...(await createTradeQuotePreview({
+				marketId: trade.marketId,
+				userId: interaction.user.id,
+				outcomeId: trade.outcomeId,
+				action: trade.action,
+				rawAmount,
+			})),
+			allowedMentions: {
+				parse: [],
+			},
+		});
+		return;
+	}
 
-    const outcome = parseOutcomeSelection(interaction.fields.getTextInputValue('winning_outcome'), market.outcomes);
-    const resolved = await resolveMarket({
-      marketId: market.id,
-      actorId: interaction.user.id,
-      winningOutcomeId: outcome.id,
-      note: interaction.fields.getTextInputValue('note').trim() || null,
-      evidenceUrl: validateEvidenceUrl(interaction.fields.getTextInputValue('evidence_url')),
-      ...(interaction.inGuild() ? { permissions: interaction.memberPermissions ?? null } : {}),
-    });
-    await clearMarketLifecycle(market.id);
-    await refreshMarketMessage(client, market.id);
-    await notifyMarketResolved(client, resolved);
-    await interaction.reply({
-      flags: MessageFlags.Ephemeral,
-      embeds: [buildMarketStatusEmbed('Market Resolved', `Resolved **${market.title}** in favor of **${outcome.label}**.`, 0x57f287)],
-    });
-    return;
-  }
+	const resolveMarketId = parseSimpleMarketId(
+		"market:resolve-modal",
+		interaction.customId,
+	);
+	if (resolveMarketId) {
+		const market = await getMarketById(resolveMarketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
 
-  const cancelMarketId = parseSimpleMarketId('market:cancel-modal', interaction.customId);
-  if (cancelMarketId) {
-    const market = await getMarketById(cancelMarketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+		const outcome = parseOutcomeSelection(
+			interaction.fields.getTextInputValue("winning_outcome"),
+			market.outcomes,
+		);
+		const resolved = await resolveMarket({
+			marketId: market.id,
+			actorId: interaction.user.id,
+			winningOutcomeId: outcome.id,
+			note: interaction.fields.getTextInputValue("note").trim() || null,
+			evidenceUrl: validateEvidenceUrl(
+				interaction.fields.getTextInputValue("evidence_url"),
+			),
+			...(interaction.inGuild()
+				? { permissions: interaction.memberPermissions ?? null }
+				: {}),
+		});
+		await clearMarketLifecycle(market.id);
+		await refreshMarketMessage(client, market.id);
+		await notifyMarketResolved(client, resolved);
+		await interaction.reply({
+			flags: MessageFlags.Ephemeral,
+			embeds: [
+				buildMarketStatusEmbed(
+					"Market Resolved",
+					`Resolved **${market.title}** in favor of **${outcome.label}**.`,
+					0x57f287,
+				),
+			],
+		});
+		return;
+	}
 
-    const reason = interaction.fields.getTextInputValue('reason').trim() || null;
-    const cancelled = await cancelMarket({
-      marketId: market.id,
-      actorId: interaction.user.id,
-      reason,
-      ...(interaction.inGuild() ? { permissions: interaction.memberPermissions ?? null } : {}),
-    });
-    await clearMarketLifecycle(market.id);
-    await refreshMarketMessage(client, market.id);
-    await announceMarketUpdate(
-      client,
-      cancelled,
-      'Market Cancelled',
-      [
-        `**${cancelled.title}** was cancelled by <@${interaction.user.id}>.`,
-        reason ? `Reason: ${reason}` : null,
-      ].filter(Boolean).join('\n'),
-      0xf59e0b,
-    );
-    await interaction.reply({
-      flags: MessageFlags.Ephemeral,
-      embeds: [buildMarketStatusEmbed('Market Cancelled', `Cancelled **${market.title}** and refunded open positions.`, 0xf59e0b)],
-    });
-    return;
-  }
+	const cancelMarketId = parseSimpleMarketId(
+		"market:cancel-modal",
+		interaction.customId,
+	);
+	if (cancelMarketId) {
+		const market = await getMarketById(cancelMarketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
 
-  throw new Error('Unknown market modal action.');
+		const reason =
+			interaction.fields.getTextInputValue("reason").trim() || null;
+		const cancelled = await cancelMarket({
+			marketId: market.id,
+			actorId: interaction.user.id,
+			reason,
+			...(interaction.inGuild()
+				? { permissions: interaction.memberPermissions ?? null }
+				: {}),
+		});
+		await clearMarketLifecycle(market.id);
+		await refreshMarketMessage(client, market.id);
+		await announceMarketUpdate(
+			client,
+			cancelled,
+			"Market Cancelled",
+			[
+				`**${cancelled.title}** was cancelled by <@${interaction.user.id}>.`,
+				reason ? `Reason: ${reason}` : null,
+			]
+				.filter(Boolean)
+				.join("\n"),
+			0xf59e0b,
+		);
+		await interaction.reply({
+			flags: MessageFlags.Ephemeral,
+			embeds: [
+				buildMarketStatusEmbed(
+					"Market Cancelled",
+					`Cancelled **${market.title}** and refunded open positions.`,
+					0xf59e0b,
+				),
+			],
+		});
+		return;
+	}
+
+	throw new Error("Unknown market modal action.");
 };

--- a/src/features/markets/handlers/interactions/quotes.ts
+++ b/src/features/markets/handlers/interactions/quotes.ts
@@ -1,69 +1,100 @@
-import { redis } from '../../../../lib/redis.js';
-import { buildMarketTradeQuoteMessage } from '../../ui/render/trades.js';
+import { redis } from "../../../../lib/redis.js";
+import { buildMarketTradeQuoteMessage } from "../../ui/render/trades.js";
 import {
-  createMarketTradeQuoteSessionId,
-  saveMarketTradeQuoteSession,
-} from '../../state/quote-session-store.js';
-import { calculateMarketTradeQuote } from '../../services/trading/quotes.js';
-import { parseTradeInputAmount } from './shared.js';
+	createMarketTradeQuoteSessionId,
+	saveMarketTradeQuoteSession,
+} from "../../state/quote-session-store.js";
+import { calculateMarketTradeQuote } from "../../services/trading/quotes.js";
+import { parseTradeInputAmount } from "./shared.js";
 
 export const createTradeQuotePreview = async (input: {
-  marketId: string;
-  userId: string;
-  outcomeId: string;
-  action: 'buy' | 'short';
-  rawAmount: string;
+	marketId: string;
+	userId: string;
+	outcomeId: string;
+	action: "buy" | "sell" | "short" | "cover";
+	rawAmount: string;
 }): Promise<ReturnType<typeof buildMarketTradeQuoteMessage>> => {
-  const parsedAmount = parseTradeInputAmount(input.action, input.rawAmount);
-  const quote = input.action === 'buy'
-    ? await calculateMarketTradeQuote({
-        marketId: input.marketId,
-        userId: input.userId,
-        outcomeId: input.outcomeId,
-        action: 'buy',
-        amount: parsedAmount.amount,
-        amountMode: 'points',
-        rawAmount: input.rawAmount,
-      })
-    : await calculateMarketTradeQuote({
-        marketId: input.marketId,
-        userId: input.userId,
-        outcomeId: input.outcomeId,
-        action: 'short',
-        amount: parsedAmount.amount,
-        amountMode: parsedAmount.amountMode,
-        rawAmount: input.rawAmount,
-      });
-  const sessionId = createMarketTradeQuoteSessionId();
-  await saveMarketTradeQuoteSession(redis, sessionId, {
-    kind: 'trade',
-    sessionId,
-    action: quote.action,
-    guildId: quote.guildId,
-    marketId: quote.marketId,
-    marketTitle: quote.marketTitle,
-    outcomeId: quote.outcomeId,
-    outcomeLabel: quote.outcomeLabel,
-    userId: quote.userId,
-    rawAmount: quote.rawAmount,
-    amount: quote.amount,
-    amountMode: quote.amountMode,
-    shares: quote.shares,
-    averagePrice: quote.averagePrice,
-    immediateCash: quote.immediateCash,
-    grossImmediateCash: quote.grossImmediateCash,
-    netImmediateCash: quote.netImmediateCash,
-    feeCharged: quote.feeCharged,
-    collateralLocked: quote.collateralLocked,
-    netBankrollChange: quote.netBankrollChange,
-    settlementIfChosen: quote.settlementIfChosen,
-    settlementIfNotChosen: quote.settlementIfNotChosen,
-    maxProfitIfChosen: quote.maxProfitIfChosen,
-    maxProfitIfNotChosen: quote.maxProfitIfNotChosen,
-    maxLossIfChosen: quote.maxLossIfChosen,
-    maxLossIfNotChosen: quote.maxLossIfNotChosen,
-    expiresAt: new Date(Date.now() + (10 * 60 * 1_000)).toISOString(),
-  });
+	const parsedAmount = parseTradeInputAmount(input.action, input.rawAmount);
+	const quote =
+		input.action === "buy"
+			? await calculateMarketTradeQuote({
+					marketId: input.marketId,
+					userId: input.userId,
+					outcomeId: input.outcomeId,
+					action: "buy",
+					amount: parsedAmount.amount,
+					amountMode: "points",
+					rawAmount: input.rawAmount,
+				})
+			: input.action === "sell"
+				? await calculateMarketTradeQuote({
+						marketId: input.marketId,
+						userId: input.userId,
+						outcomeId: input.outcomeId,
+						action: "sell",
+						amount: parsedAmount.amount,
+						amountMode: parsedAmount.amountMode,
+						rawAmount: input.rawAmount,
+					})
+				: input.action === "short"
+					? await calculateMarketTradeQuote({
+							marketId: input.marketId,
+							userId: input.userId,
+							outcomeId: input.outcomeId,
+							action: "short",
+							amount: parsedAmount.amount,
+							amountMode: parsedAmount.amountMode,
+							rawAmount: input.rawAmount,
+						})
+					: await calculateMarketTradeQuote({
+							marketId: input.marketId,
+							userId: input.userId,
+							outcomeId: input.outcomeId,
+							action: "cover",
+							amount: parsedAmount.amount,
+							amountMode: parsedAmount.amountMode,
+							rawAmount: input.rawAmount,
+						});
+	const sessionId = createMarketTradeQuoteSessionId();
+	await saveMarketTradeQuoteSession(redis, sessionId, {
+		kind: "trade",
+		sessionId,
+		action: quote.action,
+		guildId: quote.guildId,
+		marketId: quote.marketId,
+		marketTitle: quote.marketTitle,
+		outcomeId: quote.outcomeId,
+		outcomeLabel: quote.outcomeLabel,
+		userId: quote.userId,
+		rawAmount: quote.rawAmount,
+		amount: quote.amount,
+		amountMode: quote.amountMode,
+		shares: quote.shares,
+		averagePrice: quote.averagePrice,
+		currentProbability: quote.currentProbability,
+		nextProbability: quote.nextProbability,
+		immediateCash: quote.immediateCash,
+		grossImmediateCash: quote.grossImmediateCash,
+		netImmediateCash: quote.netImmediateCash,
+		feeCharged: quote.feeCharged,
+		collateralLocked: quote.collateralLocked,
+		collateralReleased: quote.collateralReleased,
+		netBankrollChange: quote.netBankrollChange,
+		bankrollAfter: quote.bankrollAfter,
+		positionSide: quote.positionSide,
+		positionSharesAfter: quote.positionSharesAfter,
+		positionCostBasisAfter: quote.positionCostBasisAfter,
+		positionProceedsAfter: quote.positionProceedsAfter,
+		positionCollateralAfter: quote.positionCollateralAfter,
+		realizedProfitDelta: quote.realizedProfitDelta,
+		settlementIfChosen: quote.settlementIfChosen,
+		settlementIfNotChosen: quote.settlementIfNotChosen,
+		maxProfitIfChosen: quote.maxProfitIfChosen,
+		maxProfitIfNotChosen: quote.maxProfitIfNotChosen,
+		maxLossIfChosen: quote.maxLossIfChosen,
+		maxLossIfNotChosen: quote.maxLossIfNotChosen,
+		expiresAt: new Date(Date.now() + 10 * 60 * 1_000).toISOString(),
+	});
 
-  return buildMarketTradeQuoteMessage(sessionId, quote);
+	return buildMarketTradeQuoteMessage(sessionId, quote);
 };

--- a/src/features/markets/handlers/interactions/selects.ts
+++ b/src/features/markets/handlers/interactions/selects.ts
@@ -1,98 +1,191 @@
-import type { StringSelectMenuInteraction } from 'discord.js';
+import type { StringSelectMenuInteraction } from "discord.js";
 
-import { buildMarketTradeModal } from '../../ui/render/trades.js';
-import { getMarketById } from '../../services/records.js';
-import { marketPortfolioSelectCustomId } from '../../ui/custom-ids.js';
+import { buildMarketTradeModal } from "../../ui/render/trades.js";
+import { getMarketById } from "../../services/records.js";
+import { marketPortfolioSelectCustomId } from "../../ui/custom-ids.js";
 import {
-  parsePortfolioSelectionValue,
-  parseSimpleMarketId,
-  parseTradeSelectCustomId,
-} from './shared.js';
-import { buildProtectionEntryMessage } from './protection.js';
+	buildExpiredMarketInteractionResponse,
+	buildRootMarketInteractionSessionResponse,
+	getRootMarketInteractionSession,
+	refreshRootMarketInteractionSessionPreview,
+	saveRootMarketInteractionSession,
+} from "./session.js";
+import {
+	parseMarketSessionId,
+	parsePortfolioSelectionValue,
+	parseSimpleMarketId,
+	parseTradeSelectCustomId,
+} from "./shared.js";
+import { buildProtectionEntryMessage } from "./protection.js";
 
 export const handleMarketSelect = async (
-  interaction: StringSelectMenuInteraction,
+	interaction: StringSelectMenuInteraction,
 ): Promise<void> => {
-  if (interaction.customId === marketPortfolioSelectCustomId()) {
-    const value = interaction.values[0];
-    if (!value) {
-      throw new Error('Choose a position first.');
-    }
+	const outcomeSessionId = parseMarketSessionId(
+		"market:session-outcome",
+		interaction.customId,
+	);
+	if (outcomeSessionId) {
+		const outcomeId = interaction.values[0];
+		if (!outcomeId) {
+			throw new Error("Choose a market outcome first.");
+		}
 
-    const parsedValue = parsePortfolioSelectionValue(value);
-    if (!parsedValue) {
-      throw new Error('Unknown portfolio action.');
-    }
+		const session = await getRootMarketInteractionSession(
+			outcomeSessionId,
+			interaction.user.id,
+		).catch(() => null);
+		if (!session) {
+			await interaction.update(buildExpiredMarketInteractionResponse());
+			return;
+		}
 
-    if (parsedValue.action === 'protect') {
-      const market = await getMarketById(parsedValue.marketId);
-      if (!market) {
-        throw new Error('Market not found.');
-      }
+		const nextSession = await refreshRootMarketInteractionSessionPreview({
+			...session,
+			selectedOutcomeId: outcomeId,
+			targetCoverage: null,
+		});
+		await interaction.update(
+			await buildRootMarketInteractionSessionResponse(nextSession),
+		);
+		return;
+	}
 
-      const entry = buildProtectionEntryMessage(market, interaction.user.id);
-      const protectable = 'components' in entry && entry.components.length > 0
-        ? market.positions.find((position) =>
-          position.userId === interaction.user.id
-          && position.side === 'long'
-          && position.outcomeId === parsedValue.outcomeId)
-        : null;
-      if (!protectable) {
-        await interaction.update(entry);
-        return;
-      }
+	const positionSessionId = parseMarketSessionId(
+		"market:session-position",
+		interaction.customId,
+	);
+	if (positionSessionId) {
+		const outcomeId = interaction.values[0];
+		if (!outcomeId) {
+			throw new Error("Choose a position first.");
+		}
 
-      const specificEntry = buildProtectionEntryMessage({
-        ...market,
-        positions: market.positions.filter((position) =>
-          position.userId === interaction.user.id
-          && position.side === 'long'
-          && position.outcomeId === parsedValue.outcomeId),
-      }, interaction.user.id);
-      await interaction.update(specificEntry);
-      return;
-    }
+		const session = await getRootMarketInteractionSession(
+			positionSessionId,
+			interaction.user.id,
+		).catch(() => null);
+		if (!session) {
+			await interaction.update(buildExpiredMarketInteractionResponse());
+			return;
+		}
 
-    await interaction.showModal(buildMarketTradeModal(
-      parsedValue.action,
-      parsedValue.marketId,
-      parsedValue.outcomeId,
-    ));
-    return;
-  }
+		const nextSession = await saveRootMarketInteractionSession({
+			...session,
+			selectedOutcomeId: outcomeId,
+			selectedAction: null,
+			amountInput: null,
+			targetCoverage: null,
+			preview: null,
+		});
+		await interaction.update(
+			await buildRootMarketInteractionSessionResponse(nextSession),
+		);
+		return;
+	}
 
-  const parsed = parseTradeSelectCustomId(interaction.customId);
-  if (parsed) {
-    const outcomeId = interaction.values[0];
-    if (!outcomeId) {
-      throw new Error('Choose a market outcome first.');
-    }
+	if (interaction.customId === marketPortfolioSelectCustomId()) {
+		const value = interaction.values[0];
+		if (!value) {
+			throw new Error("Choose a position first.");
+		}
 
-    await interaction.showModal(buildMarketTradeModal(parsed.action, parsed.marketId, outcomeId));
-    return;
-  }
+		const parsedValue = parsePortfolioSelectionValue(value);
+		if (!parsedValue) {
+			throw new Error("Unknown portfolio action.");
+		}
 
-  const protectionMarketId = parseSimpleMarketId('market:protection-select', interaction.customId);
-  if (protectionMarketId) {
-    const market = await getMarketById(protectionMarketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+		if (parsedValue.action === "protect") {
+			const market = await getMarketById(parsedValue.marketId);
+			if (!market) {
+				throw new Error("Market not found.");
+			}
 
-    const outcomeId = interaction.values[0];
-    if (!outcomeId) {
-      throw new Error('Choose a position first.');
-    }
+			const entry = buildProtectionEntryMessage(market, interaction.user.id);
+			const protectable =
+				"components" in entry && entry.components.length > 0
+					? market.positions.find(
+							(position) =>
+								position.userId === interaction.user.id &&
+								position.side === "long" &&
+								position.outcomeId === parsedValue.outcomeId,
+						)
+					: null;
+			if (!protectable) {
+				await interaction.update(entry);
+				return;
+			}
 
-    await interaction.update(buildProtectionEntryMessage({
-      ...market,
-      positions: market.positions.filter((position) =>
-        position.userId === interaction.user.id
-        && position.side === 'long'
-        && position.outcomeId === outcomeId),
-    }, interaction.user.id));
-    return;
-  }
+			const specificEntry = buildProtectionEntryMessage(
+				{
+					...market,
+					positions: market.positions.filter(
+						(position) =>
+							position.userId === interaction.user.id &&
+							position.side === "long" &&
+							position.outcomeId === parsedValue.outcomeId,
+					),
+				},
+				interaction.user.id,
+			);
+			await interaction.update(specificEntry);
+			return;
+		}
 
-  throw new Error('Unknown market select action.');
+		await interaction.showModal(
+			buildMarketTradeModal(
+				parsedValue.action,
+				parsedValue.marketId,
+				parsedValue.outcomeId,
+			),
+		);
+		return;
+	}
+
+	const parsed = parseTradeSelectCustomId(interaction.customId);
+	if (parsed) {
+		const outcomeId = interaction.values[0];
+		if (!outcomeId) {
+			throw new Error("Choose a market outcome first.");
+		}
+
+		await interaction.showModal(
+			buildMarketTradeModal(parsed.action, parsed.marketId, outcomeId),
+		);
+		return;
+	}
+
+	const protectionMarketId = parseSimpleMarketId(
+		"market:protection-select",
+		interaction.customId,
+	);
+	if (protectionMarketId) {
+		const market = await getMarketById(protectionMarketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
+
+		const outcomeId = interaction.values[0];
+		if (!outcomeId) {
+			throw new Error("Choose a position first.");
+		}
+
+		await interaction.update(
+			buildProtectionEntryMessage(
+				{
+					...market,
+					positions: market.positions.filter(
+						(position) =>
+							position.userId === interaction.user.id &&
+							position.side === "long" &&
+							position.outcomeId === outcomeId,
+					),
+				},
+				interaction.user.id,
+			),
+		);
+		return;
+	}
+
+	throw new Error("Unknown market select action.");
 };

--- a/src/features/markets/handlers/interactions/session.ts
+++ b/src/features/markets/handlers/interactions/session.ts
@@ -1,0 +1,278 @@
+import { redis } from "../../../../lib/redis.js";
+import {
+	getLossProtection,
+	getLossProtectionMap,
+	getPositionCoverageRatio,
+	roundCurrency,
+} from "../../core/shared.js";
+import type {
+	MarketInteractionSession,
+	MarketInteractionSessionAction,
+	MarketWithRelations,
+} from "../../core/types.js";
+import { getMarketById } from "../../services/records.js";
+import { calculateLossProtectionQuote } from "../../services/trading/protection.js";
+import { calculateMarketTradeQuote } from "../../services/trading/quotes.js";
+import {
+	createMarketInteractionSessionId,
+	deleteMarketInteractionSession,
+	getMarketInteractionSession,
+	saveMarketInteractionSession,
+} from "../../state/interaction-session-store.js";
+import { buildMarketStatusEmbed } from "../../ui/render/market.js";
+import { buildMarketInteractionSessionMessage } from "../../ui/render/trades.js";
+import { parseTradeInputAmount } from "./shared.js";
+
+const sessionTtlMs = 10 * 60 * 1_000;
+
+const getExpiresAt = (): string =>
+	new Date(Date.now() + sessionTtlMs).toISOString();
+
+const getSessionPositions = (market: MarketWithRelations, userId: string) => {
+	const protectionMap = getLossProtectionMap(market.lossProtections ?? []);
+
+	return market.positions
+		.filter((position) => position.userId === userId && position.shares > 1e-6)
+		.map((position) => {
+			const outcome = market.outcomes.find(
+				(entry) => entry.id === position.outcomeId,
+			);
+			if (!outcome || outcome.settlementValue !== null) {
+				return null;
+			}
+
+			const protection =
+				position.side === "long"
+					? getLossProtection(protectionMap, userId, position.outcomeId)
+					: undefined;
+			const insuredCostBasis = roundCurrency(protection?.insuredCostBasis ?? 0);
+			const coverageRatio =
+				position.side === "long"
+					? getPositionCoverageRatio(position.costBasis, insuredCostBasis)
+					: 0;
+
+			return {
+				outcomeId: position.outcomeId,
+				outcomeLabel: outcome.label,
+				side: position.side,
+				shares: roundCurrency(position.shares),
+				costBasis: roundCurrency(position.costBasis),
+				proceeds: roundCurrency(position.proceeds),
+				collateralLocked: roundCurrency(position.collateralLocked),
+				insuredCostBasis,
+				coverageRatio,
+				canProtect: position.side === "long" && coverageRatio < 1,
+			};
+		})
+		.filter(
+			(position): position is NonNullable<typeof position> => position !== null,
+		)
+		.sort((left, right) => right.shares - left.shares);
+};
+
+const resolveDefaultTradeOutcomeId = (
+	market: MarketWithRelations,
+): string | null =>
+	market.outcomes.find((outcome) => outcome.settlementValue === null)?.id ??
+	null;
+
+const resolveDefaultManageState = (
+	market: MarketWithRelations,
+	userId: string,
+): Pick<MarketInteractionSession, "selectedOutcomeId" | "selectedAction"> => {
+	const positions = getSessionPositions(market, userId);
+	const firstPosition = positions[0];
+	if (!firstPosition) {
+		return {
+			selectedOutcomeId: null,
+			selectedAction: null,
+		};
+	}
+
+	return {
+		selectedOutcomeId: firstPosition.outcomeId,
+		selectedAction: firstPosition.side === "long" ? "sell" : "cover",
+	};
+};
+
+export const createRootMarketInteractionSession = async (input: {
+	marketId: string;
+	userId: string;
+	mode: "trade" | "manage";
+	selectedOutcomeId?: string | null;
+	selectedAction?: MarketInteractionSessionAction | null;
+}): Promise<MarketInteractionSession> => {
+	const market = await getMarketById(input.marketId);
+	if (!market) {
+		throw new Error("Market not found.");
+	}
+
+	const sessionId = createMarketInteractionSessionId();
+	const manageDefaults =
+		input.mode === "manage"
+			? resolveDefaultManageState(market, input.userId)
+			: { selectedOutcomeId: null, selectedAction: null };
+	const session: MarketInteractionSession = {
+		sessionId,
+		userId: input.userId,
+		marketId: input.marketId,
+		mode: input.mode,
+		selectedOutcomeId:
+			input.selectedOutcomeId ??
+			(input.mode === "trade"
+				? resolveDefaultTradeOutcomeId(market)
+				: manageDefaults.selectedOutcomeId),
+		selectedAction:
+			input.selectedAction ??
+			(input.mode === "trade" ? "buy" : manageDefaults.selectedAction),
+		amountInput: null,
+		targetCoverage: null,
+		preview: null,
+		expiresAt: getExpiresAt(),
+	};
+	await saveMarketInteractionSession(redis, sessionId, session);
+	return session;
+};
+
+export const getRootMarketInteractionSession = async (
+	sessionId: string,
+	userId: string,
+): Promise<MarketInteractionSession> => {
+	const session = await getMarketInteractionSession(redis, sessionId);
+	if (!session) {
+		throw new Error("Session expired. Open Trade or Manage Position again.");
+	}
+
+	if (session.userId !== userId) {
+		throw new Error("That session belongs to a different user.");
+	}
+
+	return session;
+};
+
+export const deleteRootMarketInteractionSession = async (
+	sessionId: string,
+): Promise<void> => {
+	await deleteMarketInteractionSession(redis, sessionId);
+};
+
+export const saveRootMarketInteractionSession = async (
+	session: MarketInteractionSession,
+): Promise<MarketInteractionSession> => {
+	const nextSession = {
+		...session,
+		expiresAt: getExpiresAt(),
+	};
+	await saveMarketInteractionSession(redis, session.sessionId, nextSession);
+	return nextSession;
+};
+
+export const refreshRootMarketInteractionSessionPreview = async (
+	session: MarketInteractionSession,
+): Promise<MarketInteractionSession> => {
+	const nextSession: MarketInteractionSession = {
+		...session,
+		preview: null,
+	};
+
+	if (!nextSession.selectedOutcomeId || !nextSession.selectedAction) {
+		return saveRootMarketInteractionSession(nextSession);
+	}
+
+	if (nextSession.selectedAction === "protect") {
+		if (nextSession.targetCoverage === null) {
+			return saveRootMarketInteractionSession(nextSession);
+		}
+
+		nextSession.preview = {
+			kind: "protection",
+			quote: await calculateLossProtectionQuote({
+				marketId: nextSession.marketId,
+				userId: nextSession.userId,
+				outcomeId: nextSession.selectedOutcomeId,
+				targetCoverage: nextSession.targetCoverage,
+			}),
+		};
+		return saveRootMarketInteractionSession(nextSession);
+	}
+
+	if (!nextSession.amountInput?.trim()) {
+		return saveRootMarketInteractionSession(nextSession);
+	}
+
+	const parsedAmount = parseTradeInputAmount(
+		nextSession.selectedAction,
+		nextSession.amountInput,
+	);
+	const quote =
+		nextSession.selectedAction === "buy"
+			? await calculateMarketTradeQuote({
+					marketId: nextSession.marketId,
+					userId: nextSession.userId,
+					outcomeId: nextSession.selectedOutcomeId,
+					action: "buy",
+					amount: parsedAmount.amount,
+					amountMode: "points",
+					rawAmount: nextSession.amountInput,
+				})
+			: nextSession.selectedAction === "sell"
+				? await calculateMarketTradeQuote({
+						marketId: nextSession.marketId,
+						userId: nextSession.userId,
+						outcomeId: nextSession.selectedOutcomeId,
+						action: "sell",
+						amount: parsedAmount.amount,
+						amountMode: parsedAmount.amountMode,
+						rawAmount: nextSession.amountInput,
+					})
+				: nextSession.selectedAction === "short"
+					? await calculateMarketTradeQuote({
+							marketId: nextSession.marketId,
+							userId: nextSession.userId,
+							outcomeId: nextSession.selectedOutcomeId,
+							action: "short",
+							amount: parsedAmount.amount,
+							amountMode: parsedAmount.amountMode,
+							rawAmount: nextSession.amountInput,
+						})
+					: await calculateMarketTradeQuote({
+							marketId: nextSession.marketId,
+							userId: nextSession.userId,
+							outcomeId: nextSession.selectedOutcomeId,
+							action: "cover",
+							amount: parsedAmount.amount,
+							amountMode: parsedAmount.amountMode,
+							rawAmount: nextSession.amountInput,
+						});
+	nextSession.preview = {
+		kind: "trade",
+		quote,
+	};
+	return saveRootMarketInteractionSession(nextSession);
+};
+
+export const buildRootMarketInteractionSessionResponse = async (
+	session: MarketInteractionSession,
+) => {
+	const market = await getMarketById(session.marketId);
+	if (!market) {
+		throw new Error("Market not found.");
+	}
+
+	return buildMarketInteractionSessionMessage({
+		market,
+		session,
+		positions: getSessionPositions(market, session.userId),
+	});
+};
+
+export const buildExpiredMarketInteractionResponse = () => ({
+	embeds: [
+		buildMarketStatusEmbed(
+			"Session Expired",
+			"Open Trade or Manage Position again to refresh the session.",
+			0xef4444,
+		),
+	],
+	components: [],
+});

--- a/src/features/markets/handlers/interactions/shared.ts
+++ b/src/features/markets/handlers/interactions/shared.ts
@@ -1,223 +1,339 @@
-import { PermissionFlagsBits, type ChatInputCommandInteraction } from 'discord.js';
-
-import { env } from '../../../../app/config.js';
-import { executeMarketTrade } from '../../services/trading/execution.js';
 import {
-  parseFlexibleTradeAmount,
-  parseTradeAmount,
-} from '../../parsing/market.js';
+	PermissionFlagsBits,
+	type ChatInputCommandInteraction,
+} from "discord.js";
 
-export type TradeAction = 'buy' | 'sell' | 'short' | 'cover';
+import { env } from "../../../../app/config.js";
+import { executeMarketTrade } from "../../services/trading/execution.js";
+import {
+	parseFlexibleTradeAmount,
+	parseTradeAmount,
+} from "../../parsing/market.js";
+
+export type TradeAction = "buy" | "sell" | "short" | "cover";
 
 const isMarketAdmin = (userId: string): boolean =>
-  env.DISCORD_ADMIN_USER_IDS.includes(userId);
+	env.DISCORD_ADMIN_USER_IDS.includes(userId);
 
 export const assertCanGrantMarketFunds = (userId: string): void => {
-  if (env.DISCORD_ADMIN_USER_IDS.length === 0) {
-    throw new Error('Market grants are disabled until DISCORD_ADMIN_USER_IDS is configured.');
-  }
+	if (env.DISCORD_ADMIN_USER_IDS.length === 0) {
+		throw new Error(
+			"Market grants are disabled until DISCORD_ADMIN_USER_IDS is configured.",
+		);
+	}
 
-  if (!isMarketAdmin(userId)) {
-    throw new Error('Only configured admin user IDs can grant market currency.');
-  }
+	if (!isMarketAdmin(userId)) {
+		throw new Error(
+			"Only configured admin user IDs can grant market currency.",
+		);
+	}
 };
 
-export const assertManageGuild = (interaction: ChatInputCommandInteraction): void => {
-  if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
-    throw new Error('You need Manage Server to configure prediction markets.');
-  }
+export const assertManageGuild = (
+	interaction: ChatInputCommandInteraction,
+): void => {
+	if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
+		throw new Error("You need Manage Server to configure prediction markets.");
+	}
 };
 
 export const parseTradeCustomId = (
-  customId: string,
+	customId: string,
 ): { action: TradeAction; marketId: string } | null => {
-  const match = /^market:(buy|sell|short|cover):(.+)$/.exec(customId);
-  if (!match?.[1] || !match[2]) {
-    return null;
-  }
+	const match = /^market:(buy|sell|short|cover):(.+)$/.exec(customId);
+	if (!match?.[1] || !match[2]) {
+		return null;
+	}
 
-  return {
-    action: match[1] as TradeAction,
-    marketId: match[2],
-  };
+	return {
+		action: match[1] as TradeAction,
+		marketId: match[2],
+	};
 };
 
 export const parseQuickTradeCustomId = (
-  customId: string,
-): { action: 'buy' | 'short'; marketId: string; outcomeId: string } | null => {
-  const match = /^market:quick:(buy|short):([^:]+):([^:]+)$/.exec(customId);
-  if (!match?.[1] || !match[2] || !match[3]) {
-    return null;
-  }
+	customId: string,
+): { action: "buy" | "short"; marketId: string; outcomeId: string } | null => {
+	const match = /^market:quick:(buy|short):([^:]+):([^:]+)$/.exec(customId);
+	if (!match?.[1] || !match[2] || !match[3]) {
+		return null;
+	}
 
-  return {
-    action: match[1] as 'buy' | 'short',
-    marketId: match[2],
-    outcomeId: match[3],
-  };
+	return {
+		action: match[1] as "buy" | "short",
+		marketId: match[2],
+		outcomeId: match[3],
+	};
 };
 
 export const parseMarketOutcomeCustomId = (
-  customId: string,
+	customId: string,
 ): { marketId: string; outcomeId: string } | null => {
-  const match = /^market:outcome:([^:]+):([^:]+)$/.exec(customId);
-  if (!match?.[1] || !match[2]) {
-    return null;
-  }
+	const match = /^market:outcome:([^:]+):([^:]+)$/.exec(customId);
+	if (!match?.[1] || !match[2]) {
+		return null;
+	}
 
-  return {
-    marketId: match[1],
-    outcomeId: match[2],
-  };
+	return {
+		marketId: match[1],
+		outcomeId: match[2],
+	};
 };
 
 export const parseProtectionCoverageCustomId = (
-  customId: string,
+	customId: string,
 ): { marketId: string; outcomeId: string; targetCoverage: number } | null => {
-  const match = /^market:protection-coverage:([^:]+):([^:]+):([^:]+)$/.exec(customId);
-  if (!match?.[1] || !match[2] || !match[3]) {
-    return null;
-  }
+	const match = /^market:protection-coverage:([^:]+):([^:]+):([^:]+)$/.exec(
+		customId,
+	);
+	if (!match?.[1] || !match[2] || !match[3]) {
+		return null;
+	}
 
-  return {
-    marketId: match[1],
-    outcomeId: match[2],
-    targetCoverage: Number(match[3]),
-  };
+	return {
+		marketId: match[1],
+		outcomeId: match[2],
+		targetCoverage: Number(match[3]),
+	};
 };
 
 export const parseTradeSelectCustomId = (
-  customId: string,
+	customId: string,
 ): { action: TradeAction; marketId: string } | null => {
-  const match = /^market:trade-select:(buy|sell|short|cover):(.+)$/.exec(customId);
-  if (!match?.[1] || !match[2]) {
-    return null;
-  }
+	const match = /^market:trade-select:(buy|sell|short|cover):(.+)$/.exec(
+		customId,
+	);
+	if (!match?.[1] || !match[2]) {
+		return null;
+	}
 
-  return {
-    action: match[1] as TradeAction,
-    marketId: match[2],
-  };
+	return {
+		action: match[1] as TradeAction,
+		marketId: match[2],
+	};
 };
 
 export const parseTradeModalCustomId = (
-  customId: string,
+	customId: string,
 ): { action: TradeAction; marketId: string; outcomeId: string } | null => {
-  const match = /^market:trade-modal:(buy|sell|short|cover):([^:]+):([^:]+)$/.exec(customId);
-  if (!match?.[1] || !match[2] || !match[3]) {
-    return null;
-  }
+	const match =
+		/^market:trade-modal:(buy|sell|short|cover):([^:]+):([^:]+)$/.exec(
+			customId,
+		);
+	if (!match?.[1] || !match[2] || !match[3]) {
+		return null;
+	}
 
-  return {
-    action: match[1] as TradeAction,
-    marketId: match[2],
-    outcomeId: match[3],
-  };
+	return {
+		action: match[1] as TradeAction,
+		marketId: match[2],
+		outcomeId: match[3],
+	};
 };
 
-export const parseSimpleMarketId = (prefix: string, customId: string): string | null => {
-  const match = new RegExp(`^${prefix}:(.+)$`).exec(customId);
-  return match?.[1] ?? null;
+export const parseSimpleMarketId = (
+	prefix: string,
+	customId: string,
+): string | null => {
+	const match = new RegExp(`^${prefix}:(.+)$`).exec(customId);
+	return match?.[1] ?? null;
 };
 
 export const parseQuoteSessionId = (
-  prefix: 'market:quote-confirm' | 'market:quote-cancel',
-  customId: string,
+	prefix: "market:quote-confirm" | "market:quote-cancel",
+	customId: string,
 ): string | null => {
-  const match = new RegExp(`^${prefix}:(.+)$`).exec(customId);
-  return match?.[1] ?? null;
+	const match = new RegExp(`^${prefix}:(.+)$`).exec(customId);
+	return match?.[1] ?? null;
+};
+
+export const parseMarketSessionId = (
+	prefix:
+		| "market:session-outcome"
+		| "market:session-position"
+		| "market:session-amount"
+		| "market:session-confirm"
+		| "market:session-cancel"
+		| "market:session-amount-modal",
+	customId: string,
+): string | null => {
+	const match = new RegExp(`^${prefix}:(.+)$`).exec(customId);
+	return match?.[1] ?? null;
+};
+
+export const parseMarketSessionSideCustomId = (
+	customId: string,
+): { sessionId: string; action: "buy" | "short" } | null => {
+	const match = /^market:session-side:([^:]+):(buy|short)$/.exec(customId);
+	if (!match?.[1] || !match[2]) {
+		return null;
+	}
+
+	return {
+		sessionId: match[1],
+		action: match[2] as "buy" | "short",
+	};
+};
+
+export const parseMarketSessionActionCustomId = (
+	customId: string,
+): { sessionId: string; action: "sell" | "cover" | "protect" } | null => {
+	const match = /^market:session-action:([^:]+):(sell|cover|protect)$/.exec(
+		customId,
+	);
+	if (!match?.[1] || !match[2]) {
+		return null;
+	}
+
+	return {
+		sessionId: match[1],
+		action: match[2] as "sell" | "cover" | "protect",
+	};
+};
+
+export const parseMarketSessionQuickAmountCustomId = (
+	customId: string,
+): { sessionId: string; amount: number } | null => {
+	const match = /^market:session-quick-amount:([^:]+):([^:]+)$/.exec(customId);
+	if (!match?.[1] || !match[2]) {
+		return null;
+	}
+
+	const amount = Number(match[2]);
+	if (!Number.isFinite(amount) || amount <= 0) {
+		return null;
+	}
+
+	return {
+		sessionId: match[1],
+		amount,
+	};
+};
+
+export const parseMarketSessionCoverageCustomId = (
+	customId: string,
+): { sessionId: string; targetCoverage: number } | null => {
+	const match = /^market:session-coverage:([^:]+):([^:]+)$/.exec(customId);
+	if (!match?.[1] || !match[2]) {
+		return null;
+	}
+
+	const targetCoverage = Number(match[2]) / 100;
+	if (
+		!Number.isFinite(targetCoverage) ||
+		targetCoverage <= 0 ||
+		targetCoverage > 1
+	) {
+		return null;
+	}
+
+	return {
+		sessionId: match[1],
+		targetCoverage,
+	};
 };
 
 export const parsePortfolioSelectionValue = (
-  value: string,
-): { action: 'sell' | 'cover' | 'protect'; marketId: string; outcomeId: string } | null => {
-  const match = /^(sell|cover|protect):([^:]+):([^:]+)$/.exec(value);
-  if (!match?.[1] || !match[2] || !match[3]) {
-    return null;
-  }
+	value: string,
+): {
+	action: "sell" | "cover" | "protect";
+	marketId: string;
+	outcomeId: string;
+} | null => {
+	const match = /^(sell|cover|protect):([^:]+):([^:]+)$/.exec(value);
+	if (!match?.[1] || !match[2] || !match[3]) {
+		return null;
+	}
 
-  return {
-    action: match[1] as 'sell' | 'cover' | 'protect',
-    marketId: match[2],
-    outcomeId: match[3],
-  };
+	return {
+		action: match[1] as "sell" | "cover" | "protect",
+		marketId: match[2],
+		outcomeId: match[3],
+	};
 };
 
-export const validateEvidenceUrl = (value: string | null | undefined): string | null => {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return null;
-  }
+export const validateEvidenceUrl = (
+	value: string | null | undefined,
+): string | null => {
+	const trimmed = value?.trim();
+	if (!trimmed) {
+		return null;
+	}
 
-  try {
-    const url = new URL(trimmed);
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-      throw new Error('Evidence URL must use http or https.');
-    }
+	try {
+		const url = new URL(trimmed);
+		if (url.protocol !== "http:" && url.protocol !== "https:") {
+			throw new Error("Evidence URL must use http or https.");
+		}
 
-    return url.toString();
-  } catch {
-    throw new Error('Evidence URL must be a valid http or https URL.');
-  }
+		return url.toString();
+	} catch {
+		throw new Error("Evidence URL must be a valid http or https URL.");
+	}
 };
 
-export const getTradeFeedback = (action: TradeAction): { title: string; color: number } => {
-  switch (action) {
-    case 'buy':
-      return { title: 'Position Bought', color: 0x57f287 };
-    case 'sell':
-      return { title: 'Position Sold', color: 0x60a5fa };
-    case 'short':
-      return { title: 'Position Shorted', color: 0xf59e0b };
-    case 'cover':
-      return { title: 'Position Covered', color: 0xeb459e };
-  }
+export const getTradeFeedback = (
+	action: TradeAction,
+): { title: string; color: number } => {
+	switch (action) {
+		case "buy":
+			return { title: "Position Bought", color: 0x57f287 };
+		case "sell":
+			return { title: "Position Sold", color: 0x60a5fa };
+		case "short":
+			return { title: "Position Shorted", color: 0xf59e0b };
+		case "cover":
+			return { title: "Position Covered", color: 0xeb459e };
+	}
 };
 
 export const buildTradeExecutionDescription = (
-  action: TradeAction,
-  outcomeLabel: string,
-  result: Awaited<ReturnType<typeof executeMarketTrade>>,
+	action: TradeAction,
+	outcomeLabel: string,
+	result: Awaited<ReturnType<typeof executeMarketTrade>>,
 ): string => {
-  const netCashAmount = result.netCashAmount ?? result.cashAmount;
-  const settledShares = Math.abs(result.shareDelta);
-  const payoutSummary = action === 'buy'
-    ? { ifChosen: settledShares, ifNotChosen: 0 }
-    : action === 'short'
-      ? { ifChosen: 0, ifNotChosen: settledShares }
-      : null;
+	const netCashAmount = result.netCashAmount ?? result.cashAmount;
+	const settledShares = Math.abs(result.shareDelta);
+	const payoutSummary =
+		action === "buy"
+			? { ifChosen: settledShares, ifNotChosen: 0 }
+			: action === "short"
+				? { ifChosen: 0, ifNotChosen: settledShares }
+				: null;
 
-  return [
-    `Outcome: **${outcomeLabel}**`,
-    action === 'buy'
-      ? `Spend: ${netCashAmount.toFixed(2)} pts`
-      : action === 'short'
-        ? `Proceeds: ${netCashAmount.toFixed(2)} pts`
-        : `Cash: ${result.cashAmount.toFixed(2)} pts`,
-    `Shares: ${Math.abs(result.shareDelta).toFixed(2)}`,
-    `Bankroll: ${result.account.bankroll.toFixed(2)} pts`,
-    ...(payoutSummary
-      ? [
-          `If ${outcomeLabel} is chosen: ${payoutSummary.ifChosen.toFixed(2)} pts`,
-          `If ${outcomeLabel} is not chosen: ${payoutSummary.ifNotChosen.toFixed(2)} pts`,
-        ]
-      : []),
-  ].filter(Boolean).join('\n');
+	return [
+		`Outcome: **${outcomeLabel}**`,
+		action === "buy"
+			? `Spend: ${netCashAmount.toFixed(2)} pts`
+			: action === "short"
+				? `Proceeds: ${netCashAmount.toFixed(2)} pts`
+				: `Cash: ${result.cashAmount.toFixed(2)} pts`,
+		`Shares: ${Math.abs(result.shareDelta).toFixed(2)}`,
+		`Bankroll: ${result.account.bankroll.toFixed(2)} pts`,
+		...(payoutSummary
+			? [
+					`If ${outcomeLabel} is chosen: ${payoutSummary.ifChosen.toFixed(2)} pts`,
+					`If ${outcomeLabel} is not chosen: ${payoutSummary.ifNotChosen.toFixed(2)} pts`,
+				]
+			: []),
+	]
+		.filter(Boolean)
+		.join("\n");
 };
 
 export const parseTradeInputAmount = (
-  action: TradeAction,
-  rawAmount: string,
-): { amount: number; amountMode: 'points' | 'shares' } =>
-  action === 'buy'
-    ? {
-        amount: parseTradeAmount(rawAmount),
-        amountMode: 'points',
-      }
-    : (() => {
-        const parsed = parseFlexibleTradeAmount(rawAmount);
-        return {
-          amount: parsed.amount,
-          amountMode: parsed.mode,
-        };
-      })();
+	action: TradeAction,
+	rawAmount: string,
+): { amount: number; amountMode: "points" | "shares" } =>
+	action === "buy"
+		? {
+				amount: parseTradeAmount(rawAmount),
+				amountMode: "points",
+			}
+		: (() => {
+				const parsed = parseFlexibleTradeAmount(rawAmount);
+				return {
+					amount: parsed.amount,
+					amountMode: parsed.mode,
+				};
+			})();

--- a/src/features/markets/services/forecast/queries.ts
+++ b/src/features/markets/services/forecast/queries.ts
@@ -1,8 +1,12 @@
 import type {
   MarketForecastLeaderboardEntry,
+  MarketForecastProfileDetails,
   MarketForecastProfile,
+  MarketForecastProfileRecentRecord,
+  MarketForecastProfileTrendPoint,
 } from '../../core/types.js';
 import { roundProbability } from '../../core/shared.js';
+import { prisma } from '../../../../lib/prisma.js';
 import {
   buildCalibrationBucketLabel,
   computeBestStreak,
@@ -47,11 +51,13 @@ const getMeanBrier = (records: HydratedForecastRecord[]): number | null => {
   return roundProbability(records.reduce((sum, record) => sum + record.brierScore, 0) / records.length);
 };
 
-export const getMarketForecastProfile = async (
-  guildId: string,
+const buildMarketForecastProfile = (
+  allGuildRecords: HydratedForecastRecord[],
   userId: string,
-): Promise<MarketForecastProfile> => {
-  const allGuildRecords = await getForecastRecordsForGuild(guildId);
+): {
+  profile: MarketForecastProfile;
+  userRecords: HydratedForecastRecord[];
+} => {
   const userRecords = filterForecastRecords(allGuildRecords, { userId });
   const thirtyDayRecords = filterForecastRecords(allGuildRecords, { userId, window: '30d' });
   const recordsByUser = allGuildRecords.reduce<Map<string, HydratedForecastRecord[]>>((map, record) => {
@@ -120,20 +126,98 @@ export const getMarketForecastProfile = async (
     .map(({ latestResolvedAt: _latestResolvedAt, ...entry }) => entry);
 
   return {
-    userId,
-    allTimeMeanBrier: getMeanBrier(userRecords),
-    thirtyDayMeanBrier: getMeanBrier(thirtyDayRecords),
-    allTimeSampleCount: userRecords.length,
-    thirtyDaySampleCount: thirtyDayRecords.length,
-    percentileRank,
-    rank,
-    rankedUserCount,
-    currentCorrectPickStreak: computeCurrentStreak(userRecords, (record) => record.wasCorrect),
-    bestCorrectPickStreak: computeBestStreak(userRecords, (record) => record.wasCorrect),
-    currentProfitableMarketStreak: computeCurrentStreak(userRecords, (record) => record.realizedProfit > 0),
-    bestProfitableMarketStreak: computeBestStreak(userRecords, (record) => record.realizedProfit > 0),
-    calibrationBuckets,
-    topTags,
+    profile: {
+      userId,
+      allTimeMeanBrier: getMeanBrier(userRecords),
+      thirtyDayMeanBrier: getMeanBrier(thirtyDayRecords),
+      allTimeSampleCount: userRecords.length,
+      thirtyDaySampleCount: thirtyDayRecords.length,
+      percentileRank,
+      rank,
+      rankedUserCount,
+      currentCorrectPickStreak: computeCurrentStreak(userRecords, (record) => record.wasCorrect),
+      bestCorrectPickStreak: computeBestStreak(userRecords, (record) => record.wasCorrect),
+      currentProfitableMarketStreak: computeCurrentStreak(userRecords, (record) => record.realizedProfit > 0),
+      bestProfitableMarketStreak: computeBestStreak(userRecords, (record) => record.realizedProfit > 0),
+      calibrationBuckets,
+      topTags,
+    },
+    userRecords,
+  };
+};
+
+const buildProfileTrend = (
+  records: HydratedForecastRecord[],
+): MarketForecastProfileTrendPoint[] => {
+  let cumulativeProfit = 0;
+  return records.map((record) => {
+    cumulativeProfit += record.realizedProfit;
+    return {
+      time: record.resolvedAt.getTime(),
+      brierScore: record.brierScore,
+      realizedProfit: record.realizedProfit,
+      cumulativeProfit: roundProbability(cumulativeProfit),
+    };
+  });
+};
+
+const buildRecentRecords = (
+  records: HydratedForecastRecord[],
+  titleByMarketId: Map<string, string>,
+): MarketForecastProfileRecentRecord[] =>
+  [...records]
+    .sort((left, right) => right.resolvedAt.getTime() - left.resolvedAt.getTime())
+    .slice(0, 6)
+    .map((record) => ({
+      marketId: record.marketId,
+      marketTitle: titleByMarketId.get(record.marketId) ?? record.marketId,
+      resolvedAt: record.resolvedAt,
+      brierScore: record.brierScore,
+      realizedProfit: record.realizedProfit,
+      wasCorrect: record.wasCorrect,
+      predictedOutcomeId: record.predictedOutcomeId,
+      winningOutcomeId: record.winningOutcomeId,
+      winningOutcomeProbability: record.winningOutcomeProbability,
+      tradeCount: record.tradeCount,
+      stakeWeight: record.stakeWeight,
+      tags: [...record.marketTagSnapshot],
+    }));
+
+export const getMarketForecastProfile = async (
+  guildId: string,
+  userId: string,
+): Promise<MarketForecastProfile> => {
+  const { profile } = buildMarketForecastProfile(await getForecastRecordsForGuild(guildId), userId);
+  return profile;
+};
+
+export const getMarketForecastProfileDetails = async (
+  guildId: string,
+  userId: string,
+): Promise<MarketForecastProfileDetails> => {
+  const { profile, userRecords } = buildMarketForecastProfile(await getForecastRecordsForGuild(guildId), userId);
+  const userMarketIds = [...new Set(userRecords.map((record) => record.marketId))];
+  const markets = userMarketIds.length === 0
+    ? []
+    : await prisma.market.findMany({
+        where: {
+          guildId,
+          id: {
+            in: userMarketIds,
+          },
+        },
+        select: {
+          id: true,
+          title: true,
+        },
+      });
+  const titleByMarketId = new Map(markets.map((market) => [market.id, market.title]));
+
+  return {
+    ...profile,
+    recentRecords: buildRecentRecords(userRecords, titleByMarketId),
+    brierTrend: buildProfileTrend(userRecords),
+    profitTrend: buildProfileTrend(userRecords),
   };
 };
 

--- a/src/features/markets/services/trading/quotes.ts
+++ b/src/features/markets/services/trading/quotes.ts
@@ -1,162 +1,489 @@
-import { getEffectiveAccountPreview } from '../account.js';
+import { getEffectiveAccountPreview } from "../account.js";
 import {
-  assertMarketOpen,
-  assertOutcomeTradable,
-  getMarketProbabilities,
-  getPosition,
-  getPositionMap,
-  getTradeLockReason,
-  getTradableOutcomeIndexes,
-  roundCurrency,
-} from '../../core/shared.js';
+	assertMarketOpen,
+	assertOutcomeTradable,
+	getMarketProbabilities,
+	getLossProtection,
+	getLossProtectionMap,
+	getPosition,
+	getPositionMap,
+	getTradeLockReason,
+	getTradableOutcomeIndexes,
+	roundCurrency,
+} from "../../core/shared.js";
 import {
-  computeSellPayout,
-  solveBuySharesForAmount,
-  solveShortSharesForAmount,
-} from '../../core/math.js';
-import { getMarketById } from '../records.js';
+	computeBuyCost,
+	computeSellPayout,
+	solveBuySharesForAmount,
+	solveSellSharesForAmount,
+	solveShortSharesForAmount,
+} from "../../core/math.js";
+import { getMarketById } from "../records.js";
 import type {
-  MarketTradeQuote,
-  MarketTradeQuoteAction,
-} from '../../core/types.js';
+	MarketTradeQuote,
+	MarketTradeQuoteAction,
+} from "../../core/types.js";
 import {
-  assertPositiveTradeAmount,
-  type CalculateMarketTradeQuoteInput,
-} from './shared.js';
+	assertPositiveTradeAmount,
+	type CalculateMarketTradeQuoteInput,
+} from "./shared.js";
 
-export const calculateMarketTradeQuote = async (input: CalculateMarketTradeQuoteInput): Promise<MarketTradeQuote> => {
-  assertPositiveTradeAmount(input.amount);
-  if (input.action === 'buy' && (input as { amountMode?: 'points' | 'shares' }).amountMode === 'shares') {
-    throw new Error('Buy quotes only support point amounts.');
-  }
+export const calculateMarketTradeQuote = async (
+	input: CalculateMarketTradeQuoteInput,
+): Promise<MarketTradeQuote> => {
+	assertPositiveTradeAmount(input.amount);
+	if (
+		input.action === "buy" &&
+		(input as { amountMode?: "points" | "shares" }).amountMode === "shares"
+	) {
+		throw new Error("Buy quotes only support point amounts.");
+	}
 
-  const amountMode = input.amountMode ?? 'points';
+	const amountMode = input.amountMode ?? "points";
 
-  return calculateMarketTradeQuoteUnsafe({
-    ...input,
-    amountMode,
-  });
+	return calculateMarketTradeQuoteUnsafe({
+		...input,
+		amountMode,
+	});
 };
 
 const calculateMarketTradeQuoteUnsafe = async (input: {
-  marketId: string;
-  userId: string;
-  outcomeId: string;
-  action: MarketTradeQuoteAction;
-  amount: number;
-  rawAmount: string;
-  amountMode: 'points' | 'shares';
+	marketId: string;
+	userId: string;
+	outcomeId: string;
+	action: MarketTradeQuoteAction;
+	amount: number;
+	rawAmount: string;
+	amountMode: "points" | "shares";
 }): Promise<MarketTradeQuote> => {
-  const market = await getMarketById(input.marketId);
-  if (!market) {
-    throw new Error('Market not found.');
-  }
+	const market = await getMarketById(input.marketId);
+	if (!market) {
+		throw new Error("Market not found.");
+	}
 
-  assertMarketOpen(market);
-  const outcomeIndex = market.outcomes.findIndex((outcome) => outcome.id === input.outcomeId);
-  const outcome = market.outcomes[outcomeIndex];
-  if (!outcome) {
-    throw new Error('Market outcome not found.');
-  }
+	assertMarketOpen(market);
+	const outcomeIndex = market.outcomes.findIndex(
+		(outcome) => outcome.id === input.outcomeId,
+	);
+	const outcome = market.outcomes[outcomeIndex];
+	if (!outcome) {
+		throw new Error("Market outcome not found.");
+	}
 
-  assertOutcomeTradable(market, outcome);
-  const tradeLockReason = getTradeLockReason(market, outcome.id, input.action);
-  if (tradeLockReason) {
-    throw new Error(tradeLockReason);
-  }
+	assertOutcomeTradable(market, outcome);
+	const tradeLockReason = getTradeLockReason(market, outcome.id, input.action);
+	if (tradeLockReason) {
+		throw new Error(tradeLockReason);
+	}
 
-  const tradableOutcomeIndexes = getTradableOutcomeIndexes(market);
-  const tradableIndex = tradableOutcomeIndexes.indexOf(outcomeIndex);
-  if (tradableIndex < 0) {
-    throw new Error('That outcome can no longer be traded.');
-  }
+	const tradableOutcomeIndexes = getTradableOutcomeIndexes(market);
+	const tradableIndex = tradableOutcomeIndexes.indexOf(outcomeIndex);
+	if (tradableIndex < 0) {
+		throw new Error("That outcome can no longer be traded.");
+	}
 
-  const pricingShares = tradableOutcomeIndexes.map((index) => market.outcomes[index]?.pricingShares ?? 0);
-  const positions = getPositionMap(market.positions.filter((position) => position.userId === input.userId));
-  const longPosition = getPosition(positions, outcome.id, 'long');
-  const shortPosition = getPosition(positions, outcome.id, 'short');
-  const account = await getEffectiveAccountPreview(market.guildId, input.userId);
-  const amountMode = input.amountMode;
+	const pricingShares = tradableOutcomeIndexes.map(
+		(index) => market.outcomes[index]?.pricingShares ?? 0,
+	);
+	const positions = getPositionMap(
+		market.positions.filter((position) => position.userId === input.userId),
+	);
+	const longPosition = getPosition(positions, outcome.id, "long");
+	const shortPosition = getPosition(positions, outcome.id, "short");
+	const account = await getEffectiveAccountPreview(
+		market.guildId,
+		input.userId,
+	);
+	const amountMode = input.amountMode;
+	const currentProbabilities = getMarketProbabilities(market);
+	const currentProbability = roundCurrency(
+		currentProbabilities[outcomeIndex] ?? 0,
+	);
+	const nextPricingShares = [...pricingShares];
 
-  if (input.action === 'buy') {
-    if (shortPosition && shortPosition.shares > 1e-6) {
-      throw new Error('You must cover your short position in that outcome before buying it.');
-    }
+	const buildProbabilities = (): {
+		currentProbability: number;
+		nextProbability: number;
+	} => {
+		const nextActiveProbabilities =
+			tradableOutcomeIndexes.length === 0
+				? []
+				: getMarketProbabilities({
+						...market,
+						outcomes: market.outcomes.map((marketOutcome, index) => ({
+							...marketOutcome,
+							pricingShares: tradableOutcomeIndexes.includes(index)
+								? (nextPricingShares[tradableOutcomeIndexes.indexOf(index)] ??
+									marketOutcome.pricingShares)
+								: marketOutcome.pricingShares,
+						})),
+					});
 
-    const feeCharged = 0;
-    if (account.bankroll < input.amount - 1e-6) {
-      throw new Error('You do not have enough bankroll for that trade.');
-    }
+		return {
+			currentProbability,
+			nextProbability: roundCurrency(
+				nextActiveProbabilities[outcomeIndex] ?? 0,
+			),
+		};
+	};
 
-    const sharesReceived = solveBuySharesForAmount(pricingShares, tradableIndex, input.amount, market.liquidityParameter);
-    return {
-      action: input.action,
-      marketId: market.id,
-      marketTitle: market.title,
-      outcomeId: outcome.id,
-      outcomeLabel: outcome.label,
-      userId: input.userId,
-      guildId: market.guildId,
-      amount: input.amount,
-      amountMode,
-      rawAmount: input.rawAmount,
-      shares: roundCurrency(sharesReceived),
-      averagePrice: sharesReceived > 0 ? roundCurrency(input.amount / sharesReceived) : null,
-      immediateCash: roundCurrency(input.amount),
-      grossImmediateCash: roundCurrency(input.amount),
-      netImmediateCash: roundCurrency(input.amount),
-      feeCharged,
-      collateralLocked: 0,
-      netBankrollChange: roundCurrency(-input.amount),
-      settlementIfChosen: roundCurrency(sharesReceived),
-      settlementIfNotChosen: 0,
-      maxProfitIfChosen: roundCurrency(sharesReceived - input.amount),
-      maxProfitIfNotChosen: 0,
-      maxLossIfChosen: 0,
-      maxLossIfNotChosen: roundCurrency(input.amount),
-    };
-  }
+	if (input.action === "buy") {
+		if (shortPosition && shortPosition.shares > 1e-6) {
+			throw new Error(
+				"You must cover your short position in that outcome before buying it.",
+			);
+		}
 
-  if (longPosition && longPosition.shares > 1e-6) {
-    throw new Error('You must sell your long position in that outcome before shorting it.');
-  }
+		const feeCharged = 0;
+		if (account.bankroll < input.amount - 1e-6) {
+			throw new Error("You do not have enough bankroll for that trade.");
+		}
 
-  const sharesToShort = amountMode === 'shares'
-    ? input.amount
-    : solveShortSharesForAmount(pricingShares, tradableIndex, input.amount, market.liquidityParameter);
-  const proceedsReceived = amountMode === 'shares'
-    ? roundCurrency(computeSellPayout(pricingShares, tradableIndex, sharesToShort, market.liquidityParameter))
-    : roundCurrency(input.amount);
-  const feeCharged = 0;
-  const collateralToLock = roundCurrency(sharesToShort);
-  if ((account.bankroll + proceedsReceived - collateralToLock) < -1e-6) {
-    throw new Error('You do not have enough bankroll to collateralize that short.');
-  }
+		const sharesReceived = solveBuySharesForAmount(
+			pricingShares,
+			tradableIndex,
+			input.amount,
+			market.liquidityParameter,
+		);
+		nextPricingShares[tradableIndex] =
+			(nextPricingShares[tradableIndex] ?? 0) + sharesReceived;
+		const positionSharesAfter = roundCurrency(
+			(longPosition?.shares ?? 0) + sharesReceived,
+		);
+		const positionCostBasisAfter = roundCurrency(
+			(longPosition?.costBasis ?? 0) + input.amount,
+		);
+		const bankrollAfter = roundCurrency(account.bankroll - input.amount);
+		const probabilities = buildProbabilities();
 
-  return {
-    action: input.action,
-    marketId: market.id,
-    marketTitle: market.title,
-    outcomeId: outcome.id,
-    outcomeLabel: outcome.label,
-    userId: input.userId,
-    guildId: market.guildId,
-    amount: input.amount,
-    amountMode,
-    rawAmount: input.rawAmount,
-    shares: roundCurrency(sharesToShort),
-    averagePrice: null,
-    immediateCash: roundCurrency(proceedsReceived),
-    grossImmediateCash: roundCurrency(proceedsReceived),
-    netImmediateCash: roundCurrency(proceedsReceived),
-    feeCharged,
-    collateralLocked: collateralToLock,
-    netBankrollChange: roundCurrency(proceedsReceived - collateralToLock),
-    settlementIfChosen: 0,
-    settlementIfNotChosen: collateralToLock,
-    maxProfitIfChosen: 0,
-    maxProfitIfNotChosen: roundCurrency(proceedsReceived),
-    maxLossIfChosen: roundCurrency(collateralToLock - proceedsReceived),
-    maxLossIfNotChosen: 0,
-  };
+		return {
+			action: input.action,
+			marketId: market.id,
+			marketTitle: market.title,
+			outcomeId: outcome.id,
+			outcomeLabel: outcome.label,
+			userId: input.userId,
+			guildId: market.guildId,
+			amount: input.amount,
+			amountMode,
+			rawAmount: input.rawAmount,
+			shares: roundCurrency(sharesReceived),
+			averagePrice:
+				sharesReceived > 0
+					? roundCurrency(input.amount / sharesReceived)
+					: null,
+			currentProbability: probabilities.currentProbability,
+			nextProbability: probabilities.nextProbability,
+			immediateCash: roundCurrency(input.amount),
+			grossImmediateCash: roundCurrency(input.amount),
+			netImmediateCash: roundCurrency(input.amount),
+			feeCharged,
+			collateralLocked: 0,
+			collateralReleased: 0,
+			netBankrollChange: roundCurrency(-input.amount),
+			bankrollAfter,
+			positionSide: "long",
+			positionSharesAfter,
+			positionCostBasisAfter,
+			positionProceedsAfter: 0,
+			positionCollateralAfter: 0,
+			realizedProfitDelta: 0,
+			settlementIfChosen: positionSharesAfter,
+			settlementIfNotChosen: 0,
+			maxProfitIfChosen: roundCurrency(
+				positionSharesAfter - positionCostBasisAfter,
+			),
+			maxProfitIfNotChosen: 0,
+			maxLossIfChosen: 0,
+			maxLossIfNotChosen: positionCostBasisAfter,
+		};
+	}
+
+	if (input.action === "sell") {
+		const ownedShares = longPosition?.shares ?? 0;
+		if (ownedShares <= 1e-6) {
+			throw new Error("You do not own a long position in that outcome yet.");
+		}
+
+		const requestedSharesToSell =
+			amountMode === "shares"
+				? input.amount
+				: solveSellSharesForAmount(
+						pricingShares,
+						tradableIndex,
+						input.amount,
+						ownedShares,
+						market.liquidityParameter,
+					);
+		if (requestedSharesToSell > ownedShares + 1e-6) {
+			throw new Error(
+				"You do not have enough shares in that outcome to sell that much.",
+			);
+		}
+
+		const sharesSold = roundCurrency(requestedSharesToSell);
+		const cashAmount =
+			amountMode === "shares"
+				? roundCurrency(
+						computeSellPayout(
+							pricingShares,
+							tradableIndex,
+							sharesSold,
+							market.liquidityParameter,
+						),
+					)
+				: roundCurrency(input.amount);
+		const averageCostBasis = (longPosition?.costBasis ?? 0) / ownedShares;
+		const releasedCostBasis = roundCurrency(averageCostBasis * sharesSold);
+		nextPricingShares[tradableIndex] =
+			(nextPricingShares[tradableIndex] ?? 0) - sharesSold;
+		const positionSharesAfter = roundCurrency(ownedShares - sharesSold);
+		const positionCostBasisAfter = roundCurrency(
+			(longPosition?.costBasis ?? 0) - releasedCostBasis,
+		);
+		const bankrollAfter = roundCurrency(account.bankroll + cashAmount);
+		const probabilities = buildProbabilities();
+
+		return {
+			action: input.action,
+			marketId: market.id,
+			marketTitle: market.title,
+			outcomeId: outcome.id,
+			outcomeLabel: outcome.label,
+			userId: input.userId,
+			guildId: market.guildId,
+			amount: input.amount,
+			amountMode,
+			rawAmount: input.rawAmount,
+			shares: sharesSold,
+			averagePrice:
+				sharesSold > 0 ? roundCurrency(cashAmount / sharesSold) : null,
+			currentProbability: probabilities.currentProbability,
+			nextProbability: probabilities.nextProbability,
+			immediateCash: cashAmount,
+			grossImmediateCash: cashAmount,
+			netImmediateCash: cashAmount,
+			feeCharged: 0,
+			collateralLocked: 0,
+			collateralReleased: 0,
+			netBankrollChange: cashAmount,
+			bankrollAfter,
+			positionSide: "long",
+			positionSharesAfter,
+			positionCostBasisAfter,
+			positionProceedsAfter: 0,
+			positionCollateralAfter: 0,
+			realizedProfitDelta: roundCurrency(cashAmount - releasedCostBasis),
+			settlementIfChosen: positionSharesAfter,
+			settlementIfNotChosen: 0,
+			maxProfitIfChosen: roundCurrency(
+				positionSharesAfter - positionCostBasisAfter,
+			),
+			maxProfitIfNotChosen: 0,
+			maxLossIfChosen: 0,
+			maxLossIfNotChosen: positionCostBasisAfter,
+		};
+	}
+
+	if (longPosition && longPosition.shares > 1e-6) {
+		throw new Error(
+			"You must sell your long position in that outcome before shorting it.",
+		);
+	}
+
+	if (input.action === "short") {
+		const sharesToShort =
+			amountMode === "shares"
+				? input.amount
+				: solveShortSharesForAmount(
+						pricingShares,
+						tradableIndex,
+						input.amount,
+						market.liquidityParameter,
+					);
+		const proceedsReceived =
+			amountMode === "shares"
+				? roundCurrency(
+						computeSellPayout(
+							pricingShares,
+							tradableIndex,
+							sharesToShort,
+							market.liquidityParameter,
+						),
+					)
+				: roundCurrency(input.amount);
+		const feeCharged = 0;
+		const collateralToLock = roundCurrency(sharesToShort);
+		if (account.bankroll + proceedsReceived - collateralToLock < -1e-6) {
+			throw new Error(
+				"You do not have enough bankroll to collateralize that short.",
+			);
+		}
+
+		nextPricingShares[tradableIndex] =
+			(nextPricingShares[tradableIndex] ?? 0) - sharesToShort;
+		const positionSharesAfter = roundCurrency(
+			(shortPosition?.shares ?? 0) + sharesToShort,
+		);
+		const positionProceedsAfter = roundCurrency(
+			(shortPosition?.proceeds ?? 0) + proceedsReceived,
+		);
+		const positionCollateralAfter = roundCurrency(
+			(shortPosition?.collateralLocked ?? 0) + collateralToLock,
+		);
+		const bankrollAfter = roundCurrency(
+			account.bankroll + proceedsReceived - collateralToLock,
+		);
+		const probabilities = buildProbabilities();
+
+		return {
+			action: input.action,
+			marketId: market.id,
+			marketTitle: market.title,
+			outcomeId: outcome.id,
+			outcomeLabel: outcome.label,
+			userId: input.userId,
+			guildId: market.guildId,
+			amount: input.amount,
+			amountMode,
+			rawAmount: input.rawAmount,
+			shares: roundCurrency(sharesToShort),
+			averagePrice:
+				sharesToShort > 0
+					? roundCurrency(proceedsReceived / sharesToShort)
+					: null,
+			currentProbability: probabilities.currentProbability,
+			nextProbability: probabilities.nextProbability,
+			immediateCash: roundCurrency(proceedsReceived),
+			grossImmediateCash: roundCurrency(proceedsReceived),
+			netImmediateCash: roundCurrency(proceedsReceived),
+			feeCharged,
+			collateralLocked: collateralToLock,
+			collateralReleased: 0,
+			netBankrollChange: roundCurrency(proceedsReceived - collateralToLock),
+			bankrollAfter,
+			positionSide: "short",
+			positionSharesAfter,
+			positionCostBasisAfter: 0,
+			positionProceedsAfter,
+			positionCollateralAfter,
+			realizedProfitDelta: 0,
+			settlementIfChosen: 0,
+			settlementIfNotChosen: positionCollateralAfter,
+			maxProfitIfChosen: 0,
+			maxProfitIfNotChosen: positionProceedsAfter,
+			maxLossIfChosen: roundCurrency(
+				positionCollateralAfter - positionProceedsAfter,
+			),
+			maxLossIfNotChosen: 0,
+		};
+	}
+
+	const ownedShortShares = shortPosition?.shares ?? 0;
+	if (ownedShortShares <= 1e-6) {
+		throw new Error("You do not have a short position in that outcome yet.");
+	}
+
+	if (amountMode !== "shares") {
+		const maxCoverCost = computeBuyCost(
+			pricingShares,
+			tradableIndex,
+			ownedShortShares,
+			market.liquidityParameter,
+		);
+		if (input.amount > maxCoverCost + 1e-6) {
+			throw new Error(
+				"You do not have enough short shares in that outcome to cover that much.",
+			);
+		}
+	}
+
+	const sharesToCover =
+		amountMode === "shares"
+			? input.amount
+			: solveBuySharesForAmount(
+					pricingShares,
+					tradableIndex,
+					input.amount,
+					market.liquidityParameter,
+				);
+	if (sharesToCover > ownedShortShares + 1e-6) {
+		throw new Error(
+			"You do not have enough short shares in that outcome to cover that much.",
+		);
+	}
+
+	const coverCost =
+		amountMode === "shares"
+			? roundCurrency(
+					computeBuyCost(
+						pricingShares,
+						tradableIndex,
+						sharesToCover,
+						market.liquidityParameter,
+					),
+				)
+			: roundCurrency(input.amount);
+	const averageProceeds = (shortPosition?.proceeds ?? 0) / ownedShortShares;
+	const averageCollateral =
+		(shortPosition?.collateralLocked ?? 0) / ownedShortShares;
+	const releasedProceeds = roundCurrency(averageProceeds * sharesToCover);
+	const releasedCollateral = roundCurrency(averageCollateral * sharesToCover);
+	if (account.bankroll + releasedCollateral < coverCost - 1e-6) {
+		throw new Error("You do not have enough bankroll to cover that short.");
+	}
+
+	nextPricingShares[tradableIndex] =
+		(nextPricingShares[tradableIndex] ?? 0) + sharesToCover;
+	const positionSharesAfter = roundCurrency(ownedShortShares - sharesToCover);
+	const positionProceedsAfter = roundCurrency(
+		(shortPosition?.proceeds ?? 0) - releasedProceeds,
+	);
+	const positionCollateralAfter = roundCurrency(
+		(shortPosition?.collateralLocked ?? 0) - releasedCollateral,
+	);
+	const bankrollAfter = roundCurrency(
+		account.bankroll + releasedCollateral - coverCost,
+	);
+	const probabilities = buildProbabilities();
+
+	return {
+		action: input.action,
+		marketId: market.id,
+		marketTitle: market.title,
+		outcomeId: outcome.id,
+		outcomeLabel: outcome.label,
+		userId: input.userId,
+		guildId: market.guildId,
+		amount: input.amount,
+		amountMode,
+		rawAmount: input.rawAmount,
+		shares: roundCurrency(sharesToCover),
+		averagePrice:
+			sharesToCover > 0 ? roundCurrency(coverCost / sharesToCover) : null,
+		currentProbability: probabilities.currentProbability,
+		nextProbability: probabilities.nextProbability,
+		immediateCash: coverCost,
+		grossImmediateCash: coverCost,
+		netImmediateCash: coverCost,
+		feeCharged: 0,
+		collateralLocked: 0,
+		collateralReleased: releasedCollateral,
+		netBankrollChange: roundCurrency(releasedCollateral - coverCost),
+		bankrollAfter,
+		positionSide: "short",
+		positionSharesAfter,
+		positionCostBasisAfter: 0,
+		positionProceedsAfter,
+		positionCollateralAfter,
+		realizedProfitDelta: roundCurrency(releasedProceeds - coverCost),
+		settlementIfChosen: 0,
+		settlementIfNotChosen: positionCollateralAfter,
+		maxProfitIfChosen: 0,
+		maxProfitIfNotChosen: positionProceedsAfter,
+		maxLossIfChosen: roundCurrency(
+			positionCollateralAfter - positionProceedsAfter,
+		),
+		maxLossIfNotChosen: 0,
+	};
 };

--- a/src/features/markets/services/trading/shared.ts
+++ b/src/features/markets/services/trading/shared.ts
@@ -1,38 +1,58 @@
-import { type MarketPosition } from '@prisma/client';
+import { type MarketPosition } from "@prisma/client";
 
 export type CalculateMarketTradeQuoteInput =
-  | {
-      marketId: string;
-      userId: string;
-      outcomeId: string;
-      action: 'buy';
-      amount: number;
-      rawAmount: string;
-      amountMode?: 'points';
-    }
-  | {
-      marketId: string;
-      userId: string;
-      outcomeId: string;
-      action: 'short';
-      amount: number;
-      rawAmount: string;
-      amountMode?: 'points' | 'shares';
-    };
+	| {
+			marketId: string;
+			userId: string;
+			outcomeId: string;
+			action: "buy";
+			amount: number;
+			rawAmount: string;
+			amountMode?: "points";
+	  }
+	| {
+			marketId: string;
+			userId: string;
+			outcomeId: string;
+			action: "sell";
+			amount: number;
+			rawAmount: string;
+			amountMode?: "points" | "shares";
+	  }
+	| {
+			marketId: string;
+			userId: string;
+			outcomeId: string;
+			action: "short";
+			amount: number;
+			rawAmount: string;
+			amountMode?: "points" | "shares";
+	  }
+	| {
+			marketId: string;
+			userId: string;
+			outcomeId: string;
+			action: "cover";
+			amount: number;
+			rawAmount: string;
+			amountMode?: "points" | "shares";
+	  };
 
 export const assertPositiveTradeAmount = (amount: number): void => {
-  if (!Number.isFinite(amount) || amount <= 0) {
-    throw new Error('Trade amount must be a finite value greater than zero.');
-  }
+	if (!Number.isFinite(amount) || amount <= 0) {
+		throw new Error("Trade amount must be a finite value greater than zero.");
+	}
 };
 
-export const groupPositionsByUser = (positions: MarketPosition[]): Map<string, MarketPosition[]> => {
-  const grouped = new Map<string, MarketPosition[]>();
-  for (const position of positions) {
-    const existing = grouped.get(position.userId) ?? [];
-    existing.push(position);
-    grouped.set(position.userId, existing);
-  }
+export const groupPositionsByUser = (
+	positions: MarketPosition[],
+): Map<string, MarketPosition[]> => {
+	const grouped = new Map<string, MarketPosition[]>();
+	for (const position of positions) {
+		const existing = grouped.get(position.userId) ?? [];
+		existing.push(position);
+		grouped.set(position.userId, existing);
+	}
 
-  return grouped;
+	return grouped;
 };

--- a/src/features/markets/state/interaction-session-store.ts
+++ b/src/features/markets/state/interaction-session-store.ts
@@ -1,0 +1,43 @@
+import { randomUUID } from "node:crypto";
+
+import type { Redis } from "ioredis";
+
+import type { MarketInteractionSession } from "../core/types.js";
+
+const ttlSeconds = 60 * 10;
+const getSessionKey = (sessionId: string): string =>
+	`market-interaction-session:${sessionId}`;
+
+export const createMarketInteractionSessionId = (): string => randomUUID();
+
+export const saveMarketInteractionSession = async (
+	redis: Redis,
+	sessionId: string,
+	session: MarketInteractionSession,
+): Promise<void> => {
+	await redis.set(
+		getSessionKey(sessionId),
+		JSON.stringify(session),
+		"EX",
+		ttlSeconds,
+	);
+};
+
+export const getMarketInteractionSession = async (
+	redis: Redis,
+	sessionId: string,
+): Promise<MarketInteractionSession | null> => {
+	const value = await redis.get(getSessionKey(sessionId));
+	if (!value) {
+		return null;
+	}
+
+	return JSON.parse(value) as MarketInteractionSession;
+};
+
+export const deleteMarketInteractionSession = async (
+	redis: Redis,
+	sessionId: string,
+): Promise<void> => {
+	await redis.del(getSessionKey(sessionId));
+};

--- a/src/features/markets/ui/custom-ids.ts
+++ b/src/features/markets/ui/custom-ids.ts
@@ -1,31 +1,89 @@
-export const marketBuyButtonCustomId = (marketId: string): string => `market:buy:${marketId}`;
-export const marketSellButtonCustomId = (marketId: string): string => `market:sell:${marketId}`;
-export const marketShortButtonCustomId = (marketId: string): string => `market:short:${marketId}`;
-export const marketCoverButtonCustomId = (marketId: string): string => `market:cover:${marketId}`;
-export const marketOutcomeButtonCustomId = (marketId: string, outcomeId: string): string => `market:outcome:${marketId}:${outcomeId}`;
-export const marketDetailsButtonCustomId = (marketId: string): string => `market:details:${marketId}`;
+export const marketBuyButtonCustomId = (marketId: string): string =>
+	`market:buy:${marketId}`;
+export const marketSellButtonCustomId = (marketId: string): string =>
+	`market:sell:${marketId}`;
+export const marketShortButtonCustomId = (marketId: string): string =>
+	`market:short:${marketId}`;
+export const marketCoverButtonCustomId = (marketId: string): string =>
+	`market:cover:${marketId}`;
+export const marketOutcomeButtonCustomId = (
+	marketId: string,
+	outcomeId: string,
+): string => `market:outcome:${marketId}:${outcomeId}`;
+export const marketTradeButtonCustomId = (marketId: string): string =>
+	`market:trade:${marketId}`;
+export const marketManageButtonCustomId = (marketId: string): string =>
+	`market:manage:${marketId}`;
+export const marketDetailsButtonCustomId = (marketId: string): string =>
+	`market:details:${marketId}`;
 export const marketQuickTradeButtonCustomId = (
-  action: 'buy' | 'short',
-  marketId: string,
-  outcomeId: string,
+	action: "buy" | "short",
+	marketId: string,
+	outcomeId: string,
 ): string => `market:quick:${action}:${marketId}:${outcomeId}`;
-export const marketPortfolioButtonCustomId = (marketId: string): string => `market:portfolio:${marketId}`;
-export const marketProtectButtonCustomId = (marketId: string): string => `market:protect:${marketId}`;
-export const marketPortfolioSelectCustomId = (): string => 'market:portfolio-select';
-export const marketProtectionSelectCustomId = (marketId: string): string => `market:protection-select:${marketId}`;
+export const marketPortfolioButtonCustomId = (marketId: string): string =>
+	`market:portfolio:${marketId}`;
+export const marketProtectButtonCustomId = (marketId: string): string =>
+	`market:protect:${marketId}`;
+export const marketPortfolioSelectCustomId = (): string =>
+	"market:portfolio-select";
+export const marketProtectionSelectCustomId = (marketId: string): string =>
+	`market:protection-select:${marketId}`;
 export const marketProtectionCoverageButtonCustomId = (
-  marketId: string,
-  outcomeId: string,
-  targetCoverage: number,
-): string => `market:protection-coverage:${marketId}:${outcomeId}:${targetCoverage}`;
-export const marketRefreshButtonCustomId = (marketId: string): string => `market:refresh:${marketId}`;
-export const marketTradeSelectCustomId = (action: 'buy' | 'sell' | 'short' | 'cover', marketId: string): string =>
-  `market:trade-select:${action}:${marketId}`;
-export const marketTradeModalCustomId = (action: 'buy' | 'sell' | 'short' | 'cover', marketId: string, outcomeId: string): string =>
-  `market:trade-modal:${action}:${marketId}:${outcomeId}`;
-export const marketTradeQuoteConfirmCustomId = (sessionId: string): string => `market:quote-confirm:${sessionId}`;
-export const marketTradeQuoteCancelCustomId = (sessionId: string): string => `market:quote-cancel:${sessionId}`;
-export const marketResolveButtonCustomId = (marketId: string): string => `market:resolve:${marketId}`;
-export const marketCancelButtonCustomId = (marketId: string): string => `market:cancel:${marketId}`;
-export const marketResolveModalCustomId = (marketId: string): string => `market:resolve-modal:${marketId}`;
-export const marketCancelModalCustomId = (marketId: string): string => `market:cancel-modal:${marketId}`;
+	marketId: string,
+	outcomeId: string,
+	targetCoverage: number,
+): string =>
+	`market:protection-coverage:${marketId}:${outcomeId}:${targetCoverage}`;
+export const marketRefreshButtonCustomId = (marketId: string): string =>
+	`market:refresh:${marketId}`;
+export const marketTradeSelectCustomId = (
+	action: "buy" | "sell" | "short" | "cover",
+	marketId: string,
+): string => `market:trade-select:${action}:${marketId}`;
+export const marketTradeModalCustomId = (
+	action: "buy" | "sell" | "short" | "cover",
+	marketId: string,
+	outcomeId: string,
+): string => `market:trade-modal:${action}:${marketId}:${outcomeId}`;
+export const marketTradeQuoteConfirmCustomId = (sessionId: string): string =>
+	`market:quote-confirm:${sessionId}`;
+export const marketTradeQuoteCancelCustomId = (sessionId: string): string =>
+	`market:quote-cancel:${sessionId}`;
+export const marketSessionSideButtonCustomId = (
+	sessionId: string,
+	action: "buy" | "short",
+): string => `market:session-side:${sessionId}:${action}`;
+export const marketSessionActionButtonCustomId = (
+	sessionId: string,
+	action: "sell" | "cover" | "protect",
+): string => `market:session-action:${sessionId}:${action}`;
+export const marketSessionOutcomeSelectCustomId = (sessionId: string): string =>
+	`market:session-outcome:${sessionId}`;
+export const marketSessionPositionSelectCustomId = (
+	sessionId: string,
+): string => `market:session-position:${sessionId}`;
+export const marketSessionAmountButtonCustomId = (sessionId: string): string =>
+	`market:session-amount:${sessionId}`;
+export const marketSessionQuickAmountButtonCustomId = (
+	sessionId: string,
+	amount: number,
+): string => `market:session-quick-amount:${sessionId}:${amount}`;
+export const marketSessionCoverageButtonCustomId = (
+	sessionId: string,
+	coveragePercent: number,
+): string => `market:session-coverage:${sessionId}:${coveragePercent}`;
+export const marketSessionConfirmButtonCustomId = (sessionId: string): string =>
+	`market:session-confirm:${sessionId}`;
+export const marketSessionCancelButtonCustomId = (sessionId: string): string =>
+	`market:session-cancel:${sessionId}`;
+export const marketSessionAmountModalCustomId = (sessionId: string): string =>
+	`market:session-amount-modal:${sessionId}`;
+export const marketResolveButtonCustomId = (marketId: string): string =>
+	`market:resolve:${marketId}`;
+export const marketCancelButtonCustomId = (marketId: string): string =>
+	`market:cancel:${marketId}`;
+export const marketResolveModalCustomId = (marketId: string): string =>
+	`market:resolve-modal:${marketId}`;
+export const marketCancelModalCustomId = (marketId: string): string =>
+	`market:cancel-modal:${marketId}`;

--- a/src/features/markets/ui/profile-visualize.ts
+++ b/src/features/markets/ui/profile-visualize.ts
@@ -1,0 +1,803 @@
+import { AttachmentBuilder } from 'discord.js';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  createCanvas,
+  GlobalFonts,
+  loadImage,
+  type SKRSContext2D,
+} from '@napi-rs/canvas';
+import {
+  area,
+  curveMonotoneX,
+  extent,
+  line,
+  max,
+  scaleBand,
+  scaleLinear,
+  scaleTime,
+} from 'd3';
+
+import type { MarketForecastProfileDetails } from '../core/types.js';
+import { formatBrier, formatMoney } from './render/shared.js';
+
+const width = 1320;
+const height = 1280;
+const background = '#15181d';
+const panel = '#1a1f27';
+const border = '#2b313a';
+const text = '#f4f7fb';
+const muted = '#a3adba';
+const quiet = '#66707d';
+const grid = '#2f3640';
+const gridStrong = '#404856';
+const green = '#5fd0a5';
+const blue = '#7cb7ff';
+const red = '#ff7d7d';
+const yellow = '#ffd166';
+const teal = '#74d3c3';
+const fontFamily = 'Public Sans';
+const fontStack = `'${fontFamily}', 'DejaVu Sans', 'Noto Sans', 'Liberation Sans', sans-serif`;
+const outerPadding = 40;
+
+type DiagramPayload = {
+  attachment: AttachmentBuilder;
+  fileName: string;
+};
+
+type LoadedImage = Awaited<ReturnType<typeof loadImage>>;
+
+type ProfileDiagramOptions = {
+  displayName?: string | null;
+  avatarUrl?: string | null;
+};
+
+const iconNames = {
+  brier: 'chart-histogram',
+  recent: 'clock',
+  rank: 'coins',
+  profit: 'wallet',
+} as const;
+
+const imageCache = new Map<string, Promise<LoadedImage | null>>();
+
+const compactDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+});
+
+const footerDateTimeFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+  timeZoneName: 'short',
+});
+
+let publicSansRegistered = false;
+
+const drawLabel = (
+  context: SKRSContext2D,
+  label: string,
+  x: number,
+  y: number,
+  options: {
+    font: string;
+    color: string;
+    align?: CanvasTextAlign;
+    baseline?: CanvasTextBaseline;
+  },
+): void => {
+  context.font = options.font;
+  context.fillStyle = options.color;
+  context.textAlign = options.align ?? 'left';
+  context.textBaseline = options.baseline ?? 'alphabetic';
+  context.fillText(label, x, y);
+};
+
+const truncateToWidth = (
+  context: SKRSContext2D,
+  label: string,
+  maxWidth: number,
+): string => {
+  if (context.measureText(label).width <= maxWidth) {
+    return label;
+  }
+
+  let value = label;
+  while (value.length > 1 && context.measureText(`${value}...`).width > maxWidth) {
+    value = value.slice(0, -1);
+  }
+
+  return `${value}...`;
+};
+
+const wrapText = (
+  context: SKRSContext2D,
+  label: string,
+  maxWidth: number,
+  maxLines: number,
+): string[] => {
+  const words = label.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) {
+    return [''];
+  }
+
+  const lines: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (context.measureText(next).width <= maxWidth) {
+      current = next;
+      continue;
+    }
+
+    if (current) {
+      lines.push(current);
+    }
+    current = word;
+
+    if (lines.length === maxLines - 1) {
+      break;
+    }
+  }
+
+  if (lines.length < maxLines) {
+    lines.push(current);
+  }
+
+  const consumedWordCount = lines.join(' ').trim().split(/\s+/).filter(Boolean).length;
+  if (consumedWordCount < words.length) {
+    const lastLine = lines[lines.length - 1] ?? '';
+    lines[lines.length - 1] = truncateToWidth(context, `${lastLine} ${words.slice(consumedWordCount).join(' ')}`.trim(), maxWidth);
+  }
+
+  return lines.slice(0, maxLines);
+};
+
+const resolvePublicSansPath = (
+  weight: 400 | 500 | 700,
+  moduleUrl: string = import.meta.url,
+): string | null => {
+  const relativePath = `files/public-sans-latin-${weight}-normal.woff2`;
+  const candidates = [
+    resolve(process.cwd(), 'node_modules', '@fontsource', 'public-sans', relativePath),
+    fileURLToPath(new URL(`../../../../node_modules/@fontsource/public-sans/${relativePath}`, moduleUrl)),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+};
+
+const ensurePublicSansLoaded = (): void => {
+  if (publicSansRegistered) {
+    return;
+  }
+
+  for (const weight of [400, 500, 700] as const) {
+    const path = resolvePublicSansPath(weight);
+    if (path) {
+      GlobalFonts.registerFromPath(path, fontFamily);
+    }
+  }
+
+  publicSansRegistered = true;
+};
+
+const resolveTablerIconPath = (
+  iconName: string,
+  moduleUrl: string = import.meta.url,
+): string | null => {
+  const relativePath = `icons/outline/${iconName}.svg`;
+  const candidates = [
+    resolve(process.cwd(), 'node_modules', '@tabler', 'icons', relativePath),
+    fileURLToPath(new URL(`../../../../node_modules/@tabler/icons/${relativePath}`, moduleUrl)),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+};
+
+const loadTablerIcon = async (
+  iconName: keyof typeof iconNames,
+  size: number,
+  tint: string,
+): Promise<LoadedImage | null> => {
+  const file = resolveTablerIconPath(iconNames[iconName]);
+  if (!file) {
+    return null;
+  }
+
+  const cacheKey = `${file}:${size}:${tint}`;
+  const cached = imageCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const pending = readFile(file, 'utf8')
+    .then((svg) => svg
+      .replace('<svg ', `<svg width="${size}" height="${size}" `)
+      .replaceAll('currentColor', tint))
+    .then((svg) => loadImage(Buffer.from(svg)));
+
+  imageCache.set(cacheKey, pending);
+  return pending;
+};
+
+const loadAvatarImage = async (
+  avatarUrl: string,
+): Promise<LoadedImage | null> => {
+  const cached = imageCache.get(avatarUrl);
+  if (cached) {
+    return cached;
+  }
+
+  const pending = fetch(avatarUrl)
+    .then(async (response) => {
+      if (!response.ok) {
+        return null;
+      }
+
+      const arrayBuffer = await response.arrayBuffer();
+      return loadImage(Buffer.from(arrayBuffer));
+    })
+    .catch(() => null);
+
+  imageCache.set(avatarUrl, pending);
+  return pending;
+};
+
+const drawPanel = (
+  context: SKRSContext2D,
+  x: number,
+  y: number,
+  panelWidth: number,
+  panelHeight: number,
+): void => {
+  context.fillStyle = panel;
+  context.fillRect(x, y, panelWidth, panelHeight);
+  context.strokeStyle = border;
+  context.lineWidth = 1;
+  context.strokeRect(x, y, panelWidth, panelHeight);
+};
+
+const drawAvatar = async (
+  context: SKRSContext2D,
+  x: number,
+  y: number,
+  size: number,
+  avatarUrl?: string | null,
+): Promise<void> => {
+  context.save();
+  context.beginPath();
+  context.arc(x + (size / 2), y + (size / 2), size / 2, 0, Math.PI * 2);
+  context.closePath();
+  context.clip();
+
+  const avatar = avatarUrl ? await loadAvatarImage(avatarUrl) : null;
+  if (avatar) {
+    context.drawImage(avatar, x, y, size, size);
+  } else {
+    context.fillStyle = '#243042';
+    context.fillRect(x, y, size, size);
+    drawLabel(context, '?', x + (size / 2), y + (size / 2) + 10, {
+      font: `700 40px ${fontStack}`,
+      color: text,
+      align: 'center',
+      baseline: 'middle',
+    });
+  }
+  context.restore();
+
+  context.strokeStyle = border;
+  context.lineWidth = 2;
+  context.beginPath();
+  context.arc(x + (size / 2), y + (size / 2), (size / 2) - 1, 0, Math.PI * 2);
+  context.stroke();
+};
+
+const drawMetricCard = async (
+  context: SKRSContext2D,
+  input: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    icon: keyof typeof iconNames;
+    title: string;
+    value: string;
+    accent: string;
+  },
+): Promise<void> => {
+  drawPanel(context, input.x, input.y, input.width, input.height);
+  const icon = await loadTablerIcon(input.icon, 18, input.accent);
+  if (icon) {
+    context.drawImage(icon, input.x + 18, input.y + 16, 18, 18);
+  }
+
+  drawLabel(context, input.title, input.x + 44, input.y + 29, {
+    font: `600 13px ${fontStack}`,
+    color: muted,
+    baseline: 'middle',
+  });
+  drawLabel(context, input.value, input.x + 18, input.y + 70, {
+    font: `700 32px ${fontStack}`,
+    color: input.accent,
+  });
+};
+
+const drawChartLegend = (
+  context: SKRSContext2D,
+  x: number,
+  y: number,
+): void => {
+  context.fillStyle = blue;
+  context.fillRect(x, y - 9, 18, 3);
+  drawLabel(context, 'Brier', x + 26, y, {
+    font: `13px ${fontStack}`,
+    color: muted,
+    baseline: 'middle',
+  });
+  context.fillStyle = 'rgba(95, 208, 165, 0.24)';
+  context.fillRect(x + 88, y - 9, 18, 10);
+  drawLabel(context, 'Cumulative Profit', x + 114, y, {
+    font: `13px ${fontStack}`,
+    color: muted,
+    baseline: 'middle',
+  });
+};
+
+const drawMainChart = (
+  context: SKRSContext2D,
+  bounds: { x: number; y: number; width: number; height: number },
+  profile: MarketForecastProfileDetails,
+): void => {
+  drawPanel(context, bounds.x, bounds.y, bounds.width, bounds.height);
+  drawLabel(context, 'Brier Over Time', bounds.x + 22, bounds.y + 30, {
+    font: `700 16px ${fontStack}`,
+    color: text,
+  });
+  drawChartLegend(context, bounds.x + bounds.width - 300, bounds.y + 30);
+
+  if (profile.brierTrend.length === 0) {
+    drawLabel(context, 'No scored markets yet', bounds.x + 22, bounds.y + 96, {
+      font: `15px ${fontStack}`,
+      color: muted,
+    });
+    return;
+  }
+
+  const chart = {
+    x: bounds.x + 64,
+    y: bounds.y + 68,
+    width: bounds.width - 96,
+    height: bounds.height - 114,
+  };
+  const [rawStartTime, rawEndTime] = extent(profile.brierTrend, (point) => point.time);
+  const startTime = rawStartTime ?? Date.now();
+  const endTime = Math.max(rawEndTime ?? (startTime + 1), startTime + 1);
+  const maxBrier = Math.max(0.2, (max(profile.brierTrend, (point) => point.brierScore) ?? 0.2) + 0.02);
+  const profitExtent = extent(profile.profitTrend, (point) => point.cumulativeProfit);
+  const profitLower = Math.min(0, profitExtent[0] ?? 0);
+  const profitUpper = Math.max(0, profitExtent[1] ?? 0);
+  const paddedProfitLower = profitLower - Math.max(10, Math.abs(profitLower) * 0.12);
+  const paddedProfitUpper = profitUpper + Math.max(10, Math.abs(profitUpper) * 0.12);
+
+  const xScale = scaleTime<number, number>()
+    .domain([new Date(startTime), new Date(endTime)])
+    .range([chart.x, chart.x + chart.width]);
+  const brierScale = scaleLinear()
+    .domain([0, maxBrier])
+    .range([chart.y + chart.height, chart.y]);
+  const profitScale = scaleLinear()
+    .domain([paddedProfitLower, paddedProfitUpper])
+    .range([chart.y + chart.height, chart.y]);
+
+  for (const tick of brierScale.ticks(5)) {
+    const y = brierScale(tick);
+    context.strokeStyle = tick === 0 ? gridStrong : grid;
+    context.beginPath();
+    context.moveTo(chart.x, y);
+    context.lineTo(chart.x + chart.width, y);
+    context.stroke();
+    drawLabel(context, tick.toFixed(2), chart.x - 14, y, {
+      font: `12px ${fontStack}`,
+      color: muted,
+      align: 'right',
+      baseline: 'middle',
+    });
+  }
+
+  const zeroY = profitScale(0);
+  context.strokeStyle = gridStrong;
+  context.beginPath();
+  context.moveTo(chart.x, zeroY);
+  context.lineTo(chart.x + chart.width, zeroY);
+  context.stroke();
+
+  const profitArea = area<(typeof profile.profitTrend)[number]>()
+    .x((point) => xScale(new Date(point.time)))
+    .y0(zeroY)
+    .y1((point) => profitScale(point.cumulativeProfit))
+    .curve(curveMonotoneX)
+    .context(context as never);
+  context.fillStyle = 'rgba(95, 208, 165, 0.24)';
+  context.beginPath();
+  profitArea(profile.profitTrend);
+  context.fill();
+
+  const brierLine = line<(typeof profile.brierTrend)[number]>()
+    .x((point) => xScale(new Date(point.time)))
+    .y((point) => brierScale(point.brierScore))
+    .curve(curveMonotoneX)
+    .context(context as never);
+  context.lineWidth = 3;
+  context.strokeStyle = blue;
+  context.beginPath();
+  brierLine(profile.brierTrend);
+  context.stroke();
+
+  for (const point of profile.brierTrend) {
+    const x = xScale(new Date(point.time));
+    const y = brierScale(point.brierScore);
+    context.fillStyle = blue;
+    context.beginPath();
+    context.arc(x, y, 4.5, 0, Math.PI * 2);
+    context.fill();
+  }
+
+  const xTicks = xScale.ticks(Math.min(6, Math.max(3, profile.brierTrend.length)));
+  xTicks.forEach((tick, index) => {
+    const x = xScale(tick);
+    drawLabel(context, compactDateFormatter.format(tick), x, chart.y + chart.height + 26, {
+      font: `12px ${fontStack}`,
+      color: muted,
+      align: index === 0 ? 'left' : index === xTicks.length - 1 ? 'right' : 'center',
+    });
+  });
+
+  const profitTickValues = [paddedProfitLower, 0, paddedProfitUpper];
+  profitTickValues.forEach((value) => {
+    if (Math.abs(value) < 0.001) {
+      return;
+    }
+    drawLabel(context, `${value > 0 ? '+' : ''}${Math.round(value)} pts`, chart.x + chart.width + 14, profitScale(value), {
+      font: `12px ${fontStack}`,
+      color: quiet,
+      baseline: 'middle',
+    });
+  });
+};
+
+const drawCalibrationPanel = (
+  context: SKRSContext2D,
+  profile: MarketForecastProfileDetails,
+  x: number,
+  y: number,
+  panelWidth: number,
+  panelHeight: number,
+): void => {
+  drawPanel(context, x, y, panelWidth, panelHeight);
+  drawLabel(context, 'Calibration', x + 20, y + 30, {
+    font: `700 16px ${fontStack}`,
+    color: text,
+  });
+
+  if (profile.calibrationBuckets.length === 0) {
+    drawLabel(context, 'No calibration buckets yet', x + 20, y + 70, {
+      font: `14px ${fontStack}`,
+      color: muted,
+    });
+    return;
+  }
+
+  const chart = {
+    x: x + 20,
+    y: y + 56,
+    width: panelWidth - 40,
+    height: panelHeight - 94,
+  };
+  const xScale = scaleBand<string>()
+    .domain(profile.calibrationBuckets.map((bucket) => bucket.label))
+    .range([chart.x, chart.x + chart.width])
+    .paddingInner(0.28)
+    .paddingOuter(0.06);
+  const yScale = scaleLinear()
+    .domain([0, 1])
+    .range([chart.y + chart.height, chart.y]);
+
+  for (const tick of [0, 0.5, 1]) {
+    const lineY = yScale(tick);
+    context.strokeStyle = tick === 0 ? gridStrong : grid;
+    context.beginPath();
+    context.moveTo(chart.x, lineY);
+    context.lineTo(chart.x + chart.width, lineY);
+    context.stroke();
+    drawLabel(context, `${Math.round(tick * 100)}%`, chart.x - 10, lineY, {
+      font: `11px ${fontStack}`,
+      color: quiet,
+      align: 'right',
+      baseline: 'middle',
+    });
+  }
+
+  profile.calibrationBuckets.forEach((bucket) => {
+    const bucketX = xScale(bucket.label);
+    if (bucketX === undefined) {
+      return;
+    }
+
+    const bandWidth = xScale.bandwidth();
+    const avgBarWidth = Math.max(10, (bandWidth / 2) - 4);
+    const actualBarWidth = Math.max(10, (bandWidth / 2) - 4);
+    const avgY = yScale(bucket.averageConfidence);
+    const actualY = yScale(bucket.actualRate);
+    const baseY = yScale(0);
+    context.fillStyle = 'rgba(124, 183, 255, 0.52)';
+    context.fillRect(bucketX, avgY, avgBarWidth, Math.max(2, baseY - avgY));
+    context.fillStyle = 'rgba(95, 208, 165, 0.72)';
+    context.fillRect(bucketX + bandWidth - actualBarWidth, actualY, actualBarWidth, Math.max(2, baseY - actualY));
+    drawLabel(context, bucket.label, bucketX + (bandWidth / 2), chart.y + chart.height + 18, {
+      font: `11px ${fontStack}`,
+      color: muted,
+      align: 'center',
+    });
+  });
+};
+
+const drawTopTagsPanel = (
+  context: SKRSContext2D,
+  profile: MarketForecastProfileDetails,
+  x: number,
+  y: number,
+  panelWidth: number,
+  panelHeight: number,
+): void => {
+  drawPanel(context, x, y, panelWidth, panelHeight);
+  drawLabel(context, 'Top Tags', x + 20, y + 30, {
+    font: `700 16px ${fontStack}`,
+    color: text,
+  });
+
+  if (profile.topTags.length === 0) {
+    drawLabel(context, 'Need at least 5 scored markets in a tag', x + 20, y + 70, {
+      font: `14px ${fontStack}`,
+      color: muted,
+    });
+    return;
+  }
+
+  const rowHeight = 42;
+  profile.topTags.slice(0, 3).forEach((tag, index) => {
+    const rowTop = y + 62 + (index * rowHeight);
+    const barX = x + 20;
+    const barWidth = panelWidth - 150;
+    context.fillStyle = grid;
+    context.fillRect(barX, rowTop + 18, barWidth, 10);
+    context.fillStyle = yellow;
+    context.fillRect(barX, rowTop + 18, Math.max(24, (1 - Math.min(1, tag.meanBrier)) * barWidth), 10);
+    drawLabel(context, truncateToWidth(context, tag.tag, 18), barX, rowTop + 12, {
+      font: `600 13px ${fontStack}`,
+      color: text,
+    });
+    drawLabel(context, `${formatBrier(tag.meanBrier)} • ${tag.sampleCount}`, x + panelWidth - 20, rowTop + 12, {
+      font: `12px ${fontStack}`,
+      color: muted,
+      align: 'right',
+    });
+  });
+};
+
+const drawRecentMarketsPanel = (
+  context: SKRSContext2D,
+  profile: MarketForecastProfileDetails,
+  x: number,
+  y: number,
+  panelWidth: number,
+  panelHeight: number,
+): void => {
+  drawPanel(context, x, y, panelWidth, panelHeight);
+  drawLabel(context, 'Recent Markets', x + 22, y + 32, {
+    font: `700 17px ${fontStack}`,
+    color: text,
+  });
+
+  if (profile.recentRecords.length === 0) {
+    drawLabel(context, 'No scored markets yet', x + 22, y + 76, {
+      font: `14px ${fontStack}`,
+      color: muted,
+    });
+    return;
+  }
+
+  const headerY = y + 74;
+  drawLabel(context, 'MARKET', x + 22, headerY, {
+    font: `700 11px ${fontStack}`,
+    color: quiet,
+  });
+  drawLabel(context, 'RESULT', x + panelWidth - 180, headerY, {
+    font: `700 11px ${fontStack}`,
+    color: quiet,
+    align: 'right',
+  });
+  drawLabel(context, 'DATE', x + panelWidth - 22, headerY, {
+    font: `700 11px ${fontStack}`,
+    color: quiet,
+    align: 'right',
+  });
+
+  const rowTop = headerY + 16;
+  const rowHeight = 58;
+  profile.recentRecords.slice(0, 5).forEach((record, index) => {
+    const top = rowTop + (index * rowHeight);
+    if (index > 0) {
+      context.strokeStyle = grid;
+      context.beginPath();
+      context.moveTo(x + 22, top - 14);
+      context.lineTo(x + panelWidth - 22, top - 14);
+      context.stroke();
+    }
+
+    const title = truncateToWidth(context, record.marketTitle, panelWidth - 330);
+    drawLabel(context, title, x + 22, top + 2, {
+      font: `600 16px ${fontStack}`,
+      color: text,
+    });
+    drawLabel(context, `Brier ${formatBrier(record.brierScore)} • ${record.tradeCount} trades • ${record.stakeWeight.toFixed(0)} pts staked`, x + 22, top + 28, {
+      font: `12px ${fontStack}`,
+      color: muted,
+    });
+    drawLabel(context, `${record.realizedProfit >= 0 ? '+' : ''}${formatMoney(record.realizedProfit)} • ${record.wasCorrect ? 'correct' : 'missed'}`, x + panelWidth - 180, top + 16, {
+      font: `600 13px ${fontStack}`,
+      color: record.wasCorrect ? green : red,
+      align: 'right',
+    });
+    drawLabel(context, compactDateFormatter.format(record.resolvedAt), x + panelWidth - 22, top + 16, {
+      font: `12px ${fontStack}`,
+      color: muted,
+      align: 'right',
+    });
+    const tagText = record.tags.length > 0 ? record.tags.map((tag) => `#${tag}`).join(' ') : 'No tags';
+    drawLabel(context, truncateToWidth(context, tagText, 40), x + panelWidth - 180, top + 40, {
+      font: `12px ${fontStack}`,
+      color: quiet,
+      align: 'right',
+    });
+  });
+};
+
+const buildCanvas = async (
+  profile: MarketForecastProfileDetails,
+  options?: ProfileDiagramOptions,
+): Promise<Buffer> => {
+  ensurePublicSansLoaded();
+  const canvas = createCanvas(width, height);
+  const context = canvas.getContext('2d');
+  const generatedAt = new Date();
+  const displayName = options?.displayName?.trim() || `User ${profile.userId}`;
+  const avatarSize = 88;
+
+  context.fillStyle = background;
+  context.fillRect(0, 0, width, height);
+  context.strokeStyle = border;
+  context.lineWidth = 1;
+  context.strokeRect(outerPadding / 2, outerPadding / 2, width - outerPadding, height - outerPadding);
+
+  const titleLines = wrapText(context, 'Market Forecast Profile', width - 320, 2);
+  titleLines.forEach((line, index) => {
+    drawLabel(context, line, outerPadding + 16, 74 + (index * 38), {
+      font: `700 38px ${fontStack}`,
+      color: text,
+    });
+  });
+  drawLabel(context, displayName, outerPadding + 16, 144, {
+    font: `600 20px ${fontStack}`,
+    color: muted,
+  });
+  drawLabel(context, `@${profile.userId}`, outerPadding + 16, 172, {
+    font: `14px ${fontStack}`,
+    color: quiet,
+  });
+
+  await drawAvatar(
+    context,
+    width - outerPadding - avatarSize - 12,
+    58,
+    avatarSize,
+    options?.avatarUrl,
+  );
+
+  const cardY = 214;
+  const cardGap = 20;
+  const cardWidth = 292;
+  const cardHeight = 126;
+  await Promise.all([
+    drawMetricCard(context, {
+      x: outerPadding + 16,
+      y: cardY,
+      width: cardWidth,
+      height: cardHeight,
+      icon: 'brier',
+      title: 'All-Time Brier',
+      value: formatBrier(profile.allTimeMeanBrier),
+      accent: blue,
+    }),
+    drawMetricCard(context, {
+      x: outerPadding + 16 + cardWidth + cardGap,
+      y: cardY,
+      width: cardWidth,
+      height: cardHeight,
+      icon: 'recent',
+      title: '30-Day Brier',
+      value: formatBrier(profile.thirtyDayMeanBrier),
+      accent: yellow,
+    }),
+    drawMetricCard(context, {
+      x: outerPadding + 16 + ((cardWidth + cardGap) * 2),
+      y: cardY,
+      width: cardWidth,
+      height: cardHeight,
+      icon: 'rank',
+      title: 'Percentile Rank',
+      value: profile.rank === null ? 'Unranked' : `${profile.percentileRank}%`,
+      accent: green,
+    }),
+    drawMetricCard(context, {
+      x: outerPadding + 16 + ((cardWidth + cardGap) * 3),
+      y: cardY,
+      width: cardWidth,
+      height: cardHeight,
+      icon: 'profit',
+      title: 'Streaks',
+      value: `${profile.currentCorrectPickStreak}/${profile.bestCorrectPickStreak}`,
+      accent: profile.currentProfitableMarketStreak > 0 ? teal : text,
+    }),
+  ]);
+
+  drawMainChart(context, {
+    x: outerPadding + 16,
+    y: 370,
+    width: 820,
+    height: 332,
+  }, profile);
+  drawCalibrationPanel(context, profile, 892, 370, 372, 250);
+  drawTopTagsPanel(context, profile, 892, 644, 372, 140);
+  drawRecentMarketsPanel(context, profile, outerPadding + 16, 734, 1208, 474);
+
+  drawLabel(context, `Generated ${footerDateTimeFormatter.format(generatedAt)}`, width - outerPadding - 16, height - 24, {
+    font: `13px ${fontStack}`,
+    color: quiet,
+    align: 'right',
+    baseline: 'bottom',
+  });
+
+  return canvas.encode('png');
+};
+
+export const buildMarketForecastProfileDiagram = async (
+  profile: MarketForecastProfileDetails,
+  options?: ProfileDiagramOptions,
+): Promise<DiagramPayload> => {
+  const fileName = `market-profile-${profile.userId}.png`;
+  const buffer = await buildCanvas(profile, options);
+
+  return {
+    fileName,
+    attachment: new AttachmentBuilder(buffer, {
+      name: fileName,
+    }),
+  };
+};

--- a/src/features/markets/ui/render/analytics.ts
+++ b/src/features/markets/ui/render/analytics.ts
@@ -2,6 +2,7 @@ import { EmbedBuilder } from 'discord.js';
 
 import type {
   MarketForecastLeaderboardEntry,
+  MarketForecastProfileDetails,
   MarketForecastProfile,
   MarketTraderSummary,
   MarketWithRelations,
@@ -118,6 +119,46 @@ export const buildMarketForecastProfileEmbed = (
         : `Calibration: ${profile.calibrationBuckets.map((bucket) =>
           `${bucket.label} ${formatPercent(bucket.averageConfidence)} -> ${formatPercent(bucket.actualRate)} (${bucket.sampleCount})`).join(' | ')}`,
     ].join('\n'));
+
+export const buildMarketForecastProfileEmbeds = (
+  profile: MarketForecastProfileDetails,
+): EmbedBuilder[] => {
+  const summary = buildMarketForecastProfileEmbed(profile)
+    .setDescription([
+      `User: <@${profile.userId}>`,
+      `All-Time Brier: **${formatBrier(profile.allTimeMeanBrier)}** across **${profile.allTimeSampleCount}** markets`,
+      `30-Day Brier: **${formatBrier(profile.thirtyDayMeanBrier)}** across **${profile.thirtyDaySampleCount}** markets`,
+      profile.rank === null
+        ? 'Percentile Rank: Need at least 5 scored markets to rank'
+        : `Percentile Rank: **${profile.percentileRank}%** (#${profile.rank} of ${profile.rankedUserCount})`,
+      `Correct-Pick Streak: **${profile.currentCorrectPickStreak}** current, **${profile.bestCorrectPickStreak}** best`,
+      `Profitable-Market Streak: **${profile.currentProfitableMarketStreak}** current, **${profile.bestProfitableMarketStreak}** best`,
+    ].join('\n'));
+
+  const detail = new EmbedBuilder()
+    .setTitle('Forecast Profile Details')
+    .setColor(0x60a5fa)
+    .setDescription([
+      profile.topTags.length === 0
+        ? 'Top Tags: Need at least 5 scored markets in a tag'
+        : `Top Tags: ${profile.topTags.map((tag) =>
+          `\`${tag.tag}\` (${formatBrier(tag.meanBrier)} over ${tag.sampleCount})`).join(' • ')}`,
+      profile.calibrationBuckets.length === 0
+        ? 'Calibration: No forecast record buckets yet'
+        : `Calibration: ${profile.calibrationBuckets.map((bucket) =>
+          `${bucket.label} ${formatPercent(bucket.averageConfidence)} -> ${formatPercent(bucket.actualRate)} (${bucket.sampleCount})`).join(' | ')}`,
+      '',
+      profile.recentRecords.length === 0
+        ? 'Recent Markets: No scored forecast records yet'
+        : [
+            'Recent Markets:',
+            ...profile.recentRecords.map((record) =>
+              `• **${record.marketTitle}** — Brier ${formatBrier(record.brierScore)} • ${record.realizedProfit >= 0 ? '+' : ''}${formatMoney(record.realizedProfit)} • ${record.wasCorrect ? 'correct' : 'missed'}`),
+          ].join('\n'),
+    ].join('\n'));
+
+  return [summary, detail];
+};
 
 export const buildMarketForecastLeaderboardEmbed = (
   entries: MarketForecastLeaderboardEntry[],

--- a/src/features/markets/ui/render/market.ts
+++ b/src/features/markets/ui/render/market.ts
@@ -1,260 +1,300 @@
 import {
-  ActionRowBuilder,
-  ButtonBuilder,
-  ButtonStyle,
-  EmbedBuilder,
-} from 'discord.js';
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	EmbedBuilder,
+} from "discord.js";
 
-import { buildFeedbackEmbed } from '../../../../lib/feedback-embeds.js';
+import { buildFeedbackEmbed } from "../../../../lib/feedback-embeds.js";
 import {
-  marketCancelButtonCustomId,
-  marketDetailsButtonCustomId,
-  marketOutcomeButtonCustomId,
-  marketPortfolioButtonCustomId,
-  marketProtectButtonCustomId,
-  marketRefreshButtonCustomId,
-  marketResolveButtonCustomId,
-} from '../custom-ids.js';
-import { formatProbabilityPercent } from '../../core/math.js';
-import { getTradeLockReason } from '../../core/shared.js';
-import type { MarketWithRelations } from '../../core/types.js';
+	marketCancelButtonCustomId,
+	marketDetailsButtonCustomId,
+	marketManageButtonCustomId,
+	marketRefreshButtonCustomId,
+	marketResolveButtonCustomId,
+	marketTradeButtonCustomId,
+} from "../custom-ids.js";
+import { formatProbabilityPercent } from "../../core/math.js";
+import type { MarketWithRelations } from "../../core/types.js";
 import {
-  getMarketSummary,
-  getOutcomeButtonStyle,
-  getStatusColor,
-  truncateLabel,
-} from './shared.js';
+	getMarketSummary,
+	getOutcomeButtonStyle,
+	getStatusColor,
+} from "./shared.js";
 
-const buildMarketSynopsis = (market: MarketWithRelations, status: string): string => {
-  const closesCopy = status === 'open' ? 'closes' : 'closed';
-  const parts = [
-    `${/^[aeiou]/i.test(status) ? 'An' : 'A'} ${status} market created by <@${market.creatorId}> that ${closesCopy} <t:${Math.floor(market.closeAt.getTime() / 1000)}:R>.`,
-  ];
+const buildMarketSynopsis = (
+	market: MarketWithRelations,
+	status: string,
+): string => {
+	const closesCopy = status === "open" ? "closes" : "closed";
+	const parts = [
+		`${/^[aeiou]/i.test(status) ? "An" : "A"} ${status} market created by <@${market.creatorId}> that ${closesCopy} <t:${Math.floor(market.closeAt.getTime() / 1000)}:R>.`,
+	];
 
-  if (market.threadId) {
-    parts.push(`Discuss in forum post <#${market.threadId}>.`);
-  }
+	if (market.threadId) {
+		parts.push(`Discuss in forum post <#${market.threadId}>.`);
+	}
 
-  return parts.join(' ');
+	return parts.join(" ");
 };
 
 const appendButtonToRows = (
-  rows: ActionRowBuilder<ButtonBuilder>[],
-  button: ButtonBuilder,
+	rows: ActionRowBuilder<ButtonBuilder>[],
+	button: ButtonBuilder,
 ): void => {
-  const lastRow = rows[rows.length - 1];
-  if (!lastRow || lastRow.components.length >= 5) {
-    rows.push(new ActionRowBuilder<ButtonBuilder>().addComponents(button));
-    return;
-  }
+	const lastRow = rows[rows.length - 1];
+	if (!lastRow || lastRow.components.length >= 5) {
+		rows.push(new ActionRowBuilder<ButtonBuilder>().addComponents(button));
+		return;
+	}
 
-  lastRow.addComponents(button);
+	lastRow.addComponents(button);
 };
 
-const buildDetailsFields = (market: MarketWithRelations): Array<{ name: string; value: string }> => {
-  const summary = getMarketSummary(market);
-  const status = summary.status;
-  const timing = [
-    `Created: <t:${Math.floor(market.createdAt.getTime() / 1000)}:F>`,
-    `Closes: <t:${Math.floor(market.closeAt.getTime() / 1000)}:F>`,
-    market.tradingClosedAt ? `Trading Closed: <t:${Math.floor(market.tradingClosedAt.getTime() / 1000)}:F>` : null,
-    market.resolutionGraceEndsAt ? `Grace Ends: <t:${Math.floor(market.resolutionGraceEndsAt.getTime() / 1000)}:F>` : null,
-    market.resolvedAt ? `Resolved: <t:${Math.floor(market.resolvedAt.getTime() / 1000)}:F>` : null,
-    market.cancelledAt ? `Cancelled: <t:${Math.floor(market.cancelledAt.getTime() / 1000)}:F>` : null,
-    `Updated: <t:${Math.floor(market.updatedAt.getTime() / 1000)}:F>`,
-  ].filter(Boolean).join('\n');
+const buildDetailsFields = (
+	market: MarketWithRelations,
+): Array<{ name: string; value: string }> => {
+	const summary = getMarketSummary(market);
+	const status = summary.status;
+	const timing = [
+		`Created: <t:${Math.floor(market.createdAt.getTime() / 1000)}:F>`,
+		`Closes: <t:${Math.floor(market.closeAt.getTime() / 1000)}:F>`,
+		market.tradingClosedAt
+			? `Trading Closed: <t:${Math.floor(market.tradingClosedAt.getTime() / 1000)}:F>`
+			: null,
+		market.resolutionGraceEndsAt
+			? `Grace Ends: <t:${Math.floor(market.resolutionGraceEndsAt.getTime() / 1000)}:F>`
+			: null,
+		market.resolvedAt
+			? `Resolved: <t:${Math.floor(market.resolvedAt.getTime() / 1000)}:F>`
+			: null,
+		market.cancelledAt
+			? `Cancelled: <t:${Math.floor(market.cancelledAt.getTime() / 1000)}:F>`
+			: null,
+		`Updated: <t:${Math.floor(market.updatedAt.getTime() / 1000)}:F>`,
+	]
+		.filter(Boolean)
+		.join("\n");
 
-  const liquidity = [
-    `Current: **${market.liquidityParameter}**`,
-    `Base: **${market.baseLiquidityParameter}**`,
-    `Max: **${market.maxLiquidityParameter}**`,
-    `Bonus Pool: **${market.supplementaryBonusPool.toFixed(2)} pts**`,
-    market.supplementaryBonusDistributedAt ? `Bonus Distributed: <t:${Math.floor(market.supplementaryBonusDistributedAt.getTime() / 1000)}:F>` : null,
-    market.supplementaryBonusExpiredAt ? `Bonus Expired: <t:${Math.floor(market.supplementaryBonusExpiredAt.getTime() / 1000)}:F>` : null,
-  ].filter(Boolean).join('\n');
+	const liquidity = [
+		`Current: **${market.liquidityParameter}**`,
+		`Base: **${market.baseLiquidityParameter}**`,
+		`Max: **${market.maxLiquidityParameter}**`,
+		`Bonus Pool: **${market.supplementaryBonusPool.toFixed(2)} pts**`,
+		market.supplementaryBonusDistributedAt
+			? `Bonus Distributed: <t:${Math.floor(market.supplementaryBonusDistributedAt.getTime() / 1000)}:F>`
+			: null,
+		market.supplementaryBonusExpiredAt
+			? `Bonus Expired: <t:${Math.floor(market.supplementaryBonusExpiredAt.getTime() / 1000)}:F>`
+			: null,
+	]
+		.filter(Boolean)
+		.join("\n");
 
-  const ids = [
-    `Market ID: \`${market.id}\``,
-    `Forum Post Message ID: ${market.messageId ? `\`${market.messageId}\`` : 'Not attached yet'}`,
-    `Forum Post Thread ID: ${market.threadId ? `\`${market.threadId}\`` : 'No forum post yet'}`,
-    `Creator: <@${market.creatorId}>`,
-    `Button Style: **${market.buttonStyle}**`,
-    `Volume: **${summary.totalVolume} pts**`,
-    `Tags: ${market.tags.length > 0 ? market.tags.map((tag) => `\`${tag}\``).join(' ') : 'None'}`,
-  ].join('\n');
+	const ids = [
+		`Market ID: \`${market.id}\``,
+		`Forum Post Message ID: ${market.messageId ? `\`${market.messageId}\`` : "Not attached yet"}`,
+		`Forum Post Thread ID: ${market.threadId ? `\`${market.threadId}\`` : "No forum post yet"}`,
+		`Creator: <@${market.creatorId}>`,
+		`Button Style: **${market.buttonStyle}**`,
+		`Volume: **${summary.totalVolume} pts**`,
+		`Tags: ${market.tags.length > 0 ? market.tags.map((tag) => `\`${tag}\``).join(" ") : "None"}`,
+	].join("\n");
 
-  const resolution = [
-    market.winningOutcomeId ? `Winning Outcome: **${market.outcomes.find((outcome) => outcome.id === market.winningOutcomeId)?.label ?? market.winningOutcomeId}**` : null,
-    market.resolvedByUserId ? `Resolved By: <@${market.resolvedByUserId}>` : null,
-    market.resolutionNote ? `Resolution Note: ${market.resolutionNote}` : null,
-    market.resolutionEvidenceUrl ? `Evidence: ${market.resolutionEvidenceUrl}` : null,
-  ].filter(Boolean).join('\n') || 'No resolution details yet.';
+	const resolution =
+		[
+			market.winningOutcomeId
+				? `Winning Outcome: **${market.outcomes.find((outcome) => outcome.id === market.winningOutcomeId)?.label ?? market.winningOutcomeId}**`
+				: null,
+			market.resolvedByUserId
+				? `Resolved By: <@${market.resolvedByUserId}>`
+				: null,
+			market.resolutionNote
+				? `Resolution Note: ${market.resolutionNote}`
+				: null,
+			market.resolutionEvidenceUrl
+				? `Evidence: ${market.resolutionEvidenceUrl}`
+				: null,
+		]
+			.filter(Boolean)
+			.join("\n") || "No resolution details yet.";
 
-  return [
-    {
-      name: 'Market',
-      value: [
-        `Status: **${status}**`,
-        `Creator: <@${market.creatorId}>`,
-        market.threadId ? `Forum Post: <#${market.threadId}>` : 'Forum Post: none',
-      ].join('\n'),
-    },
-    { name: 'Timing', value: timing },
-    { name: 'Liquidity & Incentives', value: liquidity },
-    { name: 'Current Probabilities', value: summary.probabilities
-      .map((entry, index) => `${index + 1}. **${entry.label}** — ${entry.isResolved
-        ? entry.settlementValue === 1
-          ? 'Winner'
-          : 'Eliminated'
-        : formatProbabilityPercent(entry.probability)} (${entry.shares.toFixed(2)} net shares)`)
-      .join('\n') },
-    { name: 'Resolution', value: resolution },
-    { name: 'IDs & Metadata', value: ids },
-  ];
+	return [
+		{
+			name: "Market",
+			value: [
+				`Status: **${status}**`,
+				`Creator: <@${market.creatorId}>`,
+				market.threadId
+					? `Forum Post: <#${market.threadId}>`
+					: "Forum Post: none",
+			].join("\n"),
+		},
+		{ name: "Timing", value: timing },
+		{ name: "Liquidity & Incentives", value: liquidity },
+		{
+			name: "Current Probabilities",
+			value: summary.probabilities
+				.map(
+					(entry, index) =>
+						`${index + 1}. **${entry.label}** — ${
+							entry.isResolved
+								? entry.settlementValue === 1
+									? "Winner"
+									: "Eliminated"
+								: formatProbabilityPercent(entry.probability)
+						} (${entry.shares.toFixed(2)} net shares)`,
+				)
+				.join("\n"),
+		},
+		{ name: "Resolution", value: resolution },
+		{ name: "IDs & Metadata", value: ids },
+	];
 };
 
-export const buildMarketStatusEmbed = (title: string, description: string, color = 0x60a5fa): EmbedBuilder =>
-  buildFeedbackEmbed(title, description, color);
+export const buildMarketStatusEmbed = (
+	title: string,
+	description: string,
+	color = 0x60a5fa,
+): EmbedBuilder => buildFeedbackEmbed(title, description, color);
 
 export const buildMarketEmbed = (market: MarketWithRelations): EmbedBuilder => {
-  const summary = getMarketSummary(market);
-  const status = summary.status;
-  const unresolvedCount = summary.probabilities.filter((entry) => !entry.isResolved).length;
-  const embed = new EmbedBuilder()
-    .setTitle(market.title)
-    .setColor(getStatusColor(market))
-    .addFields(
-      {
-        name: 'Market',
-        value: buildMarketSynopsis(market, status),
-      },
-      {
-        name: 'Current Probabilities',
-        value: summary.probabilities
-          .map((entry, index) => `${index + 1}. **${entry.label}** — ${entry.isResolved
-            ? entry.settlementValue === 1
-              ? 'Winner'
-              : 'Eliminated'
-            : formatProbabilityPercent(entry.probability)} (${entry.shares.toFixed(2)} net shares)`)
-          .join('\n'),
-      },
-      ...(unresolvedCount < market.outcomes.length
-        ? [{
-            name: 'Live Board',
-            value: unresolvedCount === 0
-              ? 'No unresolved outcomes remain.'
-              : `${unresolvedCount} outcome${unresolvedCount === 1 ? '' : 's'} still trading.`,
-          }]
-        : []),
-    )
-    .setFooter({
-      text: `Market ID: ${market.id} • Volume: ${summary.totalVolume} pts`,
-    });
+	const summary = getMarketSummary(market);
+	const status = summary.status;
+	const unresolvedCount = summary.probabilities.filter(
+		(entry) => !entry.isResolved,
+	).length;
+	const embed = new EmbedBuilder()
+		.setTitle(market.title)
+		.setColor(getStatusColor(market))
+		.addFields(
+			{
+				name: "Market",
+				value: buildMarketSynopsis(market, status),
+			},
+			{
+				name: "Current Probabilities",
+				value: summary.probabilities
+					.map(
+						(entry, index) =>
+							`${index + 1}. **${entry.label}** — ${
+								entry.isResolved
+									? entry.settlementValue === 1
+										? "Winner"
+										: "Eliminated"
+									: formatProbabilityPercent(entry.probability)
+							} (${entry.shares.toFixed(2)} net shares)`,
+					)
+					.join("\n"),
+			},
+			...(unresolvedCount < market.outcomes.length
+				? [
+						{
+							name: "Live Board",
+							value:
+								unresolvedCount === 0
+									? "No unresolved outcomes remain."
+									: `${unresolvedCount} outcome${unresolvedCount === 1 ? "" : "s"} still trading.`,
+						},
+					]
+				: []),
+		)
+		.setFooter({
+			text: `Market ID: ${market.id} • Volume: ${summary.totalVolume} pts`,
+		});
 
-  if (market.description) {
-    embed.setDescription(market.description);
-  }
+	if (market.description) {
+		embed.setDescription(market.description);
+	}
 
-  return embed;
+	return embed;
 };
 
-export const buildMarketDetailsEmbed = (market: MarketWithRelations): EmbedBuilder => {
-  const embed = new EmbedBuilder()
-    .setTitle(market.title)
-    .setColor(getStatusColor(market))
-    .addFields(...buildDetailsFields(market));
+export const buildMarketDetailsEmbed = (
+	market: MarketWithRelations,
+): EmbedBuilder => {
+	const embed = new EmbedBuilder()
+		.setTitle(market.title)
+		.setColor(getStatusColor(market))
+		.addFields(...buildDetailsFields(market));
 
-  if (market.description) {
-    embed.setDescription(market.description);
-  }
+	if (market.description) {
+		embed.setDescription(market.description);
+	}
 
-  return embed;
+	return embed;
 };
 
 export const buildMarketMessage = (
-  market: MarketWithRelations,
+	market: MarketWithRelations,
 ): {
-  embeds: [EmbedBuilder];
-  components: ActionRowBuilder<ButtonBuilder>[];
+	embeds: [EmbedBuilder];
+	components: ActionRowBuilder<ButtonBuilder>[];
 } => {
-  const status = getMarketSummary(market).status;
-  const tradingClosed = status !== 'open';
-  const summary = getMarketSummary(market);
-  const tradeRows: ActionRowBuilder<ButtonBuilder>[] = [];
-  const tradableEntries = summary.probabilities.filter((entry) => !entry.isResolved);
+	const status = getMarketSummary(market).status;
+	const tradingClosed = status !== "open";
+	const tradeRows: ActionRowBuilder<ButtonBuilder>[] = [];
 
-  if (!tradingClosed) {
-    for (const entry of tradableEntries) {
-      const buyLocked = Boolean(getTradeLockReason(market, entry.outcomeId, 'buy'));
-      const shortLocked = Boolean(getTradeLockReason(market, entry.outcomeId, 'short'));
-      appendButtonToRows(
-        tradeRows,
-        new ButtonBuilder()
-          .setCustomId(marketOutcomeButtonCustomId(market.id, entry.outcomeId))
-          .setLabel(truncateLabel(entry.label, 40))
-          .setDisabled(buyLocked && shortLocked)
-          .setStyle(getOutcomeButtonStyle(market)),
-      );
-    }
-  }
+	appendButtonToRows(
+		tradeRows,
+		new ButtonBuilder()
+			.setCustomId(marketTradeButtonCustomId(market.id))
+			.setLabel("Trade")
+			.setDisabled(tradingClosed)
+			.setStyle(getOutcomeButtonStyle(market)),
+	);
+	appendButtonToRows(
+		tradeRows,
+		new ButtonBuilder()
+			.setCustomId(marketManageButtonCustomId(market.id))
+			.setLabel("Manage Position")
+			.setStyle(ButtonStyle.Secondary)
+			.setDisabled(tradingClosed),
+	);
+	appendButtonToRows(
+		tradeRows,
+		new ButtonBuilder()
+			.setCustomId(marketDetailsButtonCustomId(market.id))
+			.setLabel("Details")
+			.setStyle(ButtonStyle.Secondary),
+	);
+	appendButtonToRows(
+		tradeRows,
+		new ButtonBuilder()
+			.setCustomId(marketRefreshButtonCustomId(market.id))
+			.setLabel("Refresh")
+			.setStyle(ButtonStyle.Secondary),
+	);
 
-  appendButtonToRows(
-    tradeRows,
-    new ButtonBuilder()
-      .setCustomId(marketPortfolioButtonCustomId(market.id))
-      .setLabel('My Positions')
-      .setStyle(ButtonStyle.Secondary),
-  );
-  appendButtonToRows(
-    tradeRows,
-    new ButtonBuilder()
-      .setCustomId(marketProtectButtonCustomId(market.id))
-      .setLabel('Protect')
-      .setStyle(ButtonStyle.Secondary)
-      .setDisabled(tradingClosed),
-  );
-  appendButtonToRows(
-    tradeRows,
-    new ButtonBuilder()
-      .setCustomId(marketDetailsButtonCustomId(market.id))
-      .setLabel('Details')
-      .setStyle(ButtonStyle.Secondary),
-  );
-  appendButtonToRows(
-    tradeRows,
-    new ButtonBuilder()
-      .setCustomId(marketRefreshButtonCustomId(market.id))
-      .setLabel('Refresh')
-      .setStyle(ButtonStyle.Secondary),
-  );
-
-  return {
-    embeds: [buildMarketEmbed(market)],
-    components: tradeRows,
-  };
+	return {
+		embeds: [buildMarketEmbed(market)],
+		components: tradeRows,
+	};
 };
 
-export const buildMarketResolvePrompt = (market: MarketWithRelations): {
-  embeds: [EmbedBuilder];
-  components: [ActionRowBuilder<ButtonBuilder>];
+export const buildMarketResolvePrompt = (
+	market: MarketWithRelations,
+): {
+	embeds: [EmbedBuilder];
+	components: [ActionRowBuilder<ButtonBuilder>];
 } => ({
-  embeds: [
-    buildMarketStatusEmbed(
-      'Market Ready To Resolve',
-      `Trading on **${market.title}** is closed. Choose **Resolve** to pick a winner or **Cancel** to refund positions.`,
-      0x60a5fa,
-    ),
-  ],
-  components: [
-    new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId(marketResolveButtonCustomId(market.id))
-        .setLabel('Resolve')
-        .setStyle(ButtonStyle.Success),
-      new ButtonBuilder()
-        .setCustomId(marketCancelButtonCustomId(market.id))
-        .setLabel('Cancel')
-        .setStyle(ButtonStyle.Danger),
-    ),
-  ],
+	embeds: [
+		buildMarketStatusEmbed(
+			"Market Ready To Resolve",
+			`Trading on **${market.title}** is closed. Choose **Resolve** to pick a winner or **Cancel** to refund positions.`,
+			0x60a5fa,
+		),
+	],
+	components: [
+		new ActionRowBuilder<ButtonBuilder>().addComponents(
+			new ButtonBuilder()
+				.setCustomId(marketResolveButtonCustomId(market.id))
+				.setLabel("Resolve")
+				.setStyle(ButtonStyle.Success),
+			new ButtonBuilder()
+				.setCustomId(marketCancelButtonCustomId(market.id))
+				.setLabel("Cancel")
+				.setStyle(ButtonStyle.Danger),
+		),
+	],
 });

--- a/src/features/markets/ui/render/trades.ts
+++ b/src/features/markets/ui/render/trades.ts
@@ -1,387 +1,880 @@
 import {
-  ActionRowBuilder,
-  ButtonBuilder,
-  ButtonStyle,
-  ModalBuilder,
-  StringSelectMenuBuilder,
-  TextInputBuilder,
-  TextInputStyle,
-  type EmbedBuilder,
-} from 'discord.js';
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	ModalBuilder,
+	StringSelectMenuBuilder,
+	TextInputBuilder,
+	TextInputStyle,
+	type EmbedBuilder,
+} from "discord.js";
 
 import {
-  marketCancelModalCustomId,
-  marketProtectionCoverageButtonCustomId,
-  marketProtectionSelectCustomId,
-  marketQuickTradeButtonCustomId,
-  marketResolveModalCustomId,
-  marketTradeModalCustomId,
-  marketTradeQuoteCancelCustomId,
-  marketTradeQuoteConfirmCustomId,
-  marketTradeSelectCustomId,
-} from '../custom-ids.js';
-import { formatProbabilityPercent } from '../../core/math.js';
-import { getTradeLockReason } from '../../core/shared.js';
+	marketCancelModalCustomId,
+	marketSessionActionButtonCustomId,
+	marketSessionAmountButtonCustomId,
+	marketSessionAmountModalCustomId,
+	marketSessionCancelButtonCustomId,
+	marketSessionConfirmButtonCustomId,
+	marketSessionCoverageButtonCustomId,
+	marketSessionOutcomeSelectCustomId,
+	marketSessionPositionSelectCustomId,
+	marketSessionQuickAmountButtonCustomId,
+	marketSessionSideButtonCustomId,
+	marketProtectionCoverageButtonCustomId,
+	marketProtectionSelectCustomId,
+	marketQuickTradeButtonCustomId,
+	marketResolveModalCustomId,
+	marketTradeModalCustomId,
+	marketTradeQuoteCancelCustomId,
+	marketTradeQuoteConfirmCustomId,
+	marketTradeSelectCustomId,
+} from "../custom-ids.js";
+import { formatProbabilityPercent } from "../../core/math.js";
+import { getTradeLockReason } from "../../core/shared.js";
 import type {
-  MarketLossProtectionQuote,
-  MarketTradeQuote,
-  MarketWithRelations,
-} from '../../core/types.js';
-import { buildMarketStatusEmbed } from './market.js';
+	MarketInteractionSession,
+	MarketLossProtectionQuote,
+	MarketTradeQuote,
+	MarketWithRelations,
+} from "../../core/types.js";
+import { buildMarketStatusEmbed } from "./market.js";
 import {
-  formatMoney,
-  formatPercent,
-  getMarketSummary,
-  getTradeCopy,
-  truncateLabel,
-} from './shared.js';
+	formatMoney,
+	formatPercent,
+	getMarketSummary,
+	getTradeCopy,
+	truncateLabel,
+} from "./shared.js";
 
 export const buildMarketTradeSelector = (
-  market: MarketWithRelations,
-  action: 'buy' | 'sell' | 'short' | 'cover',
+	market: MarketWithRelations,
+	action: "buy" | "sell" | "short" | "cover",
 ): {
-  embeds: [EmbedBuilder];
-  components: ActionRowBuilder<StringSelectMenuBuilder>[];
+	embeds: [EmbedBuilder];
+	components: ActionRowBuilder<StringSelectMenuBuilder>[];
 } => {
-  const copy = getTradeCopy(action);
-  const tradableEntries = getMarketSummary(market).probabilities.filter((entry) =>
-    !entry.isResolved && !getTradeLockReason(market, entry.outcomeId, action));
+	const copy = getTradeCopy(action);
+	const tradableEntries = getMarketSummary(market).probabilities.filter(
+		(entry) =>
+			!entry.isResolved && !getTradeLockReason(market, entry.outcomeId, action),
+	);
 
-  if (tradableEntries.length === 0) {
-    return {
-      embeds: [
-        buildMarketStatusEmbed(copy.title, 'No unresolved outcomes are available for that action right now.', copy.color),
-      ],
-      components: [],
-    };
-  }
+	if (tradableEntries.length === 0) {
+		return {
+			embeds: [
+				buildMarketStatusEmbed(
+					copy.title,
+					"No unresolved outcomes are available for that action right now.",
+					copy.color,
+				),
+			],
+			components: [],
+		};
+	}
 
-  return {
-    embeds: [
-      buildMarketStatusEmbed(copy.title, copy.description, copy.color),
-    ],
-    components: [
-      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
-        new StringSelectMenuBuilder()
-          .setCustomId(marketTradeSelectCustomId(action, market.id))
-          .setPlaceholder(`Select an outcome to ${action}`)
-          .setMinValues(1)
-          .setMaxValues(1)
-          .addOptions(
-            tradableEntries.map((entry, index) => ({
-              label: `${index + 1}. ${entry.label}`,
-              value: entry.outcomeId,
-              description: `Net shares: ${entry.shares.toFixed(2)}`,
-            })),
-          ),
-      ),
-    ],
-  };
+	return {
+		embeds: [buildMarketStatusEmbed(copy.title, copy.description, copy.color)],
+		components: [
+			new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+				new StringSelectMenuBuilder()
+					.setCustomId(marketTradeSelectCustomId(action, market.id))
+					.setPlaceholder(`Select an outcome to ${action}`)
+					.setMinValues(1)
+					.setMaxValues(1)
+					.addOptions(
+						tradableEntries.map((entry, index) => ({
+							label: `${index + 1}. ${entry.label}`,
+							value: entry.outcomeId,
+							description: `Net shares: ${entry.shares.toFixed(2)}`,
+						})),
+					),
+			),
+		],
+	};
 };
 
 export const buildMarketOutcomeTradePrompt = (
-  market: MarketWithRelations,
-  outcomeId: string,
+	market: MarketWithRelations,
+	outcomeId: string,
 ): {
-  embeds: [EmbedBuilder];
-  components: ActionRowBuilder<ButtonBuilder>[];
+	embeds: [EmbedBuilder];
+	components: ActionRowBuilder<ButtonBuilder>[];
 } => {
-  const entry = getMarketSummary(market).probabilities.find((probability) => probability.outcomeId === outcomeId);
-  if (!entry || entry.isResolved) {
-    return {
-      embeds: [
-        buildMarketStatusEmbed('Trading Unavailable', 'That outcome is not available for trading right now.', 0xef4444),
-      ],
-      components: [],
-    };
-  }
+	const entry = getMarketSummary(market).probabilities.find(
+		(probability) => probability.outcomeId === outcomeId,
+	);
+	if (!entry || entry.isResolved) {
+		return {
+			embeds: [
+				buildMarketStatusEmbed(
+					"Trading Unavailable",
+					"That outcome is not available for trading right now.",
+					0xef4444,
+				),
+			],
+			components: [],
+		};
+	}
 
-  const buyLocked = Boolean(getTradeLockReason(market, outcomeId, 'buy'));
-  const shortLocked = Boolean(getTradeLockReason(market, outcomeId, 'short'));
+	const buyLocked = Boolean(getTradeLockReason(market, outcomeId, "buy"));
+	const shortLocked = Boolean(getTradeLockReason(market, outcomeId, "short"));
 
-  return {
-    embeds: [
-      buildMarketStatusEmbed(
-        `Trade ${entry.label}`,
-        [
-          `Current probability: **${formatProbabilityPercent(entry.probability)}**`,
-          `Net shares: **${entry.shares.toFixed(2)}**`,
-          '',
-          'Choose whether you want to buy this outcome or short it.',
-        ].join('\n'),
-        0x60a5fa,
-      ),
-    ],
-    components: [
-      new ActionRowBuilder<ButtonBuilder>().addComponents(
-        new ButtonBuilder()
-          .setCustomId(marketQuickTradeButtonCustomId('buy', market.id, outcomeId))
-          .setLabel(`Buy ${formatProbabilityPercent(entry.probability)}`)
-          .setDisabled(buyLocked)
-          .setStyle(ButtonStyle.Success),
-        new ButtonBuilder()
-          .setCustomId(marketQuickTradeButtonCustomId('short', market.id, outcomeId))
-          .setLabel(`Short ${formatProbabilityPercent(1 - entry.probability)}`)
-          .setDisabled(shortLocked)
-          .setStyle(ButtonStyle.Danger),
-      ),
-    ],
-  };
+	return {
+		embeds: [
+			buildMarketStatusEmbed(
+				`Trade ${entry.label}`,
+				[
+					`Current probability: **${formatProbabilityPercent(entry.probability)}**`,
+					`Net shares: **${entry.shares.toFixed(2)}**`,
+					"",
+					"Choose whether you want to buy this outcome or short it.",
+				].join("\n"),
+				0x60a5fa,
+			),
+		],
+		components: [
+			new ActionRowBuilder<ButtonBuilder>().addComponents(
+				new ButtonBuilder()
+					.setCustomId(
+						marketQuickTradeButtonCustomId("buy", market.id, outcomeId),
+					)
+					.setLabel(`Buy ${formatProbabilityPercent(entry.probability)}`)
+					.setDisabled(buyLocked)
+					.setStyle(ButtonStyle.Success),
+				new ButtonBuilder()
+					.setCustomId(
+						marketQuickTradeButtonCustomId("short", market.id, outcomeId),
+					)
+					.setLabel(`Short ${formatProbabilityPercent(1 - entry.probability)}`)
+					.setDisabled(shortLocked)
+					.setStyle(ButtonStyle.Danger),
+			),
+		],
+	};
 };
 
 export const buildMarketTradeModal = (
-  action: 'buy' | 'sell' | 'short' | 'cover',
-  marketId: string,
-  outcomeId: string,
+	action: "buy" | "sell" | "short" | "cover",
+	marketId: string,
+	outcomeId: string,
 ): ModalBuilder => {
-  const copy = getTradeCopy(action);
+	const copy = getTradeCopy(action);
 
-  return new ModalBuilder()
-    .setCustomId(marketTradeModalCustomId(action, marketId, outcomeId))
-    .setTitle(copy.title)
-    .addComponents(
-      new ActionRowBuilder<TextInputBuilder>().addComponents(
-        new TextInputBuilder()
-          .setCustomId('amount')
-          .setLabel(copy.amountLabel)
-          .setStyle(TextInputStyle.Short)
-          .setRequired(true)
-          .setPlaceholder(copy.placeholder)
-          .setMinLength(1)
-          .setMaxLength(20),
-      ),
-    );
+	return new ModalBuilder()
+		.setCustomId(marketTradeModalCustomId(action, marketId, outcomeId))
+		.setTitle(copy.title)
+		.addComponents(
+			new ActionRowBuilder<TextInputBuilder>().addComponents(
+				new TextInputBuilder()
+					.setCustomId("amount")
+					.setLabel(copy.amountLabel)
+					.setStyle(TextInputStyle.Short)
+					.setRequired(true)
+					.setPlaceholder(copy.placeholder)
+					.setMinLength(1)
+					.setMaxLength(20),
+			),
+		);
 };
 
-export const buildMarketResolveModal = (
-  marketId: string,
-): ModalBuilder =>
-  new ModalBuilder()
-    .setCustomId(marketResolveModalCustomId(marketId))
-    .setTitle('Resolve Market')
-    .addComponents(
-      new ActionRowBuilder<TextInputBuilder>().addComponents(
-        new TextInputBuilder()
-          .setCustomId('winning_outcome')
-          .setLabel('Winning outcome')
-          .setStyle(TextInputStyle.Short)
-          .setRequired(true)
-          .setPlaceholder('1 or exact label'),
-      ),
-      new ActionRowBuilder<TextInputBuilder>().addComponents(
-        new TextInputBuilder()
-          .setCustomId('note')
-          .setLabel('Resolution note')
-          .setStyle(TextInputStyle.Paragraph)
-          .setRequired(false)
-          .setMaxLength(500),
-      ),
-      new ActionRowBuilder<TextInputBuilder>().addComponents(
-        new TextInputBuilder()
-          .setCustomId('evidence_url')
-          .setLabel('Evidence URL')
-          .setStyle(TextInputStyle.Short)
-          .setRequired(false)
-          .setPlaceholder('https://example.com'),
-      ),
-    );
+export const buildMarketSessionAmountModal = (
+	sessionId: string,
+	action: "buy" | "sell" | "short" | "cover",
+	value?: string | null,
+): ModalBuilder => {
+	const copy = getTradeCopy(action);
+	const input = new TextInputBuilder()
+		.setCustomId("amount")
+		.setLabel(copy.amountLabel)
+		.setStyle(TextInputStyle.Short)
+		.setRequired(true)
+		.setPlaceholder(copy.placeholder)
+		.setMinLength(1)
+		.setMaxLength(20);
 
-export const buildMarketCancelModal = (
-  marketId: string,
-): ModalBuilder =>
-  new ModalBuilder()
-    .setCustomId(marketCancelModalCustomId(marketId))
-    .setTitle('Cancel Market')
-    .addComponents(
-      new ActionRowBuilder<TextInputBuilder>().addComponents(
-        new TextInputBuilder()
-          .setCustomId('reason')
-          .setLabel('Cancellation reason')
-          .setStyle(TextInputStyle.Paragraph)
-          .setRequired(false)
-          .setMaxLength(500),
-      ),
-    );
+	if (value?.trim()) {
+		input.setValue(value.trim());
+	}
+
+	return new ModalBuilder()
+		.setCustomId(marketSessionAmountModalCustomId(sessionId))
+		.setTitle(copy.title)
+		.addComponents(
+			new ActionRowBuilder<TextInputBuilder>().addComponents(input),
+		);
+};
+
+export const buildMarketResolveModal = (marketId: string): ModalBuilder =>
+	new ModalBuilder()
+		.setCustomId(marketResolveModalCustomId(marketId))
+		.setTitle("Resolve Market")
+		.addComponents(
+			new ActionRowBuilder<TextInputBuilder>().addComponents(
+				new TextInputBuilder()
+					.setCustomId("winning_outcome")
+					.setLabel("Winning outcome")
+					.setStyle(TextInputStyle.Short)
+					.setRequired(true)
+					.setPlaceholder("1 or exact label"),
+			),
+			new ActionRowBuilder<TextInputBuilder>().addComponents(
+				new TextInputBuilder()
+					.setCustomId("note")
+					.setLabel("Resolution note")
+					.setStyle(TextInputStyle.Paragraph)
+					.setRequired(false)
+					.setMaxLength(500),
+			),
+			new ActionRowBuilder<TextInputBuilder>().addComponents(
+				new TextInputBuilder()
+					.setCustomId("evidence_url")
+					.setLabel("Evidence URL")
+					.setStyle(TextInputStyle.Short)
+					.setRequired(false)
+					.setPlaceholder("https://example.com"),
+			),
+		);
+
+export const buildMarketCancelModal = (marketId: string): ModalBuilder =>
+	new ModalBuilder()
+		.setCustomId(marketCancelModalCustomId(marketId))
+		.setTitle("Cancel Market")
+		.addComponents(
+			new ActionRowBuilder<TextInputBuilder>().addComponents(
+				new TextInputBuilder()
+					.setCustomId("reason")
+					.setLabel("Cancellation reason")
+					.setStyle(TextInputStyle.Paragraph)
+					.setRequired(false)
+					.setMaxLength(500),
+			),
+		);
+
+const getTradeQuoteTitle = (action: MarketTradeQuote["action"]): string => {
+	switch (action) {
+		case "buy":
+			return "Preview Buy Trade";
+		case "sell":
+			return "Preview Sell Trade";
+		case "short":
+			return "Preview Short Trade";
+		case "cover":
+			return "Preview Cover Trade";
+	}
+};
+
+const getTradeQuoteColor = (action: MarketTradeQuote["action"]): number => {
+	switch (action) {
+		case "buy":
+			return 0x57f287;
+		case "sell":
+			return 0x60a5fa;
+		case "short":
+			return 0xf59e0b;
+		case "cover":
+			return 0xeb459e;
+	}
+};
+
+const getPositionAfterCopy = (quote: MarketTradeQuote): string => {
+	if (quote.positionSharesAfter <= 1e-6) {
+		return "Position after: **Closed**";
+	}
+
+	if (quote.positionSide === "long") {
+		return `Position after: **LONG ${quote.outcomeLabel} ${quote.positionSharesAfter.toFixed(2)}** (${formatMoney(quote.positionCostBasisAfter)} basis)`;
+	}
+
+	return `Position after: **SHORT ${quote.outcomeLabel} ${quote.positionSharesAfter.toFixed(2)}** (${formatMoney(quote.positionProceedsAfter)} proceeds, ${formatMoney(quote.positionCollateralAfter)} locked)`;
+};
+
+const buildTradeQuoteDescription = (quote: MarketTradeQuote): string => {
+	const lines = [
+		`Outcome: **${quote.outcomeLabel}**`,
+		`Board: **${formatPercent(quote.currentProbability)}** -> **${formatPercent(quote.nextProbability)}**`,
+	];
+
+	switch (quote.action) {
+		case "buy":
+			lines.push(
+				`Spend now: **${formatMoney(quote.netImmediateCash)}**`,
+				`Shares received: **${quote.shares.toFixed(2)}**`,
+				quote.averagePrice === null
+					? "Average price: **N/A**"
+					: `Average price: **${formatMoney(quote.averagePrice)} / share**`,
+				`Bankroll after: **${formatMoney(quote.bankrollAfter)}**`,
+				getPositionAfterCopy(quote),
+			);
+			break;
+		case "sell":
+			lines.push(
+				`Proceeds now: **${formatMoney(quote.netImmediateCash)}**`,
+				`Shares sold: **${quote.shares.toFixed(2)}**`,
+				`Realized P/L now: **${formatMoney(quote.realizedProfitDelta)}**`,
+				`Bankroll after: **${formatMoney(quote.bankrollAfter)}**`,
+				getPositionAfterCopy(quote),
+			);
+			break;
+		case "short":
+			lines.push(
+				`Proceeds now: **${formatMoney(quote.netImmediateCash)}**`,
+				`Collateral locked: **${formatMoney(quote.collateralLocked)}**`,
+				`Net bankroll change now: **${formatMoney(quote.netBankrollChange)}**`,
+				`Shares shorted: **${quote.shares.toFixed(2)}**`,
+				`Bankroll after: **${formatMoney(quote.bankrollAfter)}**`,
+				getPositionAfterCopy(quote),
+			);
+			break;
+		case "cover":
+			lines.push(
+				`Spend now: **${formatMoney(quote.netImmediateCash)}**`,
+				`Collateral released: **${formatMoney(quote.collateralReleased)}**`,
+				`Net bankroll change now: **${formatMoney(quote.netBankrollChange)}**`,
+				`Shares covered: **${quote.shares.toFixed(2)}**`,
+				`Realized P/L now: **${formatMoney(quote.realizedProfitDelta)}**`,
+				`Bankroll after: **${formatMoney(quote.bankrollAfter)}**`,
+				getPositionAfterCopy(quote),
+			);
+			break;
+	}
+
+	lines.push(
+		"",
+		`If ${quote.outcomeLabel} is chosen: payout **${formatMoney(quote.settlementIfChosen)}**, max loss **${formatMoney(quote.maxLossIfChosen)}**, max profit **${formatMoney(quote.maxProfitIfChosen)}**`,
+		`If ${quote.outcomeLabel} is not chosen: payout **${formatMoney(quote.settlementIfNotChosen)}**, max loss **${formatMoney(quote.maxLossIfNotChosen)}**, max profit **${formatMoney(quote.maxProfitIfNotChosen)}**`,
+		"",
+		"This quote is based on the current board and may change before you confirm.",
+	);
+
+	return lines.filter(Boolean).join("\n");
+};
 
 export const buildMarketTradeQuoteMessage = (
-  sessionId: string,
-  quote: MarketTradeQuote,
+	sessionId: string,
+	quote: MarketTradeQuote,
 ): {
-  embeds: [EmbedBuilder];
-  components: [ActionRowBuilder<ButtonBuilder>];
+	embeds: [EmbedBuilder];
+	components: [ActionRowBuilder<ButtonBuilder>];
 } => {
-  const netImmediateCash = quote.netImmediateCash ?? quote.immediateCash;
-  const description = quote.action === 'buy'
-    ? [
-        `Outcome: **${quote.outcomeLabel}**`,
-        `Spend now: **${formatMoney(netImmediateCash)}**`,
-        `Shares received: **${quote.shares.toFixed(2)}**`,
-        quote.averagePrice === null ? null : `Average price: **${formatMoney(quote.averagePrice)} / share**`,
-        '',
-        `If ${quote.outcomeLabel} is chosen: payout **${formatMoney(quote.settlementIfChosen)}**, max profit **${formatMoney(quote.maxProfitIfChosen)}**`,
-        `If ${quote.outcomeLabel} is not chosen: payout **${formatMoney(quote.settlementIfNotChosen)}**, max loss **${formatMoney(quote.maxLossIfNotChosen)}**`,
-        '',
-        'This quote is based on the current board and may change before you confirm.',
-      ].filter(Boolean).join('\n')
-    : [
-        `Outcome: **${quote.outcomeLabel}**`,
-        `Proceeds now: **${formatMoney(netImmediateCash)}**`,
-        `Collateral locked: **${formatMoney(quote.collateralLocked)}**`,
-        `Net bankroll change now: **${formatMoney(quote.netBankrollChange)}**`,
-        `Shares shorted: **${quote.shares.toFixed(2)}**`,
-        '',
-        `If ${quote.outcomeLabel} is chosen: payout **${formatMoney(quote.settlementIfChosen)}**, max loss **${formatMoney(quote.maxLossIfChosen)}**`,
-        `If ${quote.outcomeLabel} is not chosen: payout **${formatMoney(quote.settlementIfNotChosen)}**, max profit **${formatMoney(quote.maxProfitIfNotChosen)}**`,
-        '',
-        'This quote is based on the current board and may change before you confirm.',
-      ].join('\n');
+	return {
+		embeds: [
+			buildMarketStatusEmbed(
+				getTradeQuoteTitle(quote.action),
+				buildTradeQuoteDescription(quote),
+				getTradeQuoteColor(quote.action),
+			),
+		],
+		components: [
+			new ActionRowBuilder<ButtonBuilder>().addComponents(
+				new ButtonBuilder()
+					.setCustomId(marketTradeQuoteConfirmCustomId(sessionId))
+					.setLabel("Confirm")
+					.setStyle(ButtonStyle.Success),
+				new ButtonBuilder()
+					.setCustomId(marketTradeQuoteCancelCustomId(sessionId))
+					.setLabel("Cancel")
+					.setStyle(ButtonStyle.Secondary),
+			),
+		],
+	};
+};
 
-  return {
-    embeds: [
-      buildMarketStatusEmbed(
-        quote.action === 'buy' ? 'Preview Buy Trade' : 'Preview Short Trade',
-        description,
-        quote.action === 'buy' ? 0x57f287 : 0xf59e0b,
-      ),
-    ],
-    components: [
-      new ActionRowBuilder<ButtonBuilder>().addComponents(
-        new ButtonBuilder()
-          .setCustomId(marketTradeQuoteConfirmCustomId(sessionId))
-          .setLabel('Confirm')
-          .setStyle(ButtonStyle.Success),
-        new ButtonBuilder()
-          .setCustomId(marketTradeQuoteCancelCustomId(sessionId))
-          .setLabel('Cancel')
-          .setStyle(ButtonStyle.Secondary),
-      ),
-    ],
-  };
+const buildProtectionQuoteDescription = (
+	quote: MarketLossProtectionQuote,
+): string =>
+	[
+		`Outcome: **${quote.outcomeLabel}**`,
+		`Current probability: **${formatPercent(quote.currentProbability)}**`,
+		`Current long basis: **${formatMoney(quote.currentLongCostBasis)}**`,
+		`Already insured: **${formatMoney(quote.alreadyInsuredCostBasis)}**`,
+		`Target coverage: **${formatPercent(quote.targetCoverage)}**`,
+		`Target insured basis: **${formatMoney(quote.targetInsuredCostBasis)}**`,
+		`Additional insured basis: **${formatMoney(quote.incrementalInsuredCostBasis)}**`,
+		`Premium now: **${formatMoney(quote.premium)}**`,
+		`Refund if ${quote.outcomeLabel} loses: **${formatMoney(quote.payoutIfLoses)}**`,
+		"",
+		"If you sell later, protected basis shrinks with the remaining position. This quote may change before you confirm.",
+	].join("\n");
+
+export const buildMarketInteractionSessionMessage = (input: {
+	market: MarketWithRelations;
+	session: MarketInteractionSession;
+	positions: Array<{
+		outcomeId: string;
+		outcomeLabel: string;
+		side: "long" | "short";
+		shares: number;
+		costBasis: number;
+		proceeds: number;
+		collateralLocked: number;
+		insuredCostBasis: number;
+		coverageRatio: number;
+		canProtect: boolean;
+	}>;
+}): {
+	embeds: [EmbedBuilder];
+	components: ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[];
+} => {
+	const { market, session, positions } = input;
+	const rows: ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[] = [];
+
+	if (session.mode === "trade") {
+		const tradableEntries = getMarketSummary(market).probabilities.filter(
+			(entry) => !entry.isResolved,
+		);
+		const selectedAction = session.selectedAction === "short" ? "short" : "buy";
+		const selectedOutcome = tradableEntries.find(
+			(entry) => entry.outcomeId === session.selectedOutcomeId,
+		);
+		const header = [
+			`Market: **${market.title}**`,
+			`Action: **${selectedAction === "buy" ? "Buy" : "Short"}**`,
+			`Outcome: **${selectedOutcome?.label ?? "Choose an outcome"}**`,
+			`Amount: **${session.amountInput ?? "Choose a quick amount or open the modal"}**`,
+			"",
+			tradableEntries.length === 0
+				? "No tradable outcomes are available right now."
+				: session.preview?.kind === "trade"
+					? buildTradeQuoteDescription(session.preview.quote)
+					: "Select an outcome, then use a quick amount or enter a custom amount to preview the trade.",
+		].join("\n");
+
+		rows.push(
+			new ActionRowBuilder<ButtonBuilder>().addComponents(
+				new ButtonBuilder()
+					.setCustomId(
+						marketSessionSideButtonCustomId(session.sessionId, "buy"),
+					)
+					.setLabel("Buy")
+					.setStyle(
+						selectedAction === "buy"
+							? ButtonStyle.Success
+							: ButtonStyle.Secondary,
+					),
+				new ButtonBuilder()
+					.setCustomId(
+						marketSessionSideButtonCustomId(session.sessionId, "short"),
+					)
+					.setLabel("Short")
+					.setStyle(
+						selectedAction === "short"
+							? ButtonStyle.Danger
+							: ButtonStyle.Secondary,
+					),
+			),
+		);
+
+		if (tradableEntries.length > 0) {
+			rows.push(
+				new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+					new StringSelectMenuBuilder()
+						.setCustomId(marketSessionOutcomeSelectCustomId(session.sessionId))
+						.setPlaceholder("Choose an outcome")
+						.setMinValues(1)
+						.setMaxValues(1)
+						.addOptions(
+							tradableEntries.slice(0, 25).map((entry) => ({
+								label: truncateLabel(entry.label, 40),
+								value: entry.outcomeId,
+								description: `${formatProbabilityPercent(entry.probability)} • ${entry.shares.toFixed(2)} net shares`,
+								default: entry.outcomeId === session.selectedOutcomeId,
+							})),
+						),
+				),
+			);
+		}
+
+		rows.push(
+			new ActionRowBuilder<ButtonBuilder>().addComponents(
+				new ButtonBuilder()
+					.setCustomId(
+						marketSessionQuickAmountButtonCustomId(session.sessionId, 10),
+					)
+					.setLabel("10 pts")
+					.setStyle(ButtonStyle.Secondary)
+					.setDisabled(!selectedOutcome),
+				new ButtonBuilder()
+					.setCustomId(
+						marketSessionQuickAmountButtonCustomId(session.sessionId, 25),
+					)
+					.setLabel("25 pts")
+					.setStyle(ButtonStyle.Secondary)
+					.setDisabled(!selectedOutcome),
+				new ButtonBuilder()
+					.setCustomId(
+						marketSessionQuickAmountButtonCustomId(session.sessionId, 50),
+					)
+					.setLabel("50 pts")
+					.setStyle(ButtonStyle.Secondary)
+					.setDisabled(!selectedOutcome),
+				new ButtonBuilder()
+					.setCustomId(marketSessionAmountButtonCustomId(session.sessionId))
+					.setLabel(session.amountInput ? "Edit Amount" : "Custom Amount")
+					.setStyle(ButtonStyle.Primary)
+					.setDisabled(!selectedOutcome),
+			),
+		);
+
+		rows.push(
+			new ActionRowBuilder<ButtonBuilder>().addComponents(
+				new ButtonBuilder()
+					.setCustomId(marketSessionConfirmButtonCustomId(session.sessionId))
+					.setLabel("Confirm")
+					.setStyle(ButtonStyle.Success)
+					.setDisabled(session.preview?.kind !== "trade"),
+				new ButtonBuilder()
+					.setCustomId(marketSessionCancelButtonCustomId(session.sessionId))
+					.setLabel("Cancel")
+					.setStyle(ButtonStyle.Secondary),
+			),
+		);
+
+		return {
+			embeds: [buildMarketStatusEmbed("Trade Session", header, 0x60a5fa)],
+			components: rows,
+		};
+	}
+
+	const selectedPosition = positions.find(
+		(position) => position.outcomeId === session.selectedOutcomeId,
+	);
+	const selectedAction =
+		session.selectedAction === "sell"
+			? "sell"
+			: session.selectedAction === "cover"
+				? "cover"
+				: session.selectedAction === "protect"
+					? "protect"
+					: null;
+	const selectedActionLabel =
+		selectedAction === null
+			? "Choose an action"
+			: `${selectedAction.charAt(0).toUpperCase()}${selectedAction.slice(1)}`;
+	const description = [
+		`Market: **${market.title}**`,
+		selectedPosition
+			? `Position: **${selectedPosition.side === "long" ? "LONG" : "SHORT"} ${selectedPosition.outcomeLabel} ${selectedPosition.shares.toFixed(2)}**`
+			: "Position: **Choose a position**",
+		`Action: **${selectedActionLabel}**`,
+		selectedAction === "protect"
+			? `Coverage: **${session.targetCoverage === null ? "Choose coverage" : formatPercent(session.targetCoverage)}**`
+			: `Amount: **${session.amountInput ?? "Choose a quick amount or open the modal"}**`,
+		"",
+		positions.length === 0
+			? "You do not have an open position in this market to manage."
+			: session.preview?.kind === "trade"
+				? buildTradeQuoteDescription(session.preview.quote)
+				: session.preview?.kind === "protection"
+					? buildProtectionQuoteDescription(session.preview.quote)
+					: "Choose a position and valid action, then use a quick amount, custom amount, or protection coverage to preview the trade.",
+	].join("\n");
+
+	if (positions.length > 0) {
+		rows.push(
+			new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+				new StringSelectMenuBuilder()
+					.setCustomId(marketSessionPositionSelectCustomId(session.sessionId))
+					.setPlaceholder("Choose a position")
+					.setMinValues(1)
+					.setMaxValues(1)
+					.addOptions(
+						positions.slice(0, 25).map((position) => ({
+							label: truncateLabel(position.outcomeLabel, 40),
+							value: position.outcomeId,
+							description:
+								position.side === "long"
+									? `LONG ${position.shares.toFixed(2)} • ${formatPercent(position.coverageRatio)} insured`
+									: `SHORT ${position.shares.toFixed(2)} • ${formatMoney(position.collateralLocked)} locked`,
+							default: position.outcomeId === session.selectedOutcomeId,
+						})),
+					),
+			),
+		);
+	}
+
+	if (selectedPosition) {
+		const validActions: Array<"sell" | "cover" | "protect"> =
+			selectedPosition.side === "long"
+				? [
+						"sell",
+						...(selectedPosition.canProtect ? (["protect"] as const) : []),
+					]
+				: ["cover"];
+
+		rows.push(
+			new ActionRowBuilder<ButtonBuilder>().addComponents(
+				...validActions.map((action) =>
+					new ButtonBuilder()
+						.setCustomId(
+							marketSessionActionButtonCustomId(session.sessionId, action),
+						)
+						.setLabel(
+							action === "cover"
+								? "Cover"
+								: action === "protect"
+									? "Protect"
+									: "Sell",
+						)
+						.setStyle(
+							action === selectedAction
+								? action === "protect"
+									? ButtonStyle.Primary
+									: action === "sell"
+										? ButtonStyle.Success
+										: ButtonStyle.Danger
+								: ButtonStyle.Secondary,
+						),
+				),
+			),
+		);
+
+		if (selectedAction === "protect") {
+			rows.push(
+				new ActionRowBuilder<ButtonBuilder>().addComponents(
+					new ButtonBuilder()
+						.setCustomId(
+							marketSessionCoverageButtonCustomId(session.sessionId, 25),
+						)
+						.setLabel("25%")
+						.setStyle(
+							session.targetCoverage === 0.25
+								? ButtonStyle.Primary
+								: ButtonStyle.Secondary,
+						)
+						.setDisabled(selectedPosition.coverageRatio >= 0.25),
+					new ButtonBuilder()
+						.setCustomId(
+							marketSessionCoverageButtonCustomId(session.sessionId, 50),
+						)
+						.setLabel("50%")
+						.setStyle(
+							session.targetCoverage === 0.5
+								? ButtonStyle.Primary
+								: ButtonStyle.Secondary,
+						)
+						.setDisabled(selectedPosition.coverageRatio >= 0.5),
+					new ButtonBuilder()
+						.setCustomId(
+							marketSessionCoverageButtonCustomId(session.sessionId, 75),
+						)
+						.setLabel("75%")
+						.setStyle(
+							session.targetCoverage === 0.75
+								? ButtonStyle.Primary
+								: ButtonStyle.Secondary,
+						)
+						.setDisabled(selectedPosition.coverageRatio >= 0.75),
+					new ButtonBuilder()
+						.setCustomId(
+							marketSessionCoverageButtonCustomId(session.sessionId, 100),
+						)
+						.setLabel("100%")
+						.setStyle(
+							session.targetCoverage === 1
+								? ButtonStyle.Primary
+								: ButtonStyle.Secondary,
+						)
+						.setDisabled(selectedPosition.coverageRatio >= 1),
+				),
+			);
+		} else if (selectedAction === "sell" || selectedAction === "cover") {
+			rows.push(
+				new ActionRowBuilder<ButtonBuilder>().addComponents(
+					new ButtonBuilder()
+						.setCustomId(
+							marketSessionQuickAmountButtonCustomId(session.sessionId, 10),
+						)
+						.setLabel("10 pts")
+						.setStyle(ButtonStyle.Secondary),
+					new ButtonBuilder()
+						.setCustomId(
+							marketSessionQuickAmountButtonCustomId(session.sessionId, 25),
+						)
+						.setLabel("25 pts")
+						.setStyle(ButtonStyle.Secondary),
+					new ButtonBuilder()
+						.setCustomId(
+							marketSessionQuickAmountButtonCustomId(session.sessionId, 50),
+						)
+						.setLabel("50 pts")
+						.setStyle(ButtonStyle.Secondary),
+					new ButtonBuilder()
+						.setCustomId(marketSessionAmountButtonCustomId(session.sessionId))
+						.setLabel(session.amountInput ? "Edit Amount" : "Custom Amount")
+						.setStyle(ButtonStyle.Primary),
+				),
+			);
+		}
+	}
+
+	rows.push(
+		new ActionRowBuilder<ButtonBuilder>().addComponents(
+			new ButtonBuilder()
+				.setCustomId(marketSessionConfirmButtonCustomId(session.sessionId))
+				.setLabel("Confirm")
+				.setStyle(ButtonStyle.Success)
+				.setDisabled(session.preview === null),
+			new ButtonBuilder()
+				.setCustomId(marketSessionCancelButtonCustomId(session.sessionId))
+				.setLabel("Cancel")
+				.setStyle(ButtonStyle.Secondary),
+		),
+	);
+
+	return {
+		embeds: [buildMarketStatusEmbed("Manage Position", description, 0x60a5fa)],
+		components: rows,
+	};
 };
 
 export const buildLossProtectionPositionSelector = (
-  market: MarketWithRelations,
-  positions: Array<{
-    outcomeId: string;
-    outcomeLabel: string;
-    currentLongCostBasis: number;
-    insuredCostBasis: number;
-    coverageRatio: number;
-  }>,
+	market: MarketWithRelations,
+	positions: Array<{
+		outcomeId: string;
+		outcomeLabel: string;
+		currentLongCostBasis: number;
+		insuredCostBasis: number;
+		coverageRatio: number;
+	}>,
 ): {
-  embeds: [EmbedBuilder];
-  components: [ActionRowBuilder<StringSelectMenuBuilder>];
+	embeds: [EmbedBuilder];
+	components: [ActionRowBuilder<StringSelectMenuBuilder>];
 } => ({
-  embeds: [
-    buildMarketStatusEmbed(
-      'Protect A Position',
-      `Choose which long position in **${market.title}** you want to protect.`,
-      0x60a5fa,
-    ),
-  ],
-  components: [
-    new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
-      new StringSelectMenuBuilder()
-        .setCustomId(marketProtectionSelectCustomId(market.id))
-        .setPlaceholder('Choose a long position to protect')
-        .setMinValues(1)
-        .setMaxValues(1)
-        .addOptions(
-          positions.slice(0, 25).map((position) => ({
-            label: truncateLabel(position.outcomeLabel, 40),
-            value: position.outcomeId,
-            description: `${formatMoney(position.currentLongCostBasis)} basis • ${formatPercent(position.coverageRatio)} insured`,
-          })),
-        ),
-    ),
-  ],
+	embeds: [
+		buildMarketStatusEmbed(
+			"Protect A Position",
+			`Choose which long position in **${market.title}** you want to protect.`,
+			0x60a5fa,
+		),
+	],
+	components: [
+		new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+			new StringSelectMenuBuilder()
+				.setCustomId(marketProtectionSelectCustomId(market.id))
+				.setPlaceholder("Choose a long position to protect")
+				.setMinValues(1)
+				.setMaxValues(1)
+				.addOptions(
+					positions.slice(0, 25).map((position) => ({
+						label: truncateLabel(position.outcomeLabel, 40),
+						value: position.outcomeId,
+						description: `${formatMoney(position.currentLongCostBasis)} basis • ${formatPercent(position.coverageRatio)} insured`,
+					})),
+				),
+		),
+	],
 });
 
 export const buildLossProtectionCoverageMessage = (input: {
-  marketId: string;
-  marketTitle: string;
-  outcomeId: string;
-  outcomeLabel: string;
-  currentLongCostBasis: number;
-  insuredCostBasis: number;
-  coverageRatio: number;
+	marketId: string;
+	marketTitle: string;
+	outcomeId: string;
+	outcomeLabel: string;
+	currentLongCostBasis: number;
+	insuredCostBasis: number;
+	coverageRatio: number;
 }): {
-  embeds: [EmbedBuilder];
-  components: [ActionRowBuilder<ButtonBuilder>];
+	embeds: [EmbedBuilder];
+	components: [ActionRowBuilder<ButtonBuilder>];
 } => ({
-  embeds: [
-    buildMarketStatusEmbed(
-      'Protect This Position',
-      [
-        `Market: **${input.marketTitle}**`,
-        `Outcome: **${input.outcomeLabel}**`,
-        `Current long basis: **${formatMoney(input.currentLongCostBasis)}**`,
-        `Already insured: **${formatMoney(input.insuredCostBasis)}** (${formatPercent(input.coverageRatio)})`,
-        '',
-        'Choose your total target coverage. You only pay for any additional protection needed to reach that level.',
-      ].join('\n'),
-      0x60a5fa,
-    ),
-  ],
-  components: [
-    new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId(marketProtectionCoverageButtonCustomId(input.marketId, input.outcomeId, 0.25))
-        .setLabel('25%')
-        .setStyle(ButtonStyle.Secondary),
-      new ButtonBuilder()
-        .setCustomId(marketProtectionCoverageButtonCustomId(input.marketId, input.outcomeId, 0.5))
-        .setLabel('50%')
-        .setStyle(ButtonStyle.Secondary),
-      new ButtonBuilder()
-        .setCustomId(marketProtectionCoverageButtonCustomId(input.marketId, input.outcomeId, 0.75))
-        .setLabel('75%')
-        .setStyle(ButtonStyle.Secondary),
-      new ButtonBuilder()
-        .setCustomId(marketProtectionCoverageButtonCustomId(input.marketId, input.outcomeId, 1))
-        .setLabel('100%')
-        .setStyle(ButtonStyle.Primary),
-    ),
-  ],
+	embeds: [
+		buildMarketStatusEmbed(
+			"Protect This Position",
+			[
+				`Market: **${input.marketTitle}**`,
+				`Outcome: **${input.outcomeLabel}**`,
+				`Current long basis: **${formatMoney(input.currentLongCostBasis)}**`,
+				`Already insured: **${formatMoney(input.insuredCostBasis)}** (${formatPercent(input.coverageRatio)})`,
+				"",
+				"Choose your total target coverage. You only pay for any additional protection needed to reach that level.",
+			].join("\n"),
+			0x60a5fa,
+		),
+	],
+	components: [
+		new ActionRowBuilder<ButtonBuilder>().addComponents(
+			new ButtonBuilder()
+				.setCustomId(
+					marketProtectionCoverageButtonCustomId(
+						input.marketId,
+						input.outcomeId,
+						0.25,
+					),
+				)
+				.setLabel("25%")
+				.setStyle(ButtonStyle.Secondary),
+			new ButtonBuilder()
+				.setCustomId(
+					marketProtectionCoverageButtonCustomId(
+						input.marketId,
+						input.outcomeId,
+						0.5,
+					),
+				)
+				.setLabel("50%")
+				.setStyle(ButtonStyle.Secondary),
+			new ButtonBuilder()
+				.setCustomId(
+					marketProtectionCoverageButtonCustomId(
+						input.marketId,
+						input.outcomeId,
+						0.75,
+					),
+				)
+				.setLabel("75%")
+				.setStyle(ButtonStyle.Secondary),
+			new ButtonBuilder()
+				.setCustomId(
+					marketProtectionCoverageButtonCustomId(
+						input.marketId,
+						input.outcomeId,
+						1,
+					),
+				)
+				.setLabel("100%")
+				.setStyle(ButtonStyle.Primary),
+		),
+	],
 });
 
 export const buildLossProtectionQuoteMessage = (
-  sessionId: string,
-  quote: MarketLossProtectionQuote,
+	sessionId: string,
+	quote: MarketLossProtectionQuote,
 ): {
-  embeds: [EmbedBuilder];
-  components: [ActionRowBuilder<ButtonBuilder>];
+	embeds: [EmbedBuilder];
+	components: [ActionRowBuilder<ButtonBuilder>];
 } => ({
-  embeds: [
-    buildMarketStatusEmbed(
-      'Preview Loss Protection',
-      [
-        `Market: **${quote.marketTitle}**`,
-        `Outcome: **${quote.outcomeLabel}**`,
-        `Current probability: **${formatPercent(quote.currentProbability)}**`,
-        `Current long basis: **${formatMoney(quote.currentLongCostBasis)}**`,
-        `Already insured: **${formatMoney(quote.alreadyInsuredCostBasis)}**`,
-        `Target coverage: **${formatPercent(quote.targetCoverage)}**`,
-        `Target insured basis: **${formatMoney(quote.targetInsuredCostBasis)}**`,
-        `Additional insured basis: **${formatMoney(quote.incrementalInsuredCostBasis)}**`,
-        `Premium now: **${formatMoney(quote.premium)}**`,
-        `Refund if ${quote.outcomeLabel} loses: **${formatMoney(quote.targetInsuredCostBasis)}**`,
-        '',
-        'If you sell later, protected basis shrinks with the remaining position. This quote may change before you confirm.',
-      ].join('\n'),
-      0x60a5fa,
-    ),
-  ],
-  components: [
-    new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId(marketTradeQuoteConfirmCustomId(sessionId))
-        .setLabel('Confirm')
-        .setStyle(ButtonStyle.Success),
-      new ButtonBuilder()
-        .setCustomId(marketTradeQuoteCancelCustomId(sessionId))
-        .setLabel('Cancel')
-        .setStyle(ButtonStyle.Secondary),
-    ),
-  ],
+	embeds: [
+		buildMarketStatusEmbed(
+			"Preview Loss Protection",
+			[
+				`Market: **${quote.marketTitle}**`,
+				`Outcome: **${quote.outcomeLabel}**`,
+				`Current probability: **${formatPercent(quote.currentProbability)}**`,
+				`Current long basis: **${formatMoney(quote.currentLongCostBasis)}**`,
+				`Already insured: **${formatMoney(quote.alreadyInsuredCostBasis)}**`,
+				`Target coverage: **${formatPercent(quote.targetCoverage)}**`,
+				`Target insured basis: **${formatMoney(quote.targetInsuredCostBasis)}**`,
+				`Additional insured basis: **${formatMoney(quote.incrementalInsuredCostBasis)}**`,
+				`Premium now: **${formatMoney(quote.premium)}**`,
+				`Refund if ${quote.outcomeLabel} loses: **${formatMoney(quote.targetInsuredCostBasis)}**`,
+				"",
+				"If you sell later, protected basis shrinks with the remaining position. This quote may change before you confirm.",
+			].join("\n"),
+			0x60a5fa,
+		),
+	],
+	components: [
+		new ActionRowBuilder<ButtonBuilder>().addComponents(
+			new ButtonBuilder()
+				.setCustomId(marketTradeQuoteConfirmCustomId(sessionId))
+				.setLabel("Confirm")
+				.setStyle(ButtonStyle.Success),
+			new ButtonBuilder()
+				.setCustomId(marketTradeQuoteCancelCustomId(sessionId))
+				.setLabel("Cancel")
+				.setStyle(ButtonStyle.Secondary),
+		),
+	],
 });

--- a/tests/market-interactions.test.ts
+++ b/tests/market-interactions.test.ts
@@ -1,988 +1,1596 @@
-import { ChannelType } from 'discord.js';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChannelType } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
-  loggerWarn,
-  env,
-  getMarketConfig,
-  setMarketConfig,
-  disableMarketConfig,
-  createMarketRecord,
-  deleteMarketRecord,
-  scheduleMarketClose,
-  scheduleMarketLiquidity,
-  clearMarketJobs,
-  appendMarketOutcomes,
-  editMarketRecord,
-  listMarkets,
-  getMarketLeaderboard,
-  getMarketAccountSummary,
-  grantMarketBankroll,
-  getMarketByQuery,
-  getMarketById,
-  summarizeMarketTraders,
-  calculateMarketTradeQuote,
-  getMarketForecastProfile,
-  getMarketForecastLeaderboard,
-  executeMarketTrade,
-  resolveMarket,
-  resolveMarketOutcome,
-  cancelMarket,
-  scheduleMarketRefresh,
-  hydrateMarketMessage,
-  announceMarketUpdate,
-  notifyMarketResolved,
-  refreshMarketMessage,
-  saveMarketTradeQuoteSession,
-  getMarketTradeQuoteSession,
-  deleteMarketTradeQuoteSession,
+	loggerWarn,
+	env,
+	getMarketConfig,
+	setMarketConfig,
+	disableMarketConfig,
+	createMarketRecord,
+	deleteMarketRecord,
+	scheduleMarketClose,
+	scheduleMarketLiquidity,
+	clearMarketJobs,
+	appendMarketOutcomes,
+	editMarketRecord,
+	listMarkets,
+	getMarketLeaderboard,
+	getMarketAccountSummary,
+	grantMarketBankroll,
+	getMarketByQuery,
+	getMarketById,
+	summarizeMarketTraders,
+	calculateMarketTradeQuote,
+	getMarketForecastProfileDetails,
+	getMarketForecastLeaderboard,
+	executeMarketTrade,
+	resolveMarket,
+	resolveMarketOutcome,
+	cancelMarket,
+	scheduleMarketRefresh,
+	hydrateMarketMessage,
+	announceMarketUpdate,
+	notifyMarketResolved,
+	refreshMarketMessage,
+	saveMarketTradeQuoteSession,
+	getMarketTradeQuoteSession,
+	deleteMarketTradeQuoteSession,
+	createMarketInteractionSessionId,
+	saveMarketInteractionSession,
+	getMarketInteractionSession,
+	deleteMarketInteractionSession,
+	calculateLossProtectionQuote,
+	purchaseLossProtection,
+	getProtectableLongPositions,
+	buildMarketForecastProfileDiagram,
 } = vi.hoisted(() => ({
-  loggerWarn: vi.fn(),
-  env: {
-    DISCORD_ADMIN_USER_IDS: ['user_1'],
-  },
-  getMarketConfig: vi.fn(),
-  setMarketConfig: vi.fn(),
-  disableMarketConfig: vi.fn(),
-  createMarketRecord: vi.fn(),
-  deleteMarketRecord: vi.fn(),
-  scheduleMarketClose: vi.fn(),
-  scheduleMarketLiquidity: vi.fn(),
-  clearMarketJobs: vi.fn(),
-  appendMarketOutcomes: vi.fn(),
-  editMarketRecord: vi.fn(),
-  listMarkets: vi.fn(),
-  getMarketLeaderboard: vi.fn(),
-  getMarketAccountSummary: vi.fn(),
-  grantMarketBankroll: vi.fn(),
-  getMarketByQuery: vi.fn(),
-  getMarketById: vi.fn(),
-  summarizeMarketTraders: vi.fn(),
-  calculateMarketTradeQuote: vi.fn(),
-  getMarketForecastProfile: vi.fn(),
-  getMarketForecastLeaderboard: vi.fn(),
-  executeMarketTrade: vi.fn(),
-  resolveMarket: vi.fn(),
-  resolveMarketOutcome: vi.fn(),
-  cancelMarket: vi.fn(),
-  scheduleMarketRefresh: vi.fn(),
-  hydrateMarketMessage: vi.fn(),
-  announceMarketUpdate: vi.fn(),
-  notifyMarketResolved: vi.fn(),
-  refreshMarketMessage: vi.fn(),
-  saveMarketTradeQuoteSession: vi.fn(),
-  getMarketTradeQuoteSession: vi.fn(),
-  deleteMarketTradeQuoteSession: vi.fn(),
+	loggerWarn: vi.fn(),
+	env: {
+		DISCORD_ADMIN_USER_IDS: ["user_1"],
+	},
+	getMarketConfig: vi.fn(),
+	setMarketConfig: vi.fn(),
+	disableMarketConfig: vi.fn(),
+	createMarketRecord: vi.fn(),
+	deleteMarketRecord: vi.fn(),
+	scheduleMarketClose: vi.fn(),
+	scheduleMarketLiquidity: vi.fn(),
+	clearMarketJobs: vi.fn(),
+	appendMarketOutcomes: vi.fn(),
+	editMarketRecord: vi.fn(),
+	listMarkets: vi.fn(),
+	getMarketLeaderboard: vi.fn(),
+	getMarketAccountSummary: vi.fn(),
+	grantMarketBankroll: vi.fn(),
+	getMarketByQuery: vi.fn(),
+	getMarketById: vi.fn(),
+	summarizeMarketTraders: vi.fn(),
+	calculateMarketTradeQuote: vi.fn(),
+	getMarketForecastProfileDetails: vi.fn(),
+	getMarketForecastLeaderboard: vi.fn(),
+	executeMarketTrade: vi.fn(),
+	resolveMarket: vi.fn(),
+	resolveMarketOutcome: vi.fn(),
+	cancelMarket: vi.fn(),
+	scheduleMarketRefresh: vi.fn(),
+	hydrateMarketMessage: vi.fn(),
+	announceMarketUpdate: vi.fn(),
+	notifyMarketResolved: vi.fn(),
+	refreshMarketMessage: vi.fn(),
+	saveMarketTradeQuoteSession: vi.fn(),
+	getMarketTradeQuoteSession: vi.fn(),
+	deleteMarketTradeQuoteSession: vi.fn(),
+	createMarketInteractionSessionId: vi.fn(() => "session_1"),
+	saveMarketInteractionSession: vi.fn(),
+	getMarketInteractionSession: vi.fn(),
+	deleteMarketInteractionSession: vi.fn(),
+	calculateLossProtectionQuote: vi.fn(),
+	purchaseLossProtection: vi.fn(),
+	getProtectableLongPositions: vi.fn(() => []),
+	buildMarketForecastProfileDiagram: vi.fn(),
 }));
 
-vi.mock('../src/app/config.js', () => ({
-  env,
+vi.mock("../src/app/config.js", () => ({
+	env,
 }));
 
-vi.mock('../src/app/logger.js', () => ({
-  logger: {
-    warn: loggerWarn,
-  },
+vi.mock("../src/app/logger.js", () => ({
+	logger: {
+		warn: loggerWarn,
+	},
 }));
 
-vi.mock('../src/features/markets/services/config.js', () => ({
-  getMarketConfig,
-  setMarketConfig,
-  disableMarketConfig,
-  describeMarketConfig: vi.fn((config: { enabled: boolean; channelId: string | null }) =>
-    config.enabled && config.channelId
-      ? `Prediction markets are enabled in forum <#${config.channelId}>.`
-      : 'Prediction markets are disabled for this server.'),
+vi.mock("../src/features/markets/services/config.js", () => ({
+	getMarketConfig,
+	setMarketConfig,
+	disableMarketConfig,
+	describeMarketConfig: vi.fn(
+		(config: { enabled: boolean; channelId: string | null }) =>
+			config.enabled && config.channelId
+				? `Prediction markets are enabled in forum <#${config.channelId}>.`
+				: "Prediction markets are disabled for this server.",
+	),
 }));
 
-vi.mock('../src/features/markets/services/account.js', () => ({
-  getMarketLeaderboard,
-  getMarketAccountSummary,
-  grantMarketBankroll,
+vi.mock("../src/features/markets/services/account.js", () => ({
+	getMarketLeaderboard,
+	getMarketAccountSummary,
+	grantMarketBankroll,
 }));
 
-vi.mock('../src/features/markets/services/forecast/queries.js', () => ({
-  getMarketForecastProfile,
-  getMarketForecastLeaderboard,
+vi.mock("../src/features/markets/services/forecast/queries.js", () => ({
+	getMarketForecastProfileDetails,
+	getMarketForecastLeaderboard,
 }));
 
-vi.mock('../src/features/markets/services/records.js', () => ({
-  createMarketRecord,
-  deleteMarketRecord,
-  appendMarketOutcomes,
-  editMarketRecord,
-  listMarkets,
-  getMarketByQuery,
-  getMarketById,
-  summarizeMarketTraders,
+vi.mock("../src/features/markets/ui/profile-visualize.js", () => ({
+	buildMarketForecastProfileDiagram,
 }));
 
-vi.mock('../src/features/markets/services/scheduler.js', () => ({
-  scheduleMarketClose,
-  scheduleMarketLiquidity,
-  clearMarketJobs,
-  scheduleMarketRefresh,
+vi.mock("../src/features/markets/services/records.js", () => ({
+	createMarketRecord,
+	deleteMarketRecord,
+	appendMarketOutcomes,
+	editMarketRecord,
+	listMarkets,
+	getMarketByQuery,
+	getMarketById,
+	summarizeMarketTraders,
 }));
 
-vi.mock('../src/features/markets/services/trading/quotes.js', () => ({
-  calculateMarketTradeQuote,
+vi.mock("../src/features/markets/services/scheduler.js", () => ({
+	scheduleMarketClose,
+	scheduleMarketLiquidity,
+	clearMarketJobs,
+	scheduleMarketRefresh,
 }));
 
-vi.mock('../src/features/markets/services/trading/execution.js', () => ({
-  executeMarketTrade,
+vi.mock("../src/features/markets/services/trading/quotes.js", () => ({
+	calculateMarketTradeQuote,
 }));
 
-vi.mock('../src/features/markets/services/trading/resolution.js', () => ({
-  resolveMarket,
-  resolveMarketOutcome,
+vi.mock("../src/features/markets/services/trading/execution.js", () => ({
+	executeMarketTrade,
 }));
 
-vi.mock('../src/features/markets/services/trading/cancel.js', () => ({
-  cancelMarket,
+vi.mock("../src/features/markets/services/trading/protection.js", () => ({
+	calculateLossProtectionQuote,
+	purchaseLossProtection,
+	getProtectableLongPositions,
 }));
 
-vi.mock('../src/features/markets/state/quote-session-store.js', () => ({
-  createMarketTradeQuoteSessionId: vi.fn(() => 'quote_session_1'),
-  saveMarketTradeQuoteSession,
-  getMarketTradeQuoteSession,
-  deleteMarketTradeQuoteSession,
+vi.mock("../src/features/markets/services/trading/resolution.js", () => ({
+	resolveMarket,
+	resolveMarketOutcome,
 }));
 
-vi.mock('../src/lib/redis.js', () => ({
-  redis: {},
+vi.mock("../src/features/markets/services/trading/cancel.js", () => ({
+	cancelMarket,
 }));
 
-vi.mock('../src/features/markets/services/lifecycle.js', () => ({
-  announceMarketUpdate,
-  hydrateMarketMessage,
-  notifyMarketResolved,
-  refreshMarketMessage,
-  buildMarketViewResponse: vi.fn(async () => ({
-    embeds: [],
-  })),
-  clearMarketLifecycle: vi.fn(),
+vi.mock("../src/features/markets/state/quote-session-store.js", () => ({
+	createMarketTradeQuoteSessionId: vi.fn(() => "quote_session_1"),
+	saveMarketTradeQuoteSession,
+	getMarketTradeQuoteSession,
+	deleteMarketTradeQuoteSession,
 }));
 
-import { handleMarketButton } from '../src/features/markets/handlers/interactions/buttons.js';
-import { handleMarketCommand } from '../src/features/markets/handlers/interactions/commands.js';
+vi.mock("../src/features/markets/state/interaction-session-store.js", () => ({
+	createMarketInteractionSessionId,
+	saveMarketInteractionSession,
+	getMarketInteractionSession,
+	deleteMarketInteractionSession,
+}));
 
-const defaultAdminUserIds = ['user_1'];
+vi.mock("../src/lib/redis.js", () => ({
+	redis: {},
+}));
+
+vi.mock("../src/features/markets/services/lifecycle.js", () => ({
+	announceMarketUpdate,
+	hydrateMarketMessage,
+	notifyMarketResolved,
+	refreshMarketMessage,
+	buildMarketViewResponse: vi.fn(async () => ({
+		embeds: [],
+	})),
+	clearMarketLifecycle: vi.fn(),
+}));
+
+import { handleMarketButton } from "../src/features/markets/handlers/interactions/buttons.js";
+import { handleMarketCommand } from "../src/features/markets/handlers/interactions/commands.js";
+import { handleMarketModal } from "../src/features/markets/handlers/interactions/modals.js";
+import { handleMarketSelect } from "../src/features/markets/handlers/interactions/selects.js";
+
+const defaultAdminUserIds = ["user_1"];
 
 const baseMarket = {
-  id: 'market_1',
-  guildId: 'guild_1',
-  creatorId: 'user_1',
-  originChannelId: 'origin_channel_1',
-  marketChannelId: 'market_channel_1',
-  messageId: 'message_market_1',
-  threadId: null,
-  title: 'Will turnout exceed 40%?',
-  description: 'A test market',
-  buttonStyle: 'primary' as const,
-  tags: ['meta'],
-  liquidityParameter: 150,
-  baseLiquidityParameter: 150,
-  maxLiquidityParameter: 450,
-  lastLiquidityInjectionAt: null,
-  closeAt: new Date('2099-03-30T00:00:00.000Z'),
-  tradingClosedAt: null,
-  resolutionGraceEndsAt: null,
-  graceNotifiedAt: null,
-  resolvedAt: null,
-  cancelledAt: null,
-  resolutionNote: null,
-  resolutionEvidenceUrl: null,
-  resolvedByUserId: null,
-  winningOutcomeId: null,
-  totalVolume: 0,
-  supplementaryBonusPool: 0,
-  supplementaryBonusDistributedAt: null,
-  supplementaryBonusExpiredAt: null,
-  createdAt: new Date('2099-03-29T00:00:00.000Z'),
-  updatedAt: new Date('2099-03-29T00:00:00.000Z'),
-  winningOutcome: null,
-  outcomes: [
-    { id: 'outcome_yes', marketId: 'market_1', label: 'Yes', sortOrder: 0, outstandingShares: 0, pricingShares: 0, settlementValue: null, resolvedAt: null, resolvedByUserId: null, resolutionNote: null, resolutionEvidenceUrl: null, createdAt: new Date('2099-03-29T00:00:00.000Z') },
-    { id: 'outcome_no', marketId: 'market_1', label: 'No', sortOrder: 1, outstandingShares: 0, pricingShares: 0, settlementValue: null, resolvedAt: null, resolvedByUserId: null, resolutionNote: null, resolutionEvidenceUrl: null, createdAt: new Date('2099-03-29T00:00:00.000Z') },
-  ],
-  trades: [],
-  positions: [],
-  liquidityEvents: [],
+	id: "market_1",
+	guildId: "guild_1",
+	creatorId: "user_1",
+	originChannelId: "origin_channel_1",
+	marketChannelId: "market_channel_1",
+	messageId: "message_market_1",
+	threadId: null,
+	title: "Will turnout exceed 40%?",
+	description: "A test market",
+	buttonStyle: "primary" as const,
+	tags: ["meta"],
+	liquidityParameter: 150,
+	baseLiquidityParameter: 150,
+	maxLiquidityParameter: 450,
+	lastLiquidityInjectionAt: null,
+	closeAt: new Date("2099-03-30T00:00:00.000Z"),
+	tradingClosedAt: null,
+	resolutionGraceEndsAt: null,
+	graceNotifiedAt: null,
+	resolvedAt: null,
+	cancelledAt: null,
+	resolutionNote: null,
+	resolutionEvidenceUrl: null,
+	resolvedByUserId: null,
+	winningOutcomeId: null,
+	totalVolume: 0,
+	supplementaryBonusPool: 0,
+	supplementaryBonusDistributedAt: null,
+	supplementaryBonusExpiredAt: null,
+	createdAt: new Date("2099-03-29T00:00:00.000Z"),
+	updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+	winningOutcome: null,
+	outcomes: [
+		{
+			id: "outcome_yes",
+			marketId: "market_1",
+			label: "Yes",
+			sortOrder: 0,
+			outstandingShares: 0,
+			pricingShares: 0,
+			settlementValue: null,
+			resolvedAt: null,
+			resolvedByUserId: null,
+			resolutionNote: null,
+			resolutionEvidenceUrl: null,
+			createdAt: new Date("2099-03-29T00:00:00.000Z"),
+		},
+		{
+			id: "outcome_no",
+			marketId: "market_1",
+			label: "No",
+			sortOrder: 1,
+			outstandingShares: 0,
+			pricingShares: 0,
+			settlementValue: null,
+			resolvedAt: null,
+			resolvedByUserId: null,
+			resolutionNote: null,
+			resolutionEvidenceUrl: null,
+			createdAt: new Date("2099-03-29T00:00:00.000Z"),
+		},
+	],
+	trades: [],
+	positions: [],
+	liquidityEvents: [],
 };
 
 const baseAccount = {
-  id: 'account_1',
-  guildConfigId: 'guild_config_1',
-  guildId: 'guild_1',
-  userId: 'user_1',
-  bankroll: 1_000,
-  realizedProfit: 0,
-  lastTopUpAt: null,
-  createdAt: new Date('2099-03-29T00:00:00.000Z'),
-  updatedAt: new Date('2099-03-29T00:00:00.000Z'),
+	id: "account_1",
+	guildConfigId: "guild_config_1",
+	guildId: "guild_1",
+	userId: "user_1",
+	bankroll: 1_000,
+	realizedProfit: 0,
+	lastTopUpAt: null,
+	createdAt: new Date("2099-03-29T00:00:00.000Z"),
+	updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+};
+
+const createTradeQuote = (overrides: Record<string, unknown> = {}) => ({
+	action: "buy",
+	marketId: "market_1",
+	marketTitle: baseMarket.title,
+	outcomeId: "outcome_yes",
+	outcomeLabel: "Yes",
+	userId: "user_1",
+	guildId: "guild_1",
+	amount: 25,
+	amountMode: "points",
+	rawAmount: "25",
+	shares: 12.5,
+	averagePrice: 2,
+	currentProbability: 0.5,
+	nextProbability: 0.56,
+	immediateCash: 25,
+	grossImmediateCash: 25,
+	netImmediateCash: 25,
+	feeCharged: 0,
+	collateralLocked: 0,
+	collateralReleased: 0,
+	netBankrollChange: -25,
+	bankrollAfter: 975,
+	positionSide: "long",
+	positionSharesAfter: 12.5,
+	positionCostBasisAfter: 25,
+	positionProceedsAfter: 0,
+	positionCollateralAfter: 0,
+	realizedProfitDelta: 0,
+	settlementIfChosen: 12.5,
+	settlementIfNotChosen: 0,
+	maxProfitIfChosen: -12.5,
+	maxProfitIfNotChosen: 0,
+	maxLossIfChosen: 0,
+	maxLossIfNotChosen: 25,
+	...overrides,
+});
+
+const baseForecastProfile = {
+	userId: "user_1",
+	allTimeMeanBrier: 0.1234,
+	thirtyDayMeanBrier: 0.101,
+	allTimeSampleCount: 12,
+	thirtyDaySampleCount: 4,
+	percentileRank: 88,
+	rank: 2,
+	rankedUserCount: 12,
+	currentCorrectPickStreak: 3,
+	bestCorrectPickStreak: 5,
+	currentProfitableMarketStreak: 2,
+	bestProfitableMarketStreak: 4,
+	calibrationBuckets: [],
+	topTags: [],
+	recentRecords: [
+		{
+			marketId: "market_1",
+			marketTitle: "Will turnout exceed 40%?",
+			resolvedAt: new Date("2099-03-31T00:00:00.000Z"),
+			brierScore: 0.14,
+			realizedProfit: 4.25,
+			wasCorrect: true,
+			predictedOutcomeId: "outcome_yes",
+			winningOutcomeId: "outcome_yes",
+			winningOutcomeProbability: 0.72,
+			tradeCount: 3,
+			stakeWeight: 80,
+			tags: ["meta"],
+		},
+	],
+	brierTrend: [
+		{
+			time: new Date("2099-03-31T00:00:00.000Z").getTime(),
+			brierScore: 0.14,
+			realizedProfit: 4.25,
+			cumulativeProfit: 4.25,
+		},
+	],
+	profitTrend: [
+		{
+			time: new Date("2099-03-31T00:00:00.000Z").getTime(),
+			brierScore: 0.14,
+			realizedProfit: 4.25,
+			cumulativeProfit: 4.25,
+		},
+	],
 };
 
 const createInteraction = (options: {
-  subcommand: string;
-  subcommandGroup?: string | null;
-  strings?: Record<string, string | null>;
-  numbers?: Record<string, number | null>;
-  users?: Record<string, { id: string; send?: ReturnType<typeof vi.fn> } | null>;
-  channels?: Record<string, { id: string; isTextBased: () => boolean; type?: number } | null>;
-  canManageGuild?: boolean;
+	subcommand: string;
+	subcommandGroup?: string | null;
+	strings?: Record<string, string | null>;
+	numbers?: Record<string, number | null>;
+	users?: Record<
+		string,
+		{
+			id: string;
+			send?: ReturnType<typeof vi.fn>;
+			displayName?: string;
+			globalName?: string | null;
+			username?: string;
+			displayAvatarURL?: ReturnType<typeof vi.fn>;
+		} | null
+	>;
+	channels?: Record<
+		string,
+		{ id: string; isTextBased: () => boolean; type?: number } | null
+	>;
+	canManageGuild?: boolean;
 }) => {
-  const strings = options.strings ?? {};
-  const numbers = options.numbers ?? {};
-  const users = options.users ?? {};
-  const channels = options.channels ?? {};
+	const strings = options.strings ?? {};
+	const numbers = options.numbers ?? {};
+	const users = options.users ?? {};
+	const channels = options.channels ?? {};
 
-  return {
-    inGuild: () => true,
-    guildId: 'guild_1',
-    channelId: 'origin_channel_1',
-    user: {
-      id: 'user_1',
-    },
-    memberPermissions: {
-      has: vi.fn(() => options.canManageGuild ?? false),
-    },
-    options: {
-      getSubcommandGroup: vi.fn(() => options.subcommandGroup ?? null),
-      getSubcommand: vi.fn(() => options.subcommand),
-      getChannel: vi.fn((name: string) => channels[name] ?? null),
-      getString: vi.fn((name: string, required?: boolean) => {
-        const value = strings[name];
-        if (required && (value === null || value === undefined)) {
-          throw new Error(`Missing required string option ${name}`);
-        }
+	return {
+		inGuild: () => true,
+		guildId: "guild_1",
+		channelId: "origin_channel_1",
+		user: {
+			id: "user_1",
+			displayName: "User One",
+			globalName: "User One",
+			username: "userone",
+			displayAvatarURL: vi.fn(() => "https://cdn.discordapp.test/avatar.png"),
+		},
+		memberPermissions: {
+			has: vi.fn(() => options.canManageGuild ?? false),
+		},
+		options: {
+			getSubcommandGroup: vi.fn(() => options.subcommandGroup ?? null),
+			getSubcommand: vi.fn(() => options.subcommand),
+			getChannel: vi.fn((name: string) => channels[name] ?? null),
+			getString: vi.fn((name: string, required?: boolean) => {
+				const value = strings[name];
+				if (required && (value === null || value === undefined)) {
+					throw new Error(`Missing required string option ${name}`);
+				}
 
-        return value ?? null;
-      }),
-      getUser: vi.fn((name: string, required?: boolean) => {
-        const value = users[name];
-        if (required && !value) {
-          throw new Error(`Missing required user option ${name}`);
-        }
+				return value ?? null;
+			}),
+			getUser: vi.fn((name: string, required?: boolean) => {
+				const value = users[name];
+				if (required && !value) {
+					throw new Error(`Missing required user option ${name}`);
+				}
 
-        return value ?? null;
-      }),
-      getNumber: vi.fn((name: string, required?: boolean) => {
-        const value = numbers[name];
-        if (required && (value === null || value === undefined)) {
-          throw new Error(`Missing required number option ${name}`);
-        }
+				return value ?? null;
+			}),
+			getNumber: vi.fn((name: string, required?: boolean) => {
+				const value = numbers[name];
+				if (required && (value === null || value === undefined)) {
+					throw new Error(`Missing required number option ${name}`);
+				}
 
-        return value ?? null;
-      }),
-      getInteger: vi.fn(() => null),
-    },
-    reply: vi.fn(),
-    deferReply: vi.fn(),
-    editReply: vi.fn(),
-  };
+				return value ?? null;
+			}),
+			getInteger: vi.fn(() => null),
+		},
+		reply: vi.fn(),
+		deferReply: vi.fn(),
+		editReply: vi.fn(),
+	};
 };
 
 const createButtonInteraction = (customId: string) => ({
-  customId,
-  user: {
-    id: 'user_1',
-  },
-  showModal: vi.fn(),
-  reply: vi.fn(),
-  update: vi.fn(),
-  deferUpdate: vi.fn(),
+	customId,
+	user: {
+		id: "user_1",
+	},
+	showModal: vi.fn(),
+	reply: vi.fn(),
+	update: vi.fn(),
+	deferUpdate: vi.fn(),
 });
 
-describe('market interactions', () => {
-  beforeEach(() => {
-    env.DISCORD_ADMIN_USER_IDS = [...defaultAdminUserIds];
-    loggerWarn.mockReset();
-    getMarketConfig.mockReset();
-    setMarketConfig.mockReset();
-    disableMarketConfig.mockReset();
-    createMarketRecord.mockReset();
-    deleteMarketRecord.mockReset();
-    hydrateMarketMessage.mockReset();
-  scheduleMarketClose.mockReset();
-    scheduleMarketLiquidity.mockReset();
-    clearMarketJobs.mockReset();
-    appendMarketOutcomes.mockReset();
-    editMarketRecord.mockReset();
-    listMarkets.mockReset();
-    getMarketLeaderboard.mockReset();
-    getMarketAccountSummary.mockReset();
-    grantMarketBankroll.mockReset();
-    getMarketByQuery.mockReset();
-    getMarketById.mockReset();
-    summarizeMarketTraders.mockReset();
-    calculateMarketTradeQuote.mockReset();
-    getMarketForecastProfile.mockReset();
-    getMarketForecastLeaderboard.mockReset();
-    executeMarketTrade.mockReset();
-    resolveMarket.mockReset();
-    resolveMarketOutcome.mockReset();
-    cancelMarket.mockReset();
-    scheduleMarketRefresh.mockReset();
-    refreshMarketMessage.mockReset();
-    announceMarketUpdate.mockReset();
-    notifyMarketResolved.mockReset();
-    saveMarketTradeQuoteSession.mockReset();
-    getMarketTradeQuoteSession.mockReset();
-    deleteMarketTradeQuoteSession.mockReset();
-
-    getMarketConfig.mockResolvedValue({
-      enabled: true,
-      channelId: 'market_channel_1',
-    });
-    createMarketRecord.mockResolvedValue(baseMarket);
-    appendMarketOutcomes.mockResolvedValue({
-      ...baseMarket,
-      outcomes: [
-        ...baseMarket.outcomes,
-        {
-          id: 'outcome_maybe',
-          marketId: 'market_1',
-          label: 'Maybe',
-          sortOrder: 2,
-          outstandingShares: 0,
-          pricingShares: 0,
-          settlementValue: null,
-          resolvedAt: null,
-          resolvedByUserId: null,
-          resolutionNote: null,
-          resolutionEvidenceUrl: null,
-          createdAt: new Date('2099-03-29T00:00:00.000Z'),
-        },
-      ],
-    });
-    hydrateMarketMessage.mockResolvedValue({
-      messageId: 'message_market_1',
-      url: 'https://discord.com/channels/guild_1/market_channel_1/message_market_1',
-      threadCreated: true,
-      threadId: 'thread_1',
-      threadUrl: 'https://discord.com/channels/guild_1/thread_1',
-    });
-    deleteMarketRecord.mockResolvedValue(undefined);
-    setMarketConfig.mockResolvedValue({
-      marketEnabled: true,
-      marketChannelId: 'market_channel_1',
-    });
-    disableMarketConfig.mockResolvedValue({
-      marketEnabled: false,
-      marketChannelId: null,
-    });
-    calculateMarketTradeQuote.mockResolvedValue({
-      action: 'buy',
-      marketId: 'market_1',
-      marketTitle: baseMarket.title,
-      outcomeId: 'outcome_yes',
-      outcomeLabel: 'Yes',
-      userId: 'user_1',
-      guildId: 'guild_1',
-      amount: 50,
-      amountMode: 'points',
-      rawAmount: '50',
-      shares: 80,
-      averagePrice: 0.63,
-      immediateCash: 50,
-      collateralLocked: 0,
-      netBankrollChange: -50,
-      settlementIfChosen: 80,
-      settlementIfNotChosen: 0,
-      maxProfitIfChosen: 30,
-      maxProfitIfNotChosen: 0,
-      maxLossIfChosen: 0,
-      maxLossIfNotChosen: 50,
-    });
-    getMarketForecastProfile.mockResolvedValue({
-      userId: 'user_1',
-      allTimeMeanBrier: 0.1234,
-      thirtyDayMeanBrier: 0.101,
-      allTimeSampleCount: 12,
-      thirtyDaySampleCount: 4,
-      percentileRank: 88,
-      rank: 2,
-      rankedUserCount: 12,
-      currentCorrectPickStreak: 3,
-      bestCorrectPickStreak: 5,
-      currentProfitableMarketStreak: 2,
-      bestProfitableMarketStreak: 4,
-      calibrationBuckets: [],
-      topTags: [],
-    });
-    getMarketForecastLeaderboard.mockResolvedValue([
-      {
-        userId: 'user_1',
-        meanBrier: 0.1234,
-        sampleCount: 12,
-        correctPickRate: 0.75,
-        currentCorrectPickStreak: 3,
-      },
-    ]);
-    summarizeMarketTraders.mockReturnValue({
-      marketId: 'market_1',
-      marketTitle: baseMarket.title,
-      traderCount: 2,
-      totalSpent: 85,
-      entries: [
-        {
-          userId: 'user_2',
-          amountSpent: 60,
-          tradeCount: 2,
-          lastTradedAt: new Date('2099-03-29T01:00:00.000Z'),
-        },
-        {
-          userId: 'user_3',
-          amountSpent: 25,
-          tradeCount: 1,
-          lastTradedAt: new Date('2099-03-29T02:00:00.000Z'),
-        },
-      ],
-    });
-    saveMarketTradeQuoteSession.mockResolvedValue(undefined);
-    grantMarketBankroll.mockResolvedValue({
-      ...baseAccount,
-      userId: 'user_2',
-      bankroll: 1250,
-    });
-    getMarketTradeQuoteSession.mockResolvedValue({
-      sessionId: 'quote_session_1',
-      action: 'buy',
-      guildId: 'guild_1',
-      marketId: 'market_1',
-      marketTitle: baseMarket.title,
-      outcomeId: 'outcome_yes',
-      outcomeLabel: 'Yes',
-      userId: 'user_1',
-      rawAmount: '50',
-      amount: 50,
-      amountMode: 'points',
-      shares: 80,
-      averagePrice: 0.63,
-      immediateCash: 50,
-      collateralLocked: 0,
-      netBankrollChange: -50,
-      settlementIfChosen: 80,
-      settlementIfNotChosen: 0,
-      maxProfitIfChosen: 30,
-      maxProfitIfNotChosen: 0,
-      maxLossIfChosen: 0,
-      maxLossIfNotChosen: 50,
-      expiresAt: new Date('2099-03-29T01:00:00.000Z').toISOString(),
-    });
-    deleteMarketTradeQuoteSession.mockResolvedValue(undefined);
-    executeMarketTrade.mockResolvedValue({
-      market: baseMarket,
-      outcome: baseMarket.outcomes[0],
-      account: { ...baseAccount, bankroll: 950 },
-      positionSide: 'long',
-      shareDelta: 80,
-      cashAmount: 50,
-      realizedProfitDelta: 0,
-    });
-    resolveMarketOutcome.mockResolvedValue({
-      market: baseMarket,
-      outcome: baseMarket.outcomes[1],
-      payouts: [],
-    });
-    resolveMarket.mockResolvedValue({
-      market: {
-        ...baseMarket,
-        resolvedAt: new Date('2099-03-30T00:00:00.000Z'),
-        winningOutcomeId: 'outcome_yes',
-        winningOutcome: baseMarket.outcomes[0],
-      },
-      payouts: [],
-    });
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-    env.DISCORD_ADMIN_USER_IDS = [...defaultAdminUserIds];
-  });
-
-  it('stores the official market forum through config set', async () => {
-    const interaction = createInteraction({
-      subcommandGroup: 'config',
-      subcommand: 'set',
-      canManageGuild: true,
-      channels: {
-        channel: {
-          id: 'market_channel_1',
-          type: ChannelType.GuildForum,
-          isTextBased: () => true,
-        },
-      },
-    });
-
-    await handleMarketCommand({} as never, interaction as never);
-
-    expect(setMarketConfig).toHaveBeenCalledWith('guild_1', 'market_channel_1');
-    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
-      flags: 64,
-    }));
-  });
-
-  it('rejects non-forum market config channels', async () => {
-    const interaction = createInteraction({
-      subcommandGroup: 'config',
-      subcommand: 'set',
-      canManageGuild: true,
-      channels: {
-        channel: {
-          id: 'market_channel_1',
-          type: ChannelType.GuildText,
-          isTextBased: () => true,
-        },
-      },
-    });
-
-    await expect(handleMarketCommand({} as never, interaction as never)).rejects.toThrow(
-      'The official market channel must be a forum channel.',
-    );
-    expect(setMarketConfig).not.toHaveBeenCalled();
-  });
-
-  it('creates a market in the configured channel and replies publicly in the invoking channel', async () => {
-    const interaction = createInteraction({
-      subcommand: 'create',
-      strings: {
-        title: 'Will turnout exceed 40%?',
-        outcomes: 'Yes, No',
-        close: '24h',
-        description: 'A test market',
-        tags: 'meta,events',
-      },
-    });
-
-    await handleMarketCommand({} as never, interaction as never);
-
-    expect(createMarketRecord).toHaveBeenCalledWith(expect.objectContaining({
-      guildId: 'guild_1',
-      creatorId: 'user_1',
-      originChannelId: 'origin_channel_1',
-      marketChannelId: 'market_channel_1',
-      closeAt: expect.any(Date),
-    }));
-    expect(hydrateMarketMessage).toHaveBeenCalledWith({}, baseMarket);
-    expect(interaction.deferReply).toHaveBeenCalledWith();
-    expect(interaction.editReply).toHaveBeenCalledTimes(1);
-    expect(interaction.editReply.mock.calls[0]?.[0]).not.toHaveProperty('flags');
-    expect(interaction.editReply.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
-      embeds: expect.any(Array),
-    }));
-  });
-
-  it('accepts an absolute close time during market creation', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-03-30T12:00:00.000Z'));
-
-    const interaction = createInteraction({
-      subcommand: 'create',
-      strings: {
-        title: 'Will turnout exceed 40%?',
-        outcomes: 'Yes, No',
-        close: 'April 6 2026 10:00pm CDT',
-      },
-    });
-
-    await handleMarketCommand({} as never, interaction as never);
-
-    expect(createMarketRecord).toHaveBeenCalledWith(expect.objectContaining({
-      closeAt: expect.any(Date),
-    }));
-  });
-
-  it('passes the selected button style during market creation', async () => {
-    const interaction = createInteraction({
-      subcommand: 'create',
-      strings: {
-        title: 'Will turnout exceed 40%?',
-        outcomes: 'Yes, No',
-        close: '24h',
-        button_style: 'success',
-      },
-    });
-
-    await handleMarketCommand({} as never, interaction as never);
-
-    expect(createMarketRecord).toHaveBeenCalledWith(expect.objectContaining({
-      buttonStyle: 'success',
-    }));
-  });
-
-  it('allows editing close time and button style and announces the change', async () => {
-    const interaction = createInteraction({
-      subcommand: 'edit',
-      strings: {
-        query: 'market_1',
-        close: '48h',
-        button_style: 'danger',
-      },
-    });
-
-    getMarketByQuery.mockResolvedValue({
-      ...baseMarket,
-      trades: [
-        {
-          id: 'trade_1',
-          marketId: 'market_1',
-          outcomeId: 'outcome_yes',
-          userId: 'user_2',
-          side: 'buy' as const,
-          shareDelta: 2,
-          cashDelta: -10,
-          feeCharged: 0,
-          probabilitySnapshot: 0.5,
-          cumulativeVolume: 10,
-          createdAt: new Date('2099-03-29T01:00:00.000Z'),
-        },
-      ],
-    });
-    editMarketRecord.mockResolvedValue({
-      ...baseMarket,
-      buttonStyle: 'danger',
-      closeAt: new Date('2099-03-31T00:00:00.000Z'),
-    });
-
-    await handleMarketCommand({} as never, interaction as never);
-
-    expect(editMarketRecord).toHaveBeenCalledWith('market_1', 'user_1', expect.objectContaining({
-      closeAt: expect.any(Date),
-      buttonStyle: 'danger',
-    }));
-    expect(announceMarketUpdate).toHaveBeenCalledWith(
-      {},
-      expect.objectContaining({ id: 'market_1' }),
-      'Market Updated',
-      expect.stringContaining('Button style'),
-    );
-  });
-
-  it('resolves a specific outcome without closing the market', async () => {
-    const interaction = createInteraction({
-      subcommand: 'resolve-outcome',
-      strings: {
-        query: 'market_1',
-        outcome: 'No',
-        note: 'Eliminated in the semifinal.',
-        evidence_url: 'https://example.com/game',
-      },
-    });
-
-    getMarketByQuery.mockResolvedValue(baseMarket);
-
-    await handleMarketCommand({} as never, interaction as never);
-
-    expect(resolveMarketOutcome).toHaveBeenCalledWith(expect.objectContaining({
-      marketId: 'market_1',
-      actorId: 'user_1',
-      outcomeId: 'outcome_no',
-      note: 'Eliminated in the semifinal.',
-      evidenceUrl: 'https://example.com/game',
-    }));
-    expect(refreshMarketMessage).toHaveBeenCalledWith({}, 'market_1');
-    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
-      embeds: expect.any(Array),
-    }));
-  });
-
-  it('appends outcomes to an open market without resetting existing trades', async () => {
-    const interaction = createInteraction({
-      subcommand: 'add-outcomes',
-      strings: {
-        query: 'market_1',
-        outcomes: 'Maybe',
-      },
-    });
-
-    getMarketByQuery.mockResolvedValue(baseMarket);
-
-    await handleMarketCommand({} as never, interaction as never);
-
-    expect(appendMarketOutcomes).toHaveBeenCalledWith('market_1', 'user_1', ['Maybe']);
-    expect(refreshMarketMessage).toHaveBeenCalledWith({}, 'market_1');
-    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
-      embeds: expect.any(Array),
-    }));
-  });
-
-  it('cleans up the market record when publication fails', async () => {
-    const interaction = createInteraction({
-      subcommand: 'create',
-      strings: {
-        title: 'Will turnout exceed 40%?',
-        outcomes: 'Yes, No',
-        close: '24h',
-      },
-    });
-
-    hydrateMarketMessage.mockRejectedValue(new Error('Discord send failed'));
-
-    await expect(handleMarketCommand({} as never, interaction as never)).rejects.toThrow('Discord send failed');
-
-    expect(deleteMarketRecord).toHaveBeenCalledWith('market_1');
-    expect(interaction.reply).not.toHaveBeenCalled();
-  });
-
-  it('rejects non-http evidence URLs before resolving a market', async () => {
-    const interaction = createInteraction({
-      subcommand: 'resolve',
-      strings: {
-        query: 'market_1',
-        winning_outcome: '1',
-        evidence_url: 'javascript:alert(1)',
-      },
-    });
-
-    getMarketByQuery.mockResolvedValue(baseMarket);
-
-    await expect(handleMarketCommand({} as never, interaction as never)).rejects.toThrow(
-      'Evidence URL must be a valid http or https URL.',
-    );
-
-    expect(resolveMarket).not.toHaveBeenCalled();
-  });
-
-  it('shows a quote preview instead of executing a buy trade immediately', async () => {
-    const interaction = createInteraction({
-      subcommand: 'trade',
-      strings: {
-        query: 'market_1',
-        action: 'buy',
-        amount: '50',
-        outcome: 'Yes',
-      },
-    });
-
-    getMarketByQuery.mockResolvedValue(baseMarket);
-
-    await handleMarketCommand({} as never, interaction as never);
-
-    expect(calculateMarketTradeQuote).toHaveBeenCalledWith(expect.objectContaining({
-      marketId: 'market_1',
-      action: 'buy',
-      rawAmount: '50',
-    }));
-    expect(saveMarketTradeQuoteSession).toHaveBeenCalledTimes(1);
-    expect(executeMarketTrade).not.toHaveBeenCalled();
-    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
-      embeds: expect.any(Array),
-      components: expect.any(Array),
-    }));
-  });
-
-  it('shows a forecasting profile through /market profile', async () => {
-    const interaction = createInteraction({
-      subcommand: 'profile',
-    });
-
-    await handleMarketCommand({} as never, interaction as never);
-
-    expect(getMarketForecastProfile).toHaveBeenCalledWith('guild_1', 'user_1');
-    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
-      flags: 64,
-      embeds: expect.any(Array),
-    }));
-  });
-
-  it('shows all traders and their spend through /market traders', async () => {
-    const interaction = createInteraction({
-      subcommand: 'traders',
-      strings: {
-        query: 'market_1',
-      },
-    });
-
-    getMarketByQuery.mockResolvedValue(baseMarket);
-
-    await handleMarketCommand({} as never, interaction as never);
-
-    expect(getMarketByQuery).toHaveBeenCalledWith('market_1', 'guild_1');
-    expect(summarizeMarketTraders).toHaveBeenCalledWith(baseMarket);
-    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
-      flags: 64,
-      embeds: expect.any(Array),
-    }));
-  });
-
-  it('shows the forecast leaderboard when requested', async () => {
-    const interaction = createInteraction({
-      subcommand: 'leaderboard',
-      strings: {
-        board: 'forecast',
-        window: '30d',
-        tag: 'meta',
-      },
-    });
-
-    await handleMarketCommand({} as never, interaction as never);
-
-    expect(getMarketForecastLeaderboard).toHaveBeenCalledWith({
-      guildId: 'guild_1',
-      window: '30d',
-      tag: 'meta',
-    });
-    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
-      flags: 64,
-      embeds: expect.any(Array),
-    }));
-  });
-
-  it('returns paged leaderboard embeds when there are many entries', async () => {
-    const interaction = createInteraction({
-      subcommand: 'leaderboard',
-    });
-
-    getMarketLeaderboard.mockResolvedValue(
-      Array.from({ length: 12 }, (_, index) => ({
-        ...baseAccount,
-        userId: `user_${index + 1}`,
-        bankroll: 1000 - index,
-        realizedProfit: index,
-      })),
-    );
-
-    await handleMarketCommand({} as never, interaction as never);
-
-    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
-      flags: 64,
-      embeds: expect.arrayContaining([
-        expect.objectContaining({ data: expect.objectContaining({ title: expect.stringContaining('(1/2)') }) }),
-        expect.objectContaining({ data: expect.objectContaining({ title: expect.stringContaining('(2/2)') }) }),
-      ]),
-    }));
-  });
-
-  it('confirms a quoted trade from the preview buttons', async () => {
-    const interaction = createButtonInteraction('market:quote-confirm:quote_session_1');
-    executeMarketTrade.mockResolvedValue({
-      market: baseMarket,
-      outcome: baseMarket.outcomes[0],
-      account: { ...baseAccount, bankroll: 955 },
-      positionSide: 'long',
-      shareDelta: 70,
-      cashAmount: 45,
-      realizedProfitDelta: 0,
-    });
-
-    await handleMarketButton(interaction as never);
-
-    expect(getMarketTradeQuoteSession).toHaveBeenCalledWith({}, 'quote_session_1');
-    expect(executeMarketTrade).toHaveBeenCalledWith({
-      marketId: 'market_1',
-      userId: 'user_1',
-      outcomeId: 'outcome_yes',
-      action: 'buy',
-      amount: 50,
-      amountMode: 'points',
-    });
-    expect(deleteMarketTradeQuoteSession).toHaveBeenCalledWith({}, 'quote_session_1');
-    expect(interaction.update).toHaveBeenCalledWith(expect.objectContaining({
-      embeds: expect.any(Array),
-      components: [],
-    }));
-    const updatePayload = interaction.update.mock.calls[0]?.[0];
-    expect(updatePayload.embeds[0].data.description).toContain('Spend: 45.00 pts');
-    expect(updatePayload.embeds[0].data.description).toContain('If Yes is chosen: 70.00 pts');
-  });
-
-  it('shows market details from the details button', async () => {
-    const interaction = createButtonInteraction('market:details:market_1');
-    getMarketById.mockResolvedValue(baseMarket);
-
-    await handleMarketButton(interaction as never);
-
-    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
-      flags: 64,
-      embeds: expect.any(Array),
-    }));
-  });
-
-  it('grants market currency to a user and DMs them', async () => {
-    const recipientSend = vi.fn().mockResolvedValue(undefined);
-    const interaction = createInteraction({
-      subcommand: 'grant',
-      numbers: {
-        amount: 250,
-      },
-      strings: {
-        reason: 'Won the seasonal tournament',
-      },
-      users: {
-        user: {
-          id: 'user_2',
-          send: recipientSend,
-        },
-      },
-    });
-
-    await handleMarketCommand({} as never, interaction as never);
-
-    expect(grantMarketBankroll).toHaveBeenCalledWith({
-      guildId: 'guild_1',
-      userId: 'user_2',
-      amount: 250,
-    });
-    expect(recipientSend).toHaveBeenCalledWith(expect.objectContaining({
-      embeds: expect.any(Array),
-    }));
-    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
-      flags: 64,
-      embeds: expect.any(Array),
-    }));
-  });
-
-  it('logs when a grant DM cannot be delivered', async () => {
-    const interaction = createInteraction({
-      subcommand: 'grant',
-      numbers: {
-        amount: 250,
-      },
-      strings: {
-        reason: 'Won the seasonal tournament',
-      },
-      users: {
-        user: {
-          id: 'user_2',
-          send: vi.fn().mockRejectedValue(new Error('DMs closed')),
-        },
-      },
-    });
-
-    await handleMarketCommand({} as never, interaction as never);
-
-    expect(loggerWarn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        recipientUserId: 'user_2',
-        adminUserId: 'user_1',
-      }),
-      'Could not DM market grant recipient',
-    );
-  });
-
-  it('rejects non-admin users who try to grant market currency', async () => {
-    env.DISCORD_ADMIN_USER_IDS = ['someone_else'];
-    const interaction = createInteraction({
-      subcommand: 'grant',
-      numbers: {
-        amount: 50,
-      },
-      strings: {
-        reason: 'Test grant',
-      },
-      users: {
-        user: {
-          id: 'user_2',
-          send: vi.fn(),
-        },
-      },
-    });
-
-    await expect(handleMarketCommand({} as never, interaction as never)).rejects.toThrow(
-      'Only configured admin user IDs can grant market currency.',
-    );
-
-    expect(grantMarketBankroll).not.toHaveBeenCalled();
-  });
+const createStringSelectInteraction = (customId: string, values: string[]) => ({
+	customId,
+	values,
+	user: {
+		id: "user_1",
+	},
+	showModal: vi.fn(),
+	update: vi.fn(),
+});
+
+const createModalInteraction = (customId: string, amount = "25") => ({
+	customId,
+	user: {
+		id: "user_1",
+	},
+	fields: {
+		getTextInputValue: vi.fn((name: string) =>
+			name === "amount" ? amount : "",
+		),
+	},
+	memberPermissions: null,
+	inGuild: () => true,
+	reply: vi.fn(),
+});
+
+describe("market interactions", () => {
+	beforeEach(() => {
+		env.DISCORD_ADMIN_USER_IDS = [...defaultAdminUserIds];
+		loggerWarn.mockReset();
+		getMarketConfig.mockReset();
+		setMarketConfig.mockReset();
+		disableMarketConfig.mockReset();
+		createMarketRecord.mockReset();
+		deleteMarketRecord.mockReset();
+		hydrateMarketMessage.mockReset();
+		scheduleMarketClose.mockReset();
+		scheduleMarketLiquidity.mockReset();
+		clearMarketJobs.mockReset();
+		appendMarketOutcomes.mockReset();
+		editMarketRecord.mockReset();
+		listMarkets.mockReset();
+		getMarketLeaderboard.mockReset();
+		getMarketAccountSummary.mockReset();
+		grantMarketBankroll.mockReset();
+		getMarketByQuery.mockReset();
+		getMarketById.mockReset();
+		summarizeMarketTraders.mockReset();
+		calculateMarketTradeQuote.mockReset();
+		getMarketForecastProfileDetails.mockReset();
+		getMarketForecastLeaderboard.mockReset();
+		executeMarketTrade.mockReset();
+		resolveMarket.mockReset();
+		resolveMarketOutcome.mockReset();
+		cancelMarket.mockReset();
+		scheduleMarketRefresh.mockReset();
+		refreshMarketMessage.mockReset();
+		announceMarketUpdate.mockReset();
+		notifyMarketResolved.mockReset();
+		saveMarketTradeQuoteSession.mockReset();
+		getMarketTradeQuoteSession.mockReset();
+		deleteMarketTradeQuoteSession.mockReset();
+		createMarketInteractionSessionId.mockReset();
+		saveMarketInteractionSession.mockReset();
+		getMarketInteractionSession.mockReset();
+		deleteMarketInteractionSession.mockReset();
+		calculateLossProtectionQuote.mockReset();
+		purchaseLossProtection.mockReset();
+		getProtectableLongPositions.mockReset();
+		buildMarketForecastProfileDiagram.mockReset();
+
+		createMarketInteractionSessionId.mockReturnValue("session_1");
+		getProtectableLongPositions.mockReturnValue([]);
+		calculateMarketTradeQuote.mockResolvedValue(createTradeQuote());
+
+		getMarketConfig.mockResolvedValue({
+			enabled: true,
+			channelId: "market_channel_1",
+		});
+		createMarketRecord.mockResolvedValue(baseMarket);
+		appendMarketOutcomes.mockResolvedValue({
+			...baseMarket,
+			outcomes: [
+				...baseMarket.outcomes,
+				{
+					id: "outcome_maybe",
+					marketId: "market_1",
+					label: "Maybe",
+					sortOrder: 2,
+					outstandingShares: 0,
+					pricingShares: 0,
+					settlementValue: null,
+					resolvedAt: null,
+					resolvedByUserId: null,
+					resolutionNote: null,
+					resolutionEvidenceUrl: null,
+					createdAt: new Date("2099-03-29T00:00:00.000Z"),
+				},
+			],
+		});
+		hydrateMarketMessage.mockResolvedValue({
+			messageId: "message_market_1",
+			url: "https://discord.com/channels/guild_1/market_channel_1/message_market_1",
+			threadCreated: true,
+			threadId: "thread_1",
+			threadUrl: "https://discord.com/channels/guild_1/thread_1",
+		});
+		deleteMarketRecord.mockResolvedValue(undefined);
+		setMarketConfig.mockResolvedValue({
+			marketEnabled: true,
+			marketChannelId: "market_channel_1",
+		});
+		disableMarketConfig.mockResolvedValue({
+			marketEnabled: false,
+			marketChannelId: null,
+		});
+		calculateMarketTradeQuote.mockResolvedValue({
+			action: "buy",
+			marketId: "market_1",
+			marketTitle: baseMarket.title,
+			outcomeId: "outcome_yes",
+			outcomeLabel: "Yes",
+			userId: "user_1",
+			guildId: "guild_1",
+			amount: 50,
+			amountMode: "points",
+			rawAmount: "50",
+			shares: 80,
+			averagePrice: 0.63,
+			immediateCash: 50,
+			collateralLocked: 0,
+			netBankrollChange: -50,
+			settlementIfChosen: 80,
+			settlementIfNotChosen: 0,
+			maxProfitIfChosen: 30,
+			maxProfitIfNotChosen: 0,
+			maxLossIfChosen: 0,
+			maxLossIfNotChosen: 50,
+		});
+		getMarketForecastProfileDetails.mockResolvedValue(baseForecastProfile);
+		getMarketForecastLeaderboard.mockResolvedValue([
+			{
+				userId: "user_1",
+				meanBrier: 0.1234,
+				sampleCount: 12,
+				correctPickRate: 0.75,
+				currentCorrectPickStreak: 3,
+			},
+		]);
+		buildMarketForecastProfileDiagram.mockResolvedValue({
+			fileName: "market-profile-user_1.png",
+			attachment: { name: "market-profile-user_1.png" },
+		});
+		summarizeMarketTraders.mockReturnValue({
+			marketId: "market_1",
+			marketTitle: baseMarket.title,
+			traderCount: 2,
+			totalSpent: 85,
+			entries: [
+				{
+					userId: "user_2",
+					amountSpent: 60,
+					tradeCount: 2,
+					lastTradedAt: new Date("2099-03-29T01:00:00.000Z"),
+				},
+				{
+					userId: "user_3",
+					amountSpent: 25,
+					tradeCount: 1,
+					lastTradedAt: new Date("2099-03-29T02:00:00.000Z"),
+				},
+			],
+		});
+		saveMarketTradeQuoteSession.mockResolvedValue(undefined);
+		grantMarketBankroll.mockResolvedValue({
+			...baseAccount,
+			userId: "user_2",
+			bankroll: 1250,
+		});
+		getMarketTradeQuoteSession.mockResolvedValue({
+			sessionId: "quote_session_1",
+			action: "buy",
+			guildId: "guild_1",
+			marketId: "market_1",
+			marketTitle: baseMarket.title,
+			outcomeId: "outcome_yes",
+			outcomeLabel: "Yes",
+			userId: "user_1",
+			rawAmount: "50",
+			amount: 50,
+			amountMode: "points",
+			shares: 80,
+			averagePrice: 0.63,
+			immediateCash: 50,
+			collateralLocked: 0,
+			netBankrollChange: -50,
+			settlementIfChosen: 80,
+			settlementIfNotChosen: 0,
+			maxProfitIfChosen: 30,
+			maxProfitIfNotChosen: 0,
+			maxLossIfChosen: 0,
+			maxLossIfNotChosen: 50,
+			expiresAt: new Date("2099-03-29T01:00:00.000Z").toISOString(),
+		});
+		deleteMarketTradeQuoteSession.mockResolvedValue(undefined);
+		executeMarketTrade.mockResolvedValue({
+			market: baseMarket,
+			outcome: baseMarket.outcomes[0],
+			account: { ...baseAccount, bankroll: 950 },
+			positionSide: "long",
+			shareDelta: 80,
+			cashAmount: 50,
+			realizedProfitDelta: 0,
+		});
+		resolveMarketOutcome.mockResolvedValue({
+			market: baseMarket,
+			outcome: baseMarket.outcomes[1],
+			payouts: [],
+		});
+		resolveMarket.mockResolvedValue({
+			market: {
+				...baseMarket,
+				resolvedAt: new Date("2099-03-30T00:00:00.000Z"),
+				winningOutcomeId: "outcome_yes",
+				winningOutcome: baseMarket.outcomes[0],
+			},
+			payouts: [],
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		env.DISCORD_ADMIN_USER_IDS = [...defaultAdminUserIds];
+	});
+
+	it("stores the official market forum through config set", async () => {
+		const interaction = createInteraction({
+			subcommandGroup: "config",
+			subcommand: "set",
+			canManageGuild: true,
+			channels: {
+				channel: {
+					id: "market_channel_1",
+					type: ChannelType.GuildForum,
+					isTextBased: () => true,
+				},
+			},
+		});
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(setMarketConfig).toHaveBeenCalledWith("guild_1", "market_channel_1");
+		expect(interaction.reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				flags: 64,
+			}),
+		);
+	});
+
+	it("rejects non-forum market config channels", async () => {
+		const interaction = createInteraction({
+			subcommandGroup: "config",
+			subcommand: "set",
+			canManageGuild: true,
+			channels: {
+				channel: {
+					id: "market_channel_1",
+					type: ChannelType.GuildText,
+					isTextBased: () => true,
+				},
+			},
+		});
+
+		await expect(
+			handleMarketCommand({} as never, interaction as never),
+		).rejects.toThrow("The official market channel must be a forum channel.");
+		expect(setMarketConfig).not.toHaveBeenCalled();
+	});
+
+	it("creates a market in the configured channel and replies publicly in the invoking channel", async () => {
+		const interaction = createInteraction({
+			subcommand: "create",
+			strings: {
+				title: "Will turnout exceed 40%?",
+				outcomes: "Yes, No",
+				close: "24h",
+				description: "A test market",
+				tags: "meta,events",
+			},
+		});
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(createMarketRecord).toHaveBeenCalledWith(
+			expect.objectContaining({
+				guildId: "guild_1",
+				creatorId: "user_1",
+				originChannelId: "origin_channel_1",
+				marketChannelId: "market_channel_1",
+				closeAt: expect.any(Date),
+			}),
+		);
+		expect(hydrateMarketMessage).toHaveBeenCalledWith({}, baseMarket);
+		expect(interaction.deferReply).toHaveBeenCalledWith();
+		expect(interaction.editReply).toHaveBeenCalledTimes(1);
+		expect(interaction.editReply.mock.calls[0]?.[0]).not.toHaveProperty(
+			"flags",
+		);
+		expect(interaction.editReply.mock.calls[0]?.[0]).toEqual(
+			expect.objectContaining({
+				embeds: expect.any(Array),
+			}),
+		);
+	});
+
+	it("accepts an absolute close time during market creation", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-03-30T12:00:00.000Z"));
+
+		const interaction = createInteraction({
+			subcommand: "create",
+			strings: {
+				title: "Will turnout exceed 40%?",
+				outcomes: "Yes, No",
+				close: "April 6 2026 10:00pm CDT",
+			},
+		});
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(createMarketRecord).toHaveBeenCalledWith(
+			expect.objectContaining({
+				closeAt: expect.any(Date),
+			}),
+		);
+	});
+
+	it("passes the selected button style during market creation", async () => {
+		const interaction = createInteraction({
+			subcommand: "create",
+			strings: {
+				title: "Will turnout exceed 40%?",
+				outcomes: "Yes, No",
+				close: "24h",
+				button_style: "success",
+			},
+		});
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(createMarketRecord).toHaveBeenCalledWith(
+			expect.objectContaining({
+				buttonStyle: "success",
+			}),
+		);
+	});
+
+	it("allows editing close time and button style and announces the change", async () => {
+		const interaction = createInteraction({
+			subcommand: "edit",
+			strings: {
+				query: "market_1",
+				close: "48h",
+				button_style: "danger",
+			},
+		});
+
+		getMarketByQuery.mockResolvedValue({
+			...baseMarket,
+			trades: [
+				{
+					id: "trade_1",
+					marketId: "market_1",
+					outcomeId: "outcome_yes",
+					userId: "user_2",
+					side: "buy" as const,
+					shareDelta: 2,
+					cashDelta: -10,
+					feeCharged: 0,
+					probabilitySnapshot: 0.5,
+					cumulativeVolume: 10,
+					createdAt: new Date("2099-03-29T01:00:00.000Z"),
+				},
+			],
+		});
+		editMarketRecord.mockResolvedValue({
+			...baseMarket,
+			buttonStyle: "danger",
+			closeAt: new Date("2099-03-31T00:00:00.000Z"),
+		});
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(editMarketRecord).toHaveBeenCalledWith(
+			"market_1",
+			"user_1",
+			expect.objectContaining({
+				closeAt: expect.any(Date),
+				buttonStyle: "danger",
+			}),
+		);
+		expect(announceMarketUpdate).toHaveBeenCalledWith(
+			{},
+			expect.objectContaining({ id: "market_1" }),
+			"Market Updated",
+			expect.stringContaining("Button style"),
+		);
+	});
+
+	it("resolves a specific outcome without closing the market", async () => {
+		const interaction = createInteraction({
+			subcommand: "resolve-outcome",
+			strings: {
+				query: "market_1",
+				outcome: "No",
+				note: "Eliminated in the semifinal.",
+				evidence_url: "https://example.com/game",
+			},
+		});
+
+		getMarketByQuery.mockResolvedValue(baseMarket);
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(resolveMarketOutcome).toHaveBeenCalledWith(
+			expect.objectContaining({
+				marketId: "market_1",
+				actorId: "user_1",
+				outcomeId: "outcome_no",
+				note: "Eliminated in the semifinal.",
+				evidenceUrl: "https://example.com/game",
+			}),
+		);
+		expect(refreshMarketMessage).toHaveBeenCalledWith({}, "market_1");
+		expect(interaction.editReply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				embeds: expect.any(Array),
+			}),
+		);
+	});
+
+	it("appends outcomes to an open market without resetting existing trades", async () => {
+		const interaction = createInteraction({
+			subcommand: "add-outcomes",
+			strings: {
+				query: "market_1",
+				outcomes: "Maybe",
+			},
+		});
+
+		getMarketByQuery.mockResolvedValue(baseMarket);
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(appendMarketOutcomes).toHaveBeenCalledWith("market_1", "user_1", [
+			"Maybe",
+		]);
+		expect(refreshMarketMessage).toHaveBeenCalledWith({}, "market_1");
+		expect(interaction.editReply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				embeds: expect.any(Array),
+			}),
+		);
+	});
+
+	it("cleans up the market record when publication fails", async () => {
+		const interaction = createInteraction({
+			subcommand: "create",
+			strings: {
+				title: "Will turnout exceed 40%?",
+				outcomes: "Yes, No",
+				close: "24h",
+			},
+		});
+
+		hydrateMarketMessage.mockRejectedValue(new Error("Discord send failed"));
+
+		await expect(
+			handleMarketCommand({} as never, interaction as never),
+		).rejects.toThrow("Discord send failed");
+
+		expect(deleteMarketRecord).toHaveBeenCalledWith("market_1");
+		expect(interaction.reply).not.toHaveBeenCalled();
+	});
+
+	it("rejects non-http evidence URLs before resolving a market", async () => {
+		const interaction = createInteraction({
+			subcommand: "resolve",
+			strings: {
+				query: "market_1",
+				winning_outcome: "1",
+				evidence_url: "javascript:alert(1)",
+			},
+		});
+
+		getMarketByQuery.mockResolvedValue(baseMarket);
+
+		await expect(
+			handleMarketCommand({} as never, interaction as never),
+		).rejects.toThrow("Evidence URL must be a valid http or https URL.");
+
+		expect(resolveMarket).not.toHaveBeenCalled();
+	});
+
+	it("shows a quote preview instead of executing a buy trade immediately", async () => {
+		const interaction = createInteraction({
+			subcommand: "trade",
+			strings: {
+				query: "market_1",
+				action: "buy",
+				amount: "50",
+				outcome: "Yes",
+			},
+		});
+
+		getMarketByQuery.mockResolvedValue(baseMarket);
+		calculateMarketTradeQuote.mockResolvedValue(
+			createTradeQuote({
+				amount: 50,
+				rawAmount: "50",
+				shares: 25,
+				immediateCash: 50,
+				grossImmediateCash: 50,
+				netImmediateCash: 50,
+				netBankrollChange: -50,
+				bankrollAfter: 950,
+				positionSharesAfter: 25,
+				positionCostBasisAfter: 50,
+				settlementIfChosen: 25,
+				maxProfitIfChosen: -25,
+				maxLossIfNotChosen: 50,
+			}),
+		);
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(calculateMarketTradeQuote).toHaveBeenCalledWith(
+			expect.objectContaining({
+				marketId: "market_1",
+				action: "buy",
+				rawAmount: "50",
+			}),
+		);
+		expect(saveMarketTradeQuoteSession).toHaveBeenCalledTimes(1);
+		expect(executeMarketTrade).not.toHaveBeenCalled();
+		expect(interaction.editReply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				embeds: expect.any(Array),
+				components: expect.any(Array),
+			}),
+		);
+	});
+
+	it("shows a forecasting profile through /market profile", async () => {
+		const interaction = createInteraction({
+			subcommand: "profile",
+		});
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(getMarketForecastProfileDetails).toHaveBeenCalledWith(
+			"guild_1",
+			"user_1",
+		);
+		expect(buildMarketForecastProfileDiagram).toHaveBeenCalledWith(
+			baseForecastProfile,
+			expect.objectContaining({
+				displayName: "User One",
+				avatarUrl: "https://cdn.discordapp.test/avatar.png",
+			}),
+		);
+		expect(interaction.reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				embeds: expect.arrayContaining([
+					expect.objectContaining({
+						data: expect.objectContaining({
+							image: expect.objectContaining({
+								url: "attachment://market-profile-user_1.png",
+							}),
+						}),
+					}),
+				]),
+				files: expect.any(Array),
+			}),
+		);
+	});
+
+	it("falls back to embeds only when the forecasting profile diagram fails", async () => {
+		const interaction = createInteraction({
+			subcommand: "profile",
+		});
+		buildMarketForecastProfileDiagram.mockRejectedValue(
+			new Error("Canvas failed"),
+		);
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(loggerWarn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				err: expect.any(Error),
+				guildId: "guild_1",
+				userId: "user_1",
+			}),
+			"Could not build market forecast profile diagram",
+		);
+		expect(interaction.reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				embeds: expect.any(Array),
+			}),
+		);
+	});
+
+	it("skips the forecasting profile diagram when there are no scored markets", async () => {
+		const interaction = createInteraction({
+			subcommand: "profile",
+		});
+		getMarketForecastProfileDetails.mockResolvedValue({
+			...baseForecastProfile,
+			allTimeMeanBrier: null,
+			thirtyDayMeanBrier: null,
+			allTimeSampleCount: 0,
+			thirtyDaySampleCount: 0,
+			rank: null,
+			percentileRank: null,
+			recentRecords: [],
+			brierTrend: [],
+			profitTrend: [],
+		});
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(buildMarketForecastProfileDiagram).not.toHaveBeenCalled();
+		expect(interaction.reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				embeds: expect.any(Array),
+			}),
+		);
+	});
+
+	it("shows all traders and their spend through /market traders", async () => {
+		const interaction = createInteraction({
+			subcommand: "traders",
+			strings: {
+				query: "market_1",
+			},
+		});
+
+		getMarketByQuery.mockResolvedValue(baseMarket);
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(getMarketByQuery).toHaveBeenCalledWith("market_1", "guild_1");
+		expect(summarizeMarketTraders).toHaveBeenCalledWith(baseMarket);
+		expect(interaction.reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				flags: 64,
+				embeds: expect.any(Array),
+			}),
+		);
+	});
+
+	it("shows the forecast leaderboard when requested", async () => {
+		const interaction = createInteraction({
+			subcommand: "leaderboard",
+			strings: {
+				board: "forecast",
+				window: "30d",
+				tag: "meta",
+			},
+		});
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(getMarketForecastLeaderboard).toHaveBeenCalledWith({
+			guildId: "guild_1",
+			window: "30d",
+			tag: "meta",
+		});
+		expect(interaction.reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				flags: 64,
+				embeds: expect.any(Array),
+			}),
+		);
+	});
+
+	it("returns paged leaderboard embeds when there are many entries", async () => {
+		const interaction = createInteraction({
+			subcommand: "leaderboard",
+		});
+
+		getMarketLeaderboard.mockResolvedValue(
+			Array.from({ length: 12 }, (_, index) => ({
+				...baseAccount,
+				userId: `user_${index + 1}`,
+				bankroll: 1000 - index,
+				realizedProfit: index,
+			})),
+		);
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(interaction.reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				flags: 64,
+				embeds: expect.arrayContaining([
+					expect.objectContaining({
+						data: expect.objectContaining({
+							title: expect.stringContaining("(1/2)"),
+						}),
+					}),
+					expect.objectContaining({
+						data: expect.objectContaining({
+							title: expect.stringContaining("(2/2)"),
+						}),
+					}),
+				]),
+			}),
+		);
+	});
+
+	it("confirms a quoted trade from the preview buttons", async () => {
+		const interaction = createButtonInteraction(
+			"market:quote-confirm:quote_session_1",
+		);
+		executeMarketTrade.mockResolvedValue({
+			market: baseMarket,
+			outcome: baseMarket.outcomes[0],
+			account: { ...baseAccount, bankroll: 955 },
+			positionSide: "long",
+			shareDelta: 70,
+			cashAmount: 45,
+			realizedProfitDelta: 0,
+		});
+
+		await handleMarketButton(interaction as never);
+
+		expect(getMarketTradeQuoteSession).toHaveBeenCalledWith(
+			{},
+			"quote_session_1",
+		);
+		expect(executeMarketTrade).toHaveBeenCalledWith({
+			marketId: "market_1",
+			userId: "user_1",
+			outcomeId: "outcome_yes",
+			action: "buy",
+			amount: 50,
+			amountMode: "points",
+		});
+		expect(deleteMarketTradeQuoteSession).toHaveBeenCalledWith(
+			{},
+			"quote_session_1",
+		);
+		expect(interaction.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				embeds: expect.any(Array),
+				components: [],
+			}),
+		);
+		const updatePayload = interaction.update.mock.calls[0]?.[0];
+		expect(updatePayload.embeds[0].data.description).toContain(
+			"Spend: 45.00 pts",
+		);
+		expect(updatePayload.embeds[0].data.description).toContain(
+			"If Yes is chosen: 70.00 pts",
+		);
+	});
+
+	it("opens a root trade session from the public trade button", async () => {
+		const interaction = createButtonInteraction("market:trade:market_1");
+		getMarketById.mockResolvedValue(baseMarket);
+
+		await handleMarketButton(interaction as never);
+
+		expect(saveMarketInteractionSession).toHaveBeenCalledWith(
+			{},
+			"session_1",
+			expect.objectContaining({
+				marketId: "market_1",
+				mode: "trade",
+				selectedAction: "buy",
+			}),
+		);
+		expect(interaction.reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				flags: 64,
+				embeds: expect.any(Array),
+				components: expect.any(Array),
+			}),
+		);
+		const replyPayload = interaction.reply.mock.calls[0]?.[0];
+		expect(replyPayload.embeds[0].data.title).toBe("Trade Session");
+	});
+
+	it("opens a root manage session from the public manage button", async () => {
+		const interaction = createButtonInteraction("market:manage:market_1");
+		getMarketById.mockResolvedValue({
+			...baseMarket,
+			positions: [
+				{
+					id: "position_1",
+					marketId: "market_1",
+					outcomeId: "outcome_yes",
+					userId: "user_1",
+					side: "long",
+					shares: 4,
+					costBasis: 35,
+					proceeds: 0,
+					collateralLocked: 0,
+					createdAt: new Date("2099-03-29T00:00:00.000Z"),
+					updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+				},
+			],
+		});
+
+		await handleMarketButton(interaction as never);
+
+		expect(saveMarketInteractionSession).toHaveBeenCalledWith(
+			{},
+			"session_1",
+			expect.objectContaining({
+				marketId: "market_1",
+				mode: "manage",
+				selectedOutcomeId: "outcome_yes",
+			}),
+		);
+		expect(interaction.reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				flags: 64,
+				embeds: expect.any(Array),
+				components: expect.any(Array),
+			}),
+		);
+	});
+
+	it("opens the amount modal from a root interaction session", async () => {
+		const interaction = createButtonInteraction(
+			"market:session-amount:session_1",
+		);
+		getMarketInteractionSession.mockResolvedValue({
+			sessionId: "session_1",
+			userId: "user_1",
+			marketId: "market_1",
+			mode: "trade",
+			selectedOutcomeId: "outcome_yes",
+			selectedAction: "buy",
+			amountInput: null,
+			targetCoverage: null,
+			preview: null,
+			expiresAt: new Date("2099-03-29T01:00:00.000Z").toISOString(),
+		});
+
+		await handleMarketButton(interaction as never);
+
+		expect(interaction.showModal).toHaveBeenCalledTimes(1);
+	});
+
+	it("updates a root trade session when selecting a different outcome", async () => {
+		const interaction = createStringSelectInteraction(
+			"market:session-outcome:session_1",
+			["outcome_no"],
+		);
+		getMarketInteractionSession.mockResolvedValue({
+			sessionId: "session_1",
+			userId: "user_1",
+			marketId: "market_1",
+			mode: "trade",
+			selectedOutcomeId: "outcome_yes",
+			selectedAction: "buy",
+			amountInput: "25",
+			targetCoverage: null,
+			preview: null,
+			expiresAt: new Date("2099-03-29T01:00:00.000Z").toISOString(),
+		});
+		getMarketById.mockResolvedValue(baseMarket);
+		calculateMarketTradeQuote.mockResolvedValue(
+			createTradeQuote({
+				outcomeId: "outcome_no",
+				outcomeLabel: "No",
+			}),
+		);
+
+		await handleMarketSelect(interaction as never);
+
+		expect(saveMarketInteractionSession).toHaveBeenCalledWith(
+			{},
+			"session_1",
+			expect.objectContaining({
+				selectedOutcomeId: "outcome_no",
+				preview: expect.objectContaining({ kind: "trade" }),
+			}),
+		);
+		expect(interaction.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				embeds: expect.any(Array),
+				components: expect.any(Array),
+			}),
+		);
+	});
+
+	it("replies with an updated trade session after submitting the session amount modal", async () => {
+		const interaction = createModalInteraction(
+			"market:session-amount-modal:session_1",
+			"25",
+		);
+		getMarketInteractionSession.mockResolvedValue({
+			sessionId: "session_1",
+			userId: "user_1",
+			marketId: "market_1",
+			mode: "trade",
+			selectedOutcomeId: "outcome_yes",
+			selectedAction: "buy",
+			amountInput: null,
+			targetCoverage: null,
+			preview: null,
+			expiresAt: new Date("2099-03-29T01:00:00.000Z").toISOString(),
+		});
+		getMarketById.mockResolvedValue(baseMarket);
+		calculateMarketTradeQuote.mockResolvedValue(createTradeQuote());
+
+		await handleMarketModal({} as never, interaction as never);
+
+		expect(saveMarketInteractionSession).toHaveBeenCalledWith(
+			{},
+			"session_1",
+			expect.objectContaining({
+				amountInput: "25",
+				preview: expect.objectContaining({ kind: "trade" }),
+			}),
+		);
+		expect(interaction.reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				flags: 64,
+				embeds: expect.any(Array),
+				components: expect.any(Array),
+			}),
+		);
+	});
+
+	it("confirms a quoted trade from a root interaction session", async () => {
+		const interaction = createButtonInteraction(
+			"market:session-confirm:session_1",
+		);
+		getMarketInteractionSession.mockResolvedValue({
+			sessionId: "session_1",
+			userId: "user_1",
+			marketId: "market_1",
+			mode: "trade",
+			selectedOutcomeId: "outcome_yes",
+			selectedAction: "buy",
+			amountInput: "25",
+			targetCoverage: null,
+			preview: {
+				kind: "trade",
+				quote: createTradeQuote(),
+			},
+			expiresAt: new Date("2099-03-29T01:00:00.000Z").toISOString(),
+		});
+		executeMarketTrade.mockResolvedValue({
+			market: baseMarket,
+			outcome: baseMarket.outcomes[0],
+			account: { ...baseAccount, bankroll: 975 },
+			positionSide: "long",
+			shareDelta: 12.5,
+			cashAmount: 25,
+			realizedProfitDelta: 0,
+		});
+
+		await handleMarketButton(interaction as never);
+
+		expect(executeMarketTrade).toHaveBeenCalledWith({
+			marketId: "market_1",
+			userId: "user_1",
+			outcomeId: "outcome_yes",
+			action: "buy",
+			amount: 25,
+			amountMode: "points",
+		});
+		expect(deleteMarketInteractionSession).toHaveBeenCalledWith(
+			{},
+			"session_1",
+		);
+		expect(interaction.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				embeds: expect.any(Array),
+				components: [],
+			}),
+		);
+	});
+
+	it("shows a quote preview instead of executing a sell trade modal immediately", async () => {
+		const interaction = createModalInteraction(
+			"market:trade-modal:sell:market_1:outcome_yes",
+			"10 pts",
+		);
+		getMarketById.mockResolvedValue(baseMarket);
+		calculateMarketTradeQuote.mockResolvedValue(
+			createTradeQuote({
+				action: "sell",
+				amount: 10,
+				rawAmount: "10 pts",
+				shares: 4,
+				averagePrice: 2.5,
+				nextProbability: 0.48,
+				immediateCash: 10,
+				grossImmediateCash: 10,
+				netImmediateCash: 10,
+				netBankrollChange: 10,
+				bankrollAfter: 1010,
+				positionSharesAfter: 1,
+				positionCostBasisAfter: 5,
+				realizedProfitDelta: 2,
+			}),
+		);
+
+		await handleMarketModal({} as never, interaction as never);
+
+		expect(executeMarketTrade).not.toHaveBeenCalled();
+		expect(saveMarketTradeQuoteSession).toHaveBeenCalledTimes(1);
+		expect(interaction.reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				flags: 64,
+				embeds: expect.any(Array),
+				components: expect.any(Array),
+			}),
+		);
+	});
+
+	it("shows market details from the details button", async () => {
+		const interaction = createButtonInteraction("market:details:market_1");
+		getMarketById.mockResolvedValue(baseMarket);
+
+		await handleMarketButton(interaction as never);
+
+		expect(interaction.reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				flags: 64,
+				embeds: expect.any(Array),
+			}),
+		);
+	});
+
+	it("grants market currency to a user and DMs them", async () => {
+		const recipientSend = vi.fn().mockResolvedValue(undefined);
+		const interaction = createInteraction({
+			subcommand: "grant",
+			numbers: {
+				amount: 250,
+			},
+			strings: {
+				reason: "Won the seasonal tournament",
+			},
+			users: {
+				user: {
+					id: "user_2",
+					send: recipientSend,
+				},
+			},
+		});
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(grantMarketBankroll).toHaveBeenCalledWith({
+			guildId: "guild_1",
+			userId: "user_2",
+			amount: 250,
+		});
+		expect(recipientSend).toHaveBeenCalledWith(
+			expect.objectContaining({
+				embeds: expect.any(Array),
+			}),
+		);
+		expect(interaction.reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				flags: 64,
+				embeds: expect.any(Array),
+			}),
+		);
+	});
+
+	it("logs when a grant DM cannot be delivered", async () => {
+		const interaction = createInteraction({
+			subcommand: "grant",
+			numbers: {
+				amount: 250,
+			},
+			strings: {
+				reason: "Won the seasonal tournament",
+			},
+			users: {
+				user: {
+					id: "user_2",
+					send: vi.fn().mockRejectedValue(new Error("DMs closed")),
+				},
+			},
+		});
+
+		await handleMarketCommand({} as never, interaction as never);
+
+		expect(loggerWarn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				recipientUserId: "user_2",
+				adminUserId: "user_1",
+			}),
+			"Could not DM market grant recipient",
+		);
+	});
+
+	it("rejects non-admin users who try to grant market currency", async () => {
+		env.DISCORD_ADMIN_USER_IDS = ["someone_else"];
+		const interaction = createInteraction({
+			subcommand: "grant",
+			numbers: {
+				amount: 50,
+			},
+			strings: {
+				reason: "Test grant",
+			},
+			users: {
+				user: {
+					id: "user_2",
+					send: vi.fn(),
+				},
+			},
+		});
+
+		await expect(
+			handleMarketCommand({} as never, interaction as never),
+		).rejects.toThrow(
+			"Only configured admin user IDs can grant market currency.",
+		);
+
+		expect(grantMarketBankroll).not.toHaveBeenCalled();
+	});
 });

--- a/tests/market-render.test.ts
+++ b/tests/market-render.test.ts
@@ -1,308 +1,415 @@
-import { describe, expect, it, vi } from 'vitest';
-import type { MarketWithRelations } from '../src/features/markets/core/types.js';
+import { describe, expect, it, vi } from "vitest";
+import type { MarketWithRelations } from "../src/features/markets/core/types.js";
 
-vi.mock('../src/features/markets/core/shared.js', () => ({
-  getMarketStatus: vi.fn(() => 'open'),
-  getTradeLockReason: vi.fn(() => null),
-  computeMarketSummary: vi.fn((market: MarketWithRelations) => ({
-    status: 'open',
-    probabilities: market.outcomes.map((outcome, index) => ({
-      outcomeId: outcome.id,
-      label: outcome.label,
-      probability: [0.34, 0.29, 0.17, 0.14, 0.06][index] ?? 0.1,
-      shares: outcome.outstandingShares,
-      isResolved: outcome.settlementValue !== null,
-      settlementValue: outcome.settlementValue,
-    })),
-    totalVolume: market.totalVolume,
-  })),
+vi.mock("../src/features/markets/core/shared.js", () => ({
+	getMarketStatus: vi.fn((market: MarketWithRelations) =>
+		market.cancelledAt
+			? "cancelled"
+			: market.resolvedAt
+				? "resolved"
+				: market.tradingClosedAt
+					? "closed"
+					: "open",
+	),
+	getTradeLockReason: vi.fn(() => null),
+	computeMarketSummary: vi.fn((market: MarketWithRelations) => ({
+		status: market.cancelledAt
+			? "cancelled"
+			: market.resolvedAt
+				? "resolved"
+				: market.tradingClosedAt
+					? "closed"
+					: "open",
+		probabilities: market.outcomes.map((outcome, index) => ({
+			outcomeId: outcome.id,
+			label: outcome.label,
+			probability: [0.34, 0.29, 0.17, 0.14, 0.06][index] ?? 0.1,
+			shares: outcome.outstandingShares,
+			isResolved: outcome.settlementValue !== null,
+			settlementValue: outcome.settlementValue,
+		})),
+		totalVolume: market.totalVolume,
+	})),
 }));
 
-import { buildMarketMessage } from '../src/features/markets/ui/render/market.js';
-import { buildPortfolioMessage } from '../src/features/markets/ui/render/portfolio.js';
+import { buildMarketMessage } from "../src/features/markets/ui/render/market.js";
+import { buildPortfolioMessage } from "../src/features/markets/ui/render/portfolio.js";
 
 const market = {
-  id: 'market_1',
-  guildId: 'guild_1',
-  creatorId: 'user_1',
-  originChannelId: 'origin_channel_1',
-  marketChannelId: 'market_channel_1',
-  messageId: 'message_market_1',
-  threadId: null,
-  title: 'Championship board',
-  description: 'A test market',
-  buttonStyle: 'primary' as const,
-  tags: ['sports'],
-  liquidityParameter: 150,
-  baseLiquidityParameter: 150,
-  maxLiquidityParameter: 450,
-  lastLiquidityInjectionAt: null,
-  closeAt: new Date('2099-03-30T00:00:00.000Z'),
-  tradingClosedAt: null,
-  resolutionGraceEndsAt: null,
-  graceNotifiedAt: null,
-  resolvedAt: null,
-  cancelledAt: null,
-  resolutionNote: null,
-  resolutionEvidenceUrl: null,
-  resolvedByUserId: null,
-  winningOutcomeId: null,
-  totalVolume: 120,
-  supplementaryBonusPool: 0,
-  supplementaryBonusDistributedAt: null,
-  supplementaryBonusExpiredAt: null,
-  createdAt: new Date('2099-03-29T00:00:00.000Z'),
-  updatedAt: new Date('2099-03-29T00:00:00.000Z'),
-  winningOutcome: null,
-  outcomes: [
-    { id: 'a', marketId: 'market_1', label: 'Arizona', sortOrder: 0, outstandingShares: 12, pricingShares: 12, settlementValue: null, resolvedAt: null, resolvedByUserId: null, resolutionNote: null, resolutionEvidenceUrl: null, createdAt: new Date('2099-03-29T00:00:00.000Z') },
-    { id: 'b', marketId: 'market_1', label: 'Michigan', sortOrder: 1, outstandingShares: 3, pricingShares: 3, settlementValue: null, resolvedAt: null, resolvedByUserId: null, resolutionNote: null, resolutionEvidenceUrl: null, createdAt: new Date('2099-03-29T00:00:00.000Z') },
-    { id: 'c', marketId: 'market_1', label: 'Illinois', sortOrder: 2, outstandingShares: -4, pricingShares: -4, settlementValue: null, resolvedAt: null, resolvedByUserId: null, resolutionNote: null, resolutionEvidenceUrl: null, createdAt: new Date('2099-03-29T00:00:00.000Z') },
-    { id: 'd', marketId: 'market_1', label: 'UConn', sortOrder: 3, outstandingShares: 9, pricingShares: 9, settlementValue: null, resolvedAt: null, resolvedByUserId: null, resolutionNote: null, resolutionEvidenceUrl: null, createdAt: new Date('2099-03-29T00:00:00.000Z') },
-    { id: 'e', marketId: 'market_1', label: 'Duke', sortOrder: 4, outstandingShares: 1, pricingShares: 1, settlementValue: null, resolvedAt: null, resolvedByUserId: null, resolutionNote: null, resolutionEvidenceUrl: null, createdAt: new Date('2099-03-29T00:00:00.000Z') },
-  ],
-  trades: [],
-  positions: [],
-  liquidityEvents: [],
+	id: "market_1",
+	guildId: "guild_1",
+	creatorId: "user_1",
+	originChannelId: "origin_channel_1",
+	marketChannelId: "market_channel_1",
+	messageId: "message_market_1",
+	threadId: null,
+	title: "Championship board",
+	description: "A test market",
+	buttonStyle: "primary" as const,
+	tags: ["sports"],
+	liquidityParameter: 150,
+	baseLiquidityParameter: 150,
+	maxLiquidityParameter: 450,
+	lastLiquidityInjectionAt: null,
+	closeAt: new Date("2099-03-30T00:00:00.000Z"),
+	tradingClosedAt: null,
+	resolutionGraceEndsAt: null,
+	graceNotifiedAt: null,
+	resolvedAt: null,
+	cancelledAt: null,
+	resolutionNote: null,
+	resolutionEvidenceUrl: null,
+	resolvedByUserId: null,
+	winningOutcomeId: null,
+	totalVolume: 120,
+	supplementaryBonusPool: 0,
+	supplementaryBonusDistributedAt: null,
+	supplementaryBonusExpiredAt: null,
+	createdAt: new Date("2099-03-29T00:00:00.000Z"),
+	updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+	winningOutcome: null,
+	outcomes: [
+		{
+			id: "a",
+			marketId: "market_1",
+			label: "Arizona",
+			sortOrder: 0,
+			outstandingShares: 12,
+			pricingShares: 12,
+			settlementValue: null,
+			resolvedAt: null,
+			resolvedByUserId: null,
+			resolutionNote: null,
+			resolutionEvidenceUrl: null,
+			createdAt: new Date("2099-03-29T00:00:00.000Z"),
+		},
+		{
+			id: "b",
+			marketId: "market_1",
+			label: "Michigan",
+			sortOrder: 1,
+			outstandingShares: 3,
+			pricingShares: 3,
+			settlementValue: null,
+			resolvedAt: null,
+			resolvedByUserId: null,
+			resolutionNote: null,
+			resolutionEvidenceUrl: null,
+			createdAt: new Date("2099-03-29T00:00:00.000Z"),
+		},
+		{
+			id: "c",
+			marketId: "market_1",
+			label: "Illinois",
+			sortOrder: 2,
+			outstandingShares: -4,
+			pricingShares: -4,
+			settlementValue: null,
+			resolvedAt: null,
+			resolvedByUserId: null,
+			resolutionNote: null,
+			resolutionEvidenceUrl: null,
+			createdAt: new Date("2099-03-29T00:00:00.000Z"),
+		},
+		{
+			id: "d",
+			marketId: "market_1",
+			label: "UConn",
+			sortOrder: 3,
+			outstandingShares: 9,
+			pricingShares: 9,
+			settlementValue: null,
+			resolvedAt: null,
+			resolvedByUserId: null,
+			resolutionNote: null,
+			resolutionEvidenceUrl: null,
+			createdAt: new Date("2099-03-29T00:00:00.000Z"),
+		},
+		{
+			id: "e",
+			marketId: "market_1",
+			label: "Duke",
+			sortOrder: 4,
+			outstandingShares: 1,
+			pricingShares: 1,
+			settlementValue: null,
+			resolvedAt: null,
+			resolvedByUserId: null,
+			resolutionNote: null,
+			resolutionEvidenceUrl: null,
+			createdAt: new Date("2099-03-29T00:00:00.000Z"),
+		},
+	],
+	trades: [],
+	positions: [],
+	liquidityEvents: [],
 };
 
-describe('market render', () => {
-  it('builds an outcome-first quick trade board', () => {
-    const payload = buildMarketMessage(market);
+describe("market render", () => {
+	it("builds a stable market launcher row", () => {
+		const payload = buildMarketMessage(market);
 
-    expect(payload.components).toHaveLength(2);
-    const firstRow = payload.components[0]!;
-    const firstRowJson = firstRow.toJSON();
-    const buttonComponents = firstRowJson.components as Array<{ label?: string; custom_id?: string }>;
-    const labels = buttonComponents.map((component) => component.label);
+		expect(payload.components).toHaveLength(1);
+		const firstRow = payload.components[0]!;
+		const firstRowJson = firstRow.toJSON();
+		const buttonComponents = firstRowJson.components as Array<{
+			label?: string;
+			custom_id?: string;
+		}>;
+		const labels = buttonComponents.map((component) => component.label);
 
-    expect(labels).toEqual(expect.arrayContaining([
-      'Arizona',
-      'Michigan',
-      'Illinois',
-      'UConn',
-      'Duke',
-    ]));
+		expect(labels).toEqual(["Trade", "Manage Position", "Details", "Refresh"]);
+		expect(buttonComponents[0]?.custom_id).toBe("market:trade:market_1");
+	});
 
-    expect(buttonComponents[0]?.custom_id).toBe('market:outcome:market_1:a');
-  });
+	it("keeps the market launcher stable when outcomes resolve", () => {
+		const payload = buildMarketMessage({
+			...market,
+			outcomes: market.outcomes.map((outcome) =>
+				outcome.id === "c"
+					? {
+							...outcome,
+							settlementValue: 0,
+							resolvedAt: new Date("2099-03-30T00:00:00.000Z"),
+						}
+					: outcome,
+			),
+		});
+		const labels = (
+			payload.components[0]!.toJSON().components as Array<{ label?: string }>
+		).map((component) => component.label);
 
-  it('places utility buttons after the outcome buttons', () => {
-    const payload = buildMarketMessage(market);
-    const utilityLabels = (payload.components[1]!.toJSON().components as Array<{ label?: string }>).map((component) => component.label);
+		expect(labels).toEqual(["Trade", "Manage Position", "Details", "Refresh"]);
+	});
 
-    expect(utilityLabels).toEqual(['My Positions', 'Protect', 'Details', 'Refresh']);
-  });
+	it("disables trade launchers when trading is closed", () => {
+		const payload = buildMarketMessage({
+			...market,
+			tradingClosedAt: new Date("2099-03-30T00:00:00.000Z"),
+		});
 
-  it('omits resolved outcomes from the quick trade board', () => {
-    const payload = buildMarketMessage({
-      ...market,
-      outcomes: market.outcomes.map((outcome) =>
-        outcome.id === 'c'
-          ? { ...outcome, settlementValue: 0, resolvedAt: new Date('2099-03-30T00:00:00.000Z') }
-          : outcome),
-    });
+		const components = payload.components[0]!.toJSON().components as Array<{
+			disabled?: boolean;
+			label?: string;
+		}>;
 
-    const labels = payload.components
-      .slice(0, -1)
-      .flatMap((row) => (row.toJSON().components as Array<{ label?: string }>).map((component) => component.label ?? ''));
+		expect(components[0]?.label).toBe("Trade");
+		expect(components[0]?.disabled).toBe(true);
+		expect(components[1]?.label).toBe("Manage Position");
+		expect(components[1]?.disabled).toBe(true);
+	});
 
-    expect(labels.some((label) => label.includes('Illinois'))).toBe(false);
-  });
+	it("includes the forum post when one exists", () => {
+		const payload = buildMarketMessage({
+			...market,
+			threadId: "thread_1",
+		});
 
-  it('includes the forum post when one exists', () => {
-    const payload = buildMarketMessage({
-      ...market,
-      threadId: 'thread_1',
-    });
+		const embedJson = payload.embeds[0].toJSON();
+		const marketField = embedJson.fields?.find(
+			(field) => field.name === "Market",
+		);
+		expect(marketField?.value).toContain("Discuss in forum post <#thread_1>.");
+	});
 
-    const embedJson = payload.embeds[0].toJSON();
-    const marketField = embedJson.fields?.find((field) => field.name === 'Market');
-    expect(marketField?.value).toContain('Discuss in forum post <#thread_1>.');
-  });
+	it("omits the description when none is provided", () => {
+		const payload = buildMarketMessage({
+			...market,
+			description: null,
+		});
 
-  it('omits the description when none is provided', () => {
-    const payload = buildMarketMessage({
-      ...market,
-      description: null,
-    });
+		expect(payload.embeds[0].toJSON().description).toBeUndefined();
+	});
 
-    expect(payload.embeds[0].toJSON().description).toBeUndefined();
-  });
+	it("moves volume into the footer metadata", () => {
+		const payload = buildMarketMessage(market);
 
-  it('moves volume into the footer metadata', () => {
-    const payload = buildMarketMessage(market);
+		expect(payload.embeds[0].toJSON().footer?.text).toContain(
+			"Market ID: market_1",
+		);
+		expect(payload.embeds[0].toJSON().footer?.text).toContain(
+			"Volume: 120 pts",
+		);
+	});
 
-    expect(payload.embeds[0].toJSON().footer?.text).toContain('Market ID: market_1');
-    expect(payload.embeds[0].toJSON().footer?.text).toContain('Volume: 120 pts');
-  });
+	it("builds a portfolio management selector for open positions", () => {
+		const payload = buildPortfolioMessage(
+			"user_1",
+			{
+				id: "account_1",
+				guildConfigId: "guild_config_1",
+				guildId: "guild_1",
+				userId: "user_1",
+				bankroll: 900,
+				realizedProfit: 15,
+				lastTopUpAt: null,
+				createdAt: new Date("2099-03-29T00:00:00.000Z"),
+				updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+				lockedCollateral: 6,
+				openPositions: [
+					{
+						id: "position_long",
+						marketId: "market_1",
+						outcomeId: "a",
+						userId: "user_1",
+						side: "long",
+						shares: 4,
+						costBasis: 35,
+						proceeds: 0,
+						collateralLocked: 0,
+						createdAt: new Date("2099-03-29T00:00:00.000Z"),
+						updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+						market,
+						outcome: market.outcomes[0]!,
+					},
+					{
+						id: "position_short",
+						marketId: "market_1",
+						outcomeId: "c",
+						userId: "user_1",
+						side: "short",
+						shares: 6,
+						costBasis: 0,
+						proceeds: 11,
+						collateralLocked: 6,
+						createdAt: new Date("2099-03-29T00:00:00.000Z"),
+						updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+						market,
+						outcome: market.outcomes[2]!,
+					},
+				],
+			},
+			true,
+		);
 
-  it('builds a portfolio management selector for open positions', () => {
-    const payload = buildPortfolioMessage('user_1', {
-      id: 'account_1',
-      guildConfigId: 'guild_config_1',
-      guildId: 'guild_1',
-      userId: 'user_1',
-      bankroll: 900,
-      realizedProfit: 15,
-      lastTopUpAt: null,
-      createdAt: new Date('2099-03-29T00:00:00.000Z'),
-      updatedAt: new Date('2099-03-29T00:00:00.000Z'),
-      lockedCollateral: 6,
-      openPositions: [
-        {
-          id: 'position_long',
-          marketId: 'market_1',
-          outcomeId: 'a',
-          userId: 'user_1',
-          side: 'long',
-          shares: 4,
-          costBasis: 35,
-          proceeds: 0,
-          collateralLocked: 0,
-          createdAt: new Date('2099-03-29T00:00:00.000Z'),
-          updatedAt: new Date('2099-03-29T00:00:00.000Z'),
-          market,
-          outcome: market.outcomes[0]!,
-        },
-        {
-          id: 'position_short',
-          marketId: 'market_1',
-          outcomeId: 'c',
-          userId: 'user_1',
-          side: 'short',
-          shares: 6,
-          costBasis: 0,
-          proceeds: 11,
-          collateralLocked: 6,
-          createdAt: new Date('2099-03-29T00:00:00.000Z'),
-          updatedAt: new Date('2099-03-29T00:00:00.000Z'),
-          market,
-          outcome: market.outcomes[2]!,
-        },
-      ],
-    }, true);
+		expect(payload.components).toHaveLength(1);
+		expect(payload.embeds[0].toJSON().title).toBe("My Positions");
+		const select = payload.components[0]!.components[0]!;
+		const selectJson = select.toJSON();
+		expect(selectJson.custom_id).toBe("market:portfolio-select");
+		const options = selectJson.options ?? [];
+		expect(options[0]?.label).toContain("Sell");
+		expect(options[0]?.value).toBe("sell:market_1:a");
+		expect(options[1]?.label).toContain("Protect");
+		expect(options[1]?.value).toBe("protect:market_1:a");
+		expect(options[2]?.label).toContain("Cover");
+		expect(options[2]?.value).toBe("cover:market_1:c");
+	});
 
-    expect(payload.components).toHaveLength(1);
-    expect(payload.embeds[0].toJSON().title).toBe('My Positions');
-    const select = payload.components[0]!.components[0]!;
-    const selectJson = select.toJSON();
-    expect(selectJson.custom_id).toBe('market:portfolio-select');
-    const options = selectJson.options ?? [];
-    expect(options[0]?.label).toContain('Sell');
-    expect(options[0]?.value).toBe('sell:market_1:a');
-    expect(options[1]?.label).toContain('Protect');
-    expect(options[1]?.value).toBe('protect:market_1:a');
-    expect(options[2]?.label).toContain('Cover');
-    expect(options[2]?.value).toBe('cover:market_1:c');
-  });
+	it("omits closed positions from the portfolio management selector", () => {
+		const closedMarket = {
+			...market,
+			id: "market_2",
+			title: "Closed board",
+			tradingClosedAt: new Date("2099-03-30T12:00:00.000Z"),
+		};
 
-  it('omits closed positions from the portfolio management selector', () => {
-    const closedMarket = {
-      ...market,
-      id: 'market_2',
-      title: 'Closed board',
-      tradingClosedAt: new Date('2099-03-30T12:00:00.000Z'),
-    };
+		const payload = buildPortfolioMessage(
+			"user_1",
+			{
+				id: "account_1",
+				guildConfigId: "guild_config_1",
+				guildId: "guild_1",
+				userId: "user_1",
+				bankroll: 900,
+				realizedProfit: 15,
+				lastTopUpAt: null,
+				createdAt: new Date("2099-03-29T00:00:00.000Z"),
+				updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+				lockedCollateral: 6,
+				openPositions: [
+					{
+						id: "position_open",
+						marketId: "market_1",
+						outcomeId: "a",
+						userId: "user_1",
+						side: "long",
+						shares: 4,
+						costBasis: 35,
+						proceeds: 0,
+						collateralLocked: 0,
+						createdAt: new Date("2099-03-29T00:00:00.000Z"),
+						updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+						market,
+						outcome: market.outcomes[0]!,
+					},
+					{
+						id: "position_closed",
+						marketId: "market_2",
+						outcomeId: "b",
+						userId: "user_1",
+						side: "short",
+						shares: 6,
+						costBasis: 0,
+						proceeds: 11,
+						collateralLocked: 6,
+						createdAt: new Date("2099-03-29T00:00:00.000Z"),
+						updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+						market: closedMarket,
+						outcome: closedMarket.outcomes[1]!,
+					},
+				],
+			},
+			true,
+		);
 
-    const payload = buildPortfolioMessage('user_1', {
-      id: 'account_1',
-      guildConfigId: 'guild_config_1',
-      guildId: 'guild_1',
-      userId: 'user_1',
-      bankroll: 900,
-      realizedProfit: 15,
-      lastTopUpAt: null,
-      createdAt: new Date('2099-03-29T00:00:00.000Z'),
-      updatedAt: new Date('2099-03-29T00:00:00.000Z'),
-      lockedCollateral: 6,
-      openPositions: [
-        {
-          id: 'position_open',
-          marketId: 'market_1',
-          outcomeId: 'a',
-          userId: 'user_1',
-          side: 'long',
-          shares: 4,
-          costBasis: 35,
-          proceeds: 0,
-          collateralLocked: 0,
-          createdAt: new Date('2099-03-29T00:00:00.000Z'),
-          updatedAt: new Date('2099-03-29T00:00:00.000Z'),
-          market,
-          outcome: market.outcomes[0]!,
-        },
-        {
-          id: 'position_closed',
-          marketId: 'market_2',
-          outcomeId: 'b',
-          userId: 'user_1',
-          side: 'short',
-          shares: 6,
-          costBasis: 0,
-          proceeds: 11,
-          collateralLocked: 6,
-          createdAt: new Date('2099-03-29T00:00:00.000Z'),
-          updatedAt: new Date('2099-03-29T00:00:00.000Z'),
-          market: closedMarket,
-          outcome: closedMarket.outcomes[1]!,
-        },
-      ],
-    }, true);
+		expect(payload.components).toHaveLength(1);
+		const select = payload.components[0]!.components[0]!;
+		const selectJson = select.toJSON();
+		expect(selectJson.options).toHaveLength(2);
+		expect(selectJson.options?.[0]?.value).toBe("sell:market_1:a");
+		expect(selectJson.options?.[1]?.value).toBe("protect:market_1:a");
+	});
 
-    expect(payload.components).toHaveLength(1);
-    const select = payload.components[0]!.components[0]!;
-    const selectJson = select.toJSON();
-    expect(selectJson.options).toHaveLength(2);
-    expect(selectJson.options?.[0]?.value).toBe('sell:market_1:a');
-    expect(selectJson.options?.[1]?.value).toBe('protect:market_1:a');
-  });
+	it("caps portfolio management options at Discord’s 25-option limit", () => {
+		const openPositions = Array.from({ length: 20 }, (_, index) => ({
+			id: `position_${index}`,
+			marketId: `market_${index}`,
+			outcomeId: `outcome_${index}`,
+			userId: "user_1",
+			side: "long" as const,
+			shares: 2,
+			costBasis: 10,
+			proceeds: 0,
+			collateralLocked: 0,
+			insuredCostBasis: 0,
+			premiumPaid: 0,
+			coverageRatio: 0,
+			uninsuredCostBasis: 10,
+			createdAt: new Date("2099-03-29T00:00:00.000Z"),
+			updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+			market: {
+				...market,
+				id: `market_${index}`,
+				title: `Market ${index}`,
+			},
+			outcome: {
+				...market.outcomes[0]!,
+				id: `outcome_${index}`,
+				marketId: `market_${index}`,
+				label: `Outcome ${index}`,
+			},
+		}));
 
-  it('caps portfolio management options at Discord’s 25-option limit', () => {
-    const openPositions = Array.from({ length: 20 }, (_, index) => ({
-      id: `position_${index}`,
-      marketId: `market_${index}`,
-      outcomeId: `outcome_${index}`,
-      userId: 'user_1',
-      side: 'long' as const,
-      shares: 2,
-      costBasis: 10,
-      proceeds: 0,
-      collateralLocked: 0,
-      insuredCostBasis: 0,
-      premiumPaid: 0,
-      coverageRatio: 0,
-      uninsuredCostBasis: 10,
-      createdAt: new Date('2099-03-29T00:00:00.000Z'),
-      updatedAt: new Date('2099-03-29T00:00:00.000Z'),
-      market: {
-        ...market,
-        id: `market_${index}`,
-        title: `Market ${index}`,
-      },
-      outcome: {
-        ...market.outcomes[0]!,
-        id: `outcome_${index}`,
-        marketId: `market_${index}`,
-        label: `Outcome ${index}`,
-      },
-    }));
+		const payload = buildPortfolioMessage(
+			"user_1",
+			{
+				id: "account_1",
+				guildConfigId: "guild_config_1",
+				guildId: "guild_1",
+				userId: "user_1",
+				bankroll: 900,
+				realizedProfit: 15,
+				lastTopUpAt: null,
+				createdAt: new Date("2099-03-29T00:00:00.000Z"),
+				updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+				lockedCollateral: 0,
+				openPositions,
+			},
+			true,
+		);
 
-    const payload = buildPortfolioMessage('user_1', {
-      id: 'account_1',
-      guildConfigId: 'guild_config_1',
-      guildId: 'guild_1',
-      userId: 'user_1',
-      bankroll: 900,
-      realizedProfit: 15,
-      lastTopUpAt: null,
-      createdAt: new Date('2099-03-29T00:00:00.000Z'),
-      updatedAt: new Date('2099-03-29T00:00:00.000Z'),
-      lockedCollateral: 0,
-      openPositions,
-    }, true);
-
-    const selectJson = payload.components[0]!.components[0]!.toJSON();
-    expect(selectJson.options).toHaveLength(25);
-  });
+		const selectJson = payload.components[0]!.components[0]!.toJSON();
+		expect(selectJson.options).toHaveLength(25);
+	});
 });

--- a/tests/market-service.test.ts
+++ b/tests/market-service.test.ts
@@ -1,1719 +1,2174 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const {
-  prisma,
-  transaction,
-} = vi.hoisted(() => {
-  const transactionClient = {
-    guildConfig: {
-      upsert: vi.fn(),
-    },
-    market: {
-      findUnique: vi.fn(),
-      update: vi.fn(),
-      delete: vi.fn(),
-      findMany: vi.fn(),
-      create: vi.fn(),
-      findUniqueOrThrow: vi.fn(),
-    },
-    marketOutcome: {
-      update: vi.fn(),
-      deleteMany: vi.fn(),
-    },
-    marketPosition: {
-      deleteMany: vi.fn(),
-      upsert: vi.fn(),
-      findMany: vi.fn(),
-    },
-    marketAccount: {
-      findUnique: vi.fn(),
-      upsert: vi.fn(),
-      update: vi.fn(),
-      findMany: vi.fn(),
-    },
-    marketForecastRecord: {
-      upsert: vi.fn(),
-      findMany: vi.fn(),
-    },
-    marketLiquidityEvent: {
-      create: vi.fn(),
-    },
-    marketLossProtection: {
-      findMany: vi.fn(),
-      upsert: vi.fn(),
-      update: vi.fn(),
-      deleteMany: vi.fn(),
-    },
-  };
+const { prisma, transaction } = vi.hoisted(() => {
+	const transactionClient = {
+		guildConfig: {
+			upsert: vi.fn(),
+		},
+		market: {
+			findUnique: vi.fn(),
+			update: vi.fn(),
+			delete: vi.fn(),
+			findMany: vi.fn(),
+			create: vi.fn(),
+			findUniqueOrThrow: vi.fn(),
+		},
+		marketOutcome: {
+			update: vi.fn(),
+			deleteMany: vi.fn(),
+		},
+		marketPosition: {
+			deleteMany: vi.fn(),
+			upsert: vi.fn(),
+			findMany: vi.fn(),
+		},
+		marketAccount: {
+			findUnique: vi.fn(),
+			upsert: vi.fn(),
+			update: vi.fn(),
+			findMany: vi.fn(),
+		},
+		marketForecastRecord: {
+			upsert: vi.fn(),
+			findMany: vi.fn(),
+		},
+		marketLiquidityEvent: {
+			create: vi.fn(),
+		},
+		marketLossProtection: {
+			findMany: vi.fn(),
+			upsert: vi.fn(),
+			update: vi.fn(),
+			deleteMany: vi.fn(),
+		},
+	};
 
-  return {
-    prisma: {
-      $transaction: vi.fn(),
-      guildConfig: {
-        findUnique: vi.fn(),
-      },
-      market: {
-        delete: vi.fn(),
-        create: vi.fn(),
-        findUnique: vi.fn(),
-        findUniqueOrThrow: vi.fn(),
-        findMany: vi.fn(),
-      },
-      marketAccount: {
-        findUnique: vi.fn(),
-        findMany: vi.fn(),
-      },
-      marketForecastRecord: {
-        findMany: vi.fn(),
-      },
-    },
-    transaction: transactionClient,
-  };
+	return {
+		prisma: {
+			$transaction: vi.fn(),
+			guildConfig: {
+				findUnique: vi.fn(),
+			},
+			market: {
+				delete: vi.fn(),
+				create: vi.fn(),
+				findUnique: vi.fn(),
+				findUniqueOrThrow: vi.fn(),
+				findMany: vi.fn(),
+			},
+			marketAccount: {
+				findUnique: vi.fn(),
+				findMany: vi.fn(),
+			},
+			marketForecastRecord: {
+				findMany: vi.fn(),
+			},
+		},
+		transaction: transactionClient,
+	};
 });
 
-vi.mock('../src/lib/prisma.js', () => ({
-  prisma,
+vi.mock("../src/lib/prisma.js", () => ({
+	prisma,
 }));
 
-vi.mock('../src/app/logger.js', () => ({
-  logger: {
-    warn: vi.fn(),
-  },
+vi.mock("../src/app/logger.js", () => ({
+	logger: {
+		warn: vi.fn(),
+	},
 }));
 
-vi.mock('../src/lib/queue.js', () => ({
-  marketCloseQueue: {
-    getJob: vi.fn(),
-    add: vi.fn(),
-  },
-  marketGraceQueue: {
-    getJob: vi.fn(),
-    add: vi.fn(),
-  },
-  marketRefreshQueue: {
-    getJob: vi.fn(),
-    add: vi.fn(),
-  },
+vi.mock("../src/lib/queue.js", () => ({
+	marketCloseQueue: {
+		getJob: vi.fn(),
+		add: vi.fn(),
+	},
+	marketGraceQueue: {
+		getJob: vi.fn(),
+		add: vi.fn(),
+	},
+	marketRefreshQueue: {
+		getJob: vi.fn(),
+		add: vi.fn(),
+	},
 }));
 
-let cancelMarket: typeof import('../src/features/markets/services/trading/cancel.js').cancelMarket;
-let calculateLossProtectionQuote: typeof import('../src/features/markets/services/trading/protection.js').calculateLossProtectionQuote;
-let calculateMarketTradeQuote: typeof import('../src/features/markets/services/trading/quotes.js').calculateMarketTradeQuote;
-let executeMarketTrade: typeof import('../src/features/markets/services/trading/execution.js').executeMarketTrade;
-let grantMarketBankroll: typeof import('../src/features/markets/services/account.js').grantMarketBankroll;
-let getMarketForecastLeaderboard: typeof import('../src/features/markets/services/forecast/queries.js').getMarketForecastLeaderboard;
-let getMarketForecastProfile: typeof import('../src/features/markets/services/forecast/queries.js').getMarketForecastProfile;
-let injectMarketLiquidity: typeof import('../src/features/markets/services/liquidity.js').injectMarketLiquidity;
-let appendMarketOutcomes: typeof import('../src/features/markets/services/records.js').appendMarketOutcomes;
-let editMarketRecord: typeof import('../src/features/markets/services/records.js').editMarketRecord;
-let purchaseLossProtection: typeof import('../src/features/markets/services/trading/protection.js').purchaseLossProtection;
-let resolveMarket: typeof import('../src/features/markets/services/trading/resolution.js').resolveMarket;
-let resolveMarketOutcome: typeof import('../src/features/markets/services/trading/resolution.js').resolveMarketOutcome;
-let summarizeMarketTraders: typeof import('../src/features/markets/services/records.js').summarizeMarketTraders;
-let syncLossProtectionForSellTx: typeof import('../src/features/markets/services/trading/protection.js').syncLossProtectionForSellTx;
+let cancelMarket: typeof import("../src/features/markets/services/trading/cancel.js").cancelMarket;
+let calculateLossProtectionQuote: typeof import("../src/features/markets/services/trading/protection.js").calculateLossProtectionQuote;
+let calculateMarketTradeQuote: typeof import("../src/features/markets/services/trading/quotes.js").calculateMarketTradeQuote;
+let executeMarketTrade: typeof import("../src/features/markets/services/trading/execution.js").executeMarketTrade;
+let grantMarketBankroll: typeof import("../src/features/markets/services/account.js").grantMarketBankroll;
+let getMarketForecastLeaderboard: typeof import("../src/features/markets/services/forecast/queries.js").getMarketForecastLeaderboard;
+let getMarketForecastProfile: typeof import("../src/features/markets/services/forecast/queries.js").getMarketForecastProfile;
+let getMarketForecastProfileDetails: typeof import("../src/features/markets/services/forecast/queries.js").getMarketForecastProfileDetails;
+let injectMarketLiquidity: typeof import("../src/features/markets/services/liquidity.js").injectMarketLiquidity;
+let appendMarketOutcomes: typeof import("../src/features/markets/services/records.js").appendMarketOutcomes;
+let editMarketRecord: typeof import("../src/features/markets/services/records.js").editMarketRecord;
+let purchaseLossProtection: typeof import("../src/features/markets/services/trading/protection.js").purchaseLossProtection;
+let resolveMarket: typeof import("../src/features/markets/services/trading/resolution.js").resolveMarket;
+let resolveMarketOutcome: typeof import("../src/features/markets/services/trading/resolution.js").resolveMarketOutcome;
+let summarizeMarketTraders: typeof import("../src/features/markets/services/records.js").summarizeMarketTraders;
+let syncLossProtectionForSellTx: typeof import("../src/features/markets/services/trading/protection.js").syncLossProtectionForSellTx;
 
 const baseAccount = {
-  id: 'account_1',
-  guildConfigId: 'guild_config_1',
-  guildId: 'guild_1',
-  userId: 'user_2',
-  bankroll: 1_000,
-  realizedProfit: 0,
-  lastTopUpAt: null,
-  createdAt: new Date('2099-03-29T00:00:00.000Z'),
-  updatedAt: new Date('2099-03-29T00:00:00.000Z'),
+	id: "account_1",
+	guildConfigId: "guild_config_1",
+	guildId: "guild_1",
+	userId: "user_2",
+	bankroll: 1_000,
+	realizedProfit: 0,
+	lastTopUpAt: null,
+	createdAt: new Date("2099-03-29T00:00:00.000Z"),
+	updatedAt: new Date("2099-03-29T00:00:00.000Z"),
 };
 
 const market = {
-  id: 'market_1',
-  guildId: 'guild_1',
-  creatorId: 'user_1',
-  originChannelId: 'origin_channel_1',
-  marketChannelId: 'market_channel_1',
-  messageId: 'message_market_1',
-  threadId: null,
-  title: 'Will turnout exceed 40%?',
-  description: 'A test market',
-  buttonStyle: 'primary' as const,
-  tags: ['meta'],
-  liquidityParameter: 150,
-  baseLiquidityParameter: 150,
-  maxLiquidityParameter: 450,
-  lastLiquidityInjectionAt: null,
-  closeAt: new Date('2099-03-30T00:00:00.000Z'),
-  tradingClosedAt: null,
-  resolutionGraceEndsAt: null,
-  graceNotifiedAt: null,
-  resolvedAt: null,
-  cancelledAt: null,
-  resolutionNote: null,
-  resolutionEvidenceUrl: null,
-  resolvedByUserId: null,
-  winningOutcomeId: null,
-  totalVolume: 0,
-  supplementaryBonusPool: 0,
-  supplementaryBonusDistributedAt: null,
-  supplementaryBonusExpiredAt: null,
-  createdAt: new Date('2099-03-29T00:00:00.000Z'),
-  updatedAt: new Date('2099-03-29T00:00:00.000Z'),
-  winningOutcome: null,
-  outcomes: [
-    { id: 'outcome_yes', marketId: 'market_1', label: 'Yes', sortOrder: 0, outstandingShares: 0, pricingShares: 0, settlementValue: null, resolvedAt: null, resolvedByUserId: null, resolutionNote: null, resolutionEvidenceUrl: null, createdAt: new Date('2099-03-29T00:00:00.000Z') },
-    { id: 'outcome_no', marketId: 'market_1', label: 'No', sortOrder: 1, outstandingShares: 0, pricingShares: 0, settlementValue: null, resolvedAt: null, resolvedByUserId: null, resolutionNote: null, resolutionEvidenceUrl: null, createdAt: new Date('2099-03-29T00:00:00.000Z') },
-  ],
-  trades: [],
-  positions: [],
-  lossProtections: [],
-  liquidityEvents: [],
+	id: "market_1",
+	guildId: "guild_1",
+	creatorId: "user_1",
+	originChannelId: "origin_channel_1",
+	marketChannelId: "market_channel_1",
+	messageId: "message_market_1",
+	threadId: null,
+	title: "Will turnout exceed 40%?",
+	description: "A test market",
+	buttonStyle: "primary" as const,
+	tags: ["meta"],
+	liquidityParameter: 150,
+	baseLiquidityParameter: 150,
+	maxLiquidityParameter: 450,
+	lastLiquidityInjectionAt: null,
+	closeAt: new Date("2099-03-30T00:00:00.000Z"),
+	tradingClosedAt: null,
+	resolutionGraceEndsAt: null,
+	graceNotifiedAt: null,
+	resolvedAt: null,
+	cancelledAt: null,
+	resolutionNote: null,
+	resolutionEvidenceUrl: null,
+	resolvedByUserId: null,
+	winningOutcomeId: null,
+	totalVolume: 0,
+	supplementaryBonusPool: 0,
+	supplementaryBonusDistributedAt: null,
+	supplementaryBonusExpiredAt: null,
+	createdAt: new Date("2099-03-29T00:00:00.000Z"),
+	updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+	winningOutcome: null,
+	outcomes: [
+		{
+			id: "outcome_yes",
+			marketId: "market_1",
+			label: "Yes",
+			sortOrder: 0,
+			outstandingShares: 0,
+			pricingShares: 0,
+			settlementValue: null,
+			resolvedAt: null,
+			resolvedByUserId: null,
+			resolutionNote: null,
+			resolutionEvidenceUrl: null,
+			createdAt: new Date("2099-03-29T00:00:00.000Z"),
+		},
+		{
+			id: "outcome_no",
+			marketId: "market_1",
+			label: "No",
+			sortOrder: 1,
+			outstandingShares: 0,
+			pricingShares: 0,
+			settlementValue: null,
+			resolvedAt: null,
+			resolvedByUserId: null,
+			resolutionNote: null,
+			resolutionEvidenceUrl: null,
+			createdAt: new Date("2099-03-29T00:00:00.000Z"),
+		},
+	],
+	trades: [],
+	positions: [],
+	lossProtections: [],
+	liquidityEvents: [],
 };
 
 type TestMarketPosition = {
-  id: string;
-  marketId: string;
-  outcomeId: string;
-  userId: string;
-  side: 'long' | 'short';
-  shares: number;
-  costBasis: number;
-  proceeds: number;
-  collateralLocked: number;
-  createdAt: Date;
-  updatedAt: Date;
+	id: string;
+	marketId: string;
+	outcomeId: string;
+	userId: string;
+	side: "long" | "short";
+	shares: number;
+	costBasis: number;
+	proceeds: number;
+	collateralLocked: number;
+	createdAt: Date;
+	updatedAt: Date;
 };
 
-const makeLongPosition = (overrides: Partial<TestMarketPosition> = {}): TestMarketPosition => ({
-  id: 'position_long',
-  marketId: 'market_1',
-  outcomeId: 'outcome_yes',
-  userId: 'user_2',
-  side: 'long' as const,
-  shares: 5,
-  costBasis: 60,
-  proceeds: 0,
-  collateralLocked: 0,
-  createdAt: new Date('2099-03-29T00:00:00.000Z'),
-  updatedAt: new Date('2099-03-29T00:00:00.000Z'),
-  ...overrides,
+const makeLongPosition = (
+	overrides: Partial<TestMarketPosition> = {},
+): TestMarketPosition => ({
+	id: "position_long",
+	marketId: "market_1",
+	outcomeId: "outcome_yes",
+	userId: "user_2",
+	side: "long" as const,
+	shares: 5,
+	costBasis: 60,
+	proceeds: 0,
+	collateralLocked: 0,
+	createdAt: new Date("2099-03-29T00:00:00.000Z"),
+	updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+	...overrides,
 });
 
-const makeShortPosition = (overrides: Partial<TestMarketPosition> = {}): TestMarketPosition => ({
-  id: 'position_short',
-  marketId: 'market_1',
-  outcomeId: 'outcome_yes',
-  userId: 'user_2',
-  side: 'short' as const,
-  shares: 5,
-  costBasis: 0,
-  proceeds: 25,
-  collateralLocked: 5,
-  createdAt: new Date('2099-03-29T00:00:00.000Z'),
-  updatedAt: new Date('2099-03-29T00:00:00.000Z'),
-  ...overrides,
+const makeShortPosition = (
+	overrides: Partial<TestMarketPosition> = {},
+): TestMarketPosition => ({
+	id: "position_short",
+	marketId: "market_1",
+	outcomeId: "outcome_yes",
+	userId: "user_2",
+	side: "short" as const,
+	shares: 5,
+	costBasis: 0,
+	proceeds: 25,
+	collateralLocked: 5,
+	createdAt: new Date("2099-03-29T00:00:00.000Z"),
+	updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+	...overrides,
 });
 
 const runTransaction = (): void => {
-  prisma.$transaction.mockImplementation(async (callback: (tx: typeof transaction) => Promise<unknown>) =>
-    callback(transaction));
+	prisma.$transaction.mockImplementation(
+		async (callback: (tx: typeof transaction) => Promise<unknown>) =>
+			callback(transaction),
+	);
 };
 
-describe('market service', () => {
-  beforeAll(async () => {
-    ({
-      cancelMarket,
-    } = await import('../src/features/markets/services/trading/cancel.js'));
-    ({
-      calculateLossProtectionQuote,
-      purchaseLossProtection,
-      syncLossProtectionForSellTx,
-    } = await import('../src/features/markets/services/trading/protection.js'));
-    ({
-      calculateMarketTradeQuote,
-    } = await import('../src/features/markets/services/trading/quotes.js'));
-    ({
-      executeMarketTrade,
-    } = await import('../src/features/markets/services/trading/execution.js'));
-    ({
-      resolveMarket,
-      resolveMarketOutcome,
-    } = await import('../src/features/markets/services/trading/resolution.js'));
-    ({
-      getMarketForecastLeaderboard,
-      getMarketForecastProfile,
-    } = await import('../src/features/markets/services/forecast/queries.js'));
-    ({
-      grantMarketBankroll,
-    } = await import('../src/features/markets/services/account.js'));
-    ({
-      injectMarketLiquidity,
-    } = await import('../src/features/markets/services/liquidity.js'));
-    ({
-      appendMarketOutcomes,
-      editMarketRecord,
-      summarizeMarketTraders,
-    } = await import('../src/features/markets/services/records.js'));
-  });
-
-  beforeEach(() => {
-    prisma.$transaction.mockReset();
-    transaction.guildConfig.upsert.mockReset();
-    transaction.market.findUnique.mockReset();
-    transaction.market.findUniqueOrThrow.mockReset();
-    transaction.market.update.mockReset();
-    prisma.market.findMany.mockReset();
-    transaction.marketOutcome.update.mockReset();
-    transaction.marketOutcome.deleteMany.mockReset();
-    transaction.marketPosition.deleteMany.mockReset();
-    transaction.marketPosition.upsert.mockReset();
-    transaction.marketAccount.findUnique.mockReset();
-    transaction.marketAccount.upsert.mockReset();
-    transaction.marketAccount.update.mockReset();
-    transaction.marketForecastRecord.upsert.mockReset();
-    transaction.marketLiquidityEvent.create.mockReset();
-    transaction.marketLossProtection.findMany.mockReset();
-    transaction.marketLossProtection.upsert.mockReset();
-    transaction.marketLossProtection.update.mockReset();
-    transaction.marketLossProtection.deleteMany.mockReset();
-    prisma.guildConfig.findUnique.mockReset();
-    prisma.marketAccount.findUnique.mockReset();
-    prisma.marketForecastRecord.findMany.mockReset();
-
-    transaction.guildConfig.upsert.mockResolvedValue({
-      id: 'guild_config_1',
-    });
-    transaction.market.findUnique.mockResolvedValue(market);
-    transaction.market.findUniqueOrThrow.mockResolvedValue(market);
-    transaction.marketOutcome.update.mockResolvedValue(undefined);
-    transaction.marketOutcome.deleteMany.mockResolvedValue({ count: 0 });
-    prisma.market.findMany.mockResolvedValue([]);
-    transaction.marketPosition.deleteMany.mockResolvedValue({ count: 0 });
-    transaction.marketPosition.upsert.mockResolvedValue(undefined);
-    transaction.marketAccount.findUnique.mockResolvedValue(baseAccount);
-    transaction.marketAccount.upsert.mockResolvedValue(baseAccount);
-    transaction.marketAccount.update.mockImplementation(async ({ data }: { data: Partial<typeof baseAccount> }) => ({
-      ...baseAccount,
-      ...data,
-    }));
-    transaction.marketForecastRecord.upsert.mockResolvedValue(undefined);
-    transaction.marketLiquidityEvent.create.mockResolvedValue(undefined);
-    transaction.marketLossProtection.findMany.mockResolvedValue([]);
-    transaction.marketLossProtection.upsert.mockResolvedValue(undefined);
-    transaction.marketLossProtection.update.mockResolvedValue(undefined);
-    transaction.marketLossProtection.deleteMany.mockResolvedValue({ count: 0 });
-    prisma.guildConfig.findUnique.mockResolvedValue({
-      casinoEnabled: false,
-    });
-    prisma.marketAccount.findUnique.mockResolvedValue(baseAccount);
-    prisma.marketForecastRecord.findMany.mockResolvedValue([]);
-    transaction.market.update
-      .mockResolvedValueOnce({
-        ...market,
-        updatedAt: new Date('2099-03-29T00:00:01.000Z'),
-      })
-      .mockResolvedValueOnce({
-        ...market,
-        totalVolume: 50,
-      });
-  });
-
-  it('retries serializable conflicts while executing a trade', async () => {
-    prisma.$transaction
-      .mockImplementationOnce(async () => {
-        const error = new Error('Serializable conflict');
-        (error as Error & { code?: string }).code = 'P2034';
-        throw error;
-      })
-      .mockImplementationOnce(async (callback: (tx: typeof transaction) => Promise<unknown>) =>
-        callback(transaction));
-
-    const result = await executeMarketTrade({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'buy',
-      amount: 50,
-    });
-
-    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
-    expect(prisma.$transaction).toHaveBeenNthCalledWith(
-      1,
-      expect.any(Function),
-      expect.objectContaining({
-        isolationLevel: 'Serializable',
-      }),
-    );
-    expect(result.cashAmount).toBe(50);
-    expect(transaction.market.findUnique).toHaveBeenCalledTimes(1);
-  });
-
-  it('retries serializable conflicts while resolving an outcome', async () => {
-    prisma.$transaction
-      .mockImplementationOnce(async () => {
-        const error = new Error('Serializable conflict');
-        (error as Error & { code?: string }).code = 'P2034';
-        throw error;
-      })
-      .mockImplementationOnce(async (callback: (tx: typeof transaction) => Promise<unknown>) =>
-        callback(transaction));
-
-    const updatedMarket = {
-      ...market,
-      outcomes: [
-        { ...market.outcomes[0], settlementValue: 0, resolvedAt: new Date('2099-03-30T12:00:00.000Z') },
-        market.outcomes[1],
-      ],
-    };
-    transaction.market.findUnique.mockResolvedValue(market);
-    transaction.market.findUniqueOrThrow.mockResolvedValue(updatedMarket);
-
-    const result = await resolveMarketOutcome({
-      marketId: 'market_1',
-      actorId: 'user_1',
-      outcomeId: 'outcome_yes',
-      note: 'Eliminated.',
-    });
-
-    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
-    expect(prisma.$transaction).toHaveBeenNthCalledWith(
-      1,
-      expect.any(Function),
-      expect.objectContaining({
-        isolationLevel: 'Serializable',
-      }),
-    );
-    expect(result.outcome.settlementValue).toBe(0);
-  });
-
-  it('appends outcomes to an open market without disturbing existing outcomes', async () => {
-    const updatedMarket = {
-      ...market,
-      outcomes: [
-        ...market.outcomes,
-        {
-          id: 'outcome_maybe',
-          marketId: 'market_1',
-          label: 'Maybe',
-          sortOrder: 2,
-          outstandingShares: 0,
-          pricingShares: 0,
-          settlementValue: null,
-          resolvedAt: null,
-          resolvedByUserId: null,
-          resolutionNote: null,
-          resolutionEvidenceUrl: null,
-          createdAt: new Date('2099-03-29T00:00:00.000Z'),
-        },
-      ],
-    };
-
-    runTransaction();
-    transaction.market.update.mockResolvedValueOnce(updatedMarket);
-    transaction.market.findUniqueOrThrow.mockResolvedValueOnce(updatedMarket);
-
-    const result = await appendMarketOutcomes('market_1', 'user_1', ['Maybe']);
-
-    expect(transaction.market.update).toHaveBeenCalledWith(expect.objectContaining({
-      where: {
-        id: 'market_1',
-      },
-      data: {
-        outcomes: {
-          create: [
-            {
-              label: 'Maybe',
-              sortOrder: 2,
-              pricingShares: 0,
-            },
-          ],
-        },
-      },
-    }));
-    expect(result.outcomes.map((outcome) => outcome.label)).toEqual(['Yes', 'No', 'Maybe']);
-  });
-
-  it('rejects appending an outcome label that already exists', async () => {
-    runTransaction();
-
-    await expect(appendMarketOutcomes('market_1', 'user_1', ['yes'])).rejects.toThrow(
-      'Outcome "yes" already exists in this market.',
-    );
-
-    expect(transaction.market.update).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    ['title', { title: 'Updated title' }],
-    ['description', { description: 'Updated description' }],
-    ['tags', { tags: ['updated'] }],
-    ['outcomes', { outcomes: ['Yes', 'No', 'Maybe'] }],
-  ])('rejects editing %s after the first trade', async (_field, input) => {
-    runTransaction();
-    transaction.market.findUnique.mockResolvedValue({
-      ...market,
-      trades: [{
-        id: 'trade_1',
-        marketId: 'market_1',
-        outcomeId: 'outcome_yes',
-        userId: 'user_2',
-        side: 'buy',
-        shareDelta: 5,
-        cashDelta: -40,
-        feeCharged: 0,
-        probabilitySnapshot: 0.55,
-        cumulativeVolume: 40,
-        createdAt: new Date('2099-03-29T01:00:00.000Z'),
-      }],
-    });
-
-    await expect(editMarketRecord('market_1', 'user_1', input)).rejects.toThrow(
-      'After the first trade, only close time and button style can be edited.',
-    );
-
-    expect(transaction.market.update).not.toHaveBeenCalled();
-    expect(transaction.marketOutcome.deleteMany).not.toHaveBeenCalled();
-  });
-
-  it('summarizes market traders by outgoing spend and trade count', () => {
-    const summary = summarizeMarketTraders({
-      ...market,
-      trades: [
-        {
-          id: 'trade_1',
-          marketId: 'market_1',
-          outcomeId: 'outcome_yes',
-          userId: 'user_2',
-          side: 'buy',
-          shareDelta: 5,
-          cashDelta: -40,
-          feeCharged: 0,
-          probabilitySnapshot: 0.55,
-          cumulativeVolume: 40,
-          createdAt: new Date('2099-03-29T01:00:00.000Z'),
-        },
-        {
-          id: 'trade_2',
-          marketId: 'market_1',
-          outcomeId: 'outcome_yes',
-          userId: 'user_2',
-          side: 'sell',
-          shareDelta: -2,
-          cashDelta: 15,
-          feeCharged: 0,
-          probabilitySnapshot: 0.58,
-          cumulativeVolume: 55,
-          createdAt: new Date('2099-03-29T02:00:00.000Z'),
-        },
-        {
-          id: 'trade_3',
-          marketId: 'market_1',
-          outcomeId: 'outcome_no',
-          userId: 'user_3',
-          side: 'short',
-          shareDelta: -3,
-          cashDelta: 20,
-          feeCharged: 0,
-          probabilitySnapshot: 0.35,
-          cumulativeVolume: 75,
-          createdAt: new Date('2099-03-29T03:00:00.000Z'),
-        },
-        {
-          id: 'trade_4',
-          marketId: 'market_1',
-          outcomeId: 'outcome_no',
-          userId: 'user_4',
-          side: 'buy',
-          shareDelta: 1,
-          cashDelta: -10,
-          feeCharged: 0,
-          probabilitySnapshot: 0.31,
-          cumulativeVolume: 85,
-          createdAt: new Date('2099-03-29T04:00:00.000Z'),
-        },
-      ],
-    });
-
-    expect(summary).toMatchObject({
-      marketId: 'market_1',
-      marketTitle: 'Will turnout exceed 40%?',
-      traderCount: 3,
-      totalSpent: 50,
-    });
-    expect(summary.entries).toEqual([
-      expect.objectContaining({
-        userId: 'user_2',
-        amountSpent: 40,
-        tradeCount: 2,
-      }),
-      expect.objectContaining({
-        userId: 'user_4',
-        amountSpent: 10,
-        tradeCount: 1,
-      }),
-      expect.objectContaining({
-        userId: 'user_3',
-        amountSpent: 0,
-        tradeCount: 1,
-      }),
-    ]);
-  });
-
-  it('returns an empty trader summary when a market has no trades', () => {
-    expect(summarizeMarketTraders(market)).toEqual({
-      marketId: 'market_1',
-      marketTitle: 'Will turnout exceed 40%?',
-      traderCount: 0,
-      totalSpent: 0,
-      entries: [],
-    });
-  });
-
-  it('does not count profitable trades as spend in the trader summary', () => {
-    const summary = summarizeMarketTraders({
-      ...market,
-      trades: [
-        {
-          id: 'trade_1',
-          marketId: 'market_1',
-          outcomeId: 'outcome_yes',
-          userId: 'user_2',
-          side: 'sell',
-          shareDelta: -2,
-          cashDelta: 15,
-          feeCharged: 0,
-          probabilitySnapshot: 0.58,
-          cumulativeVolume: 15,
-          createdAt: new Date('2099-03-29T02:00:00.000Z'),
-        },
-        {
-          id: 'trade_2',
-          marketId: 'market_1',
-          outcomeId: 'outcome_no',
-          userId: 'user_2',
-          side: 'short',
-          shareDelta: -3,
-          cashDelta: 20,
-          feeCharged: 0,
-          probabilitySnapshot: 0.35,
-          cumulativeVolume: 35,
-          createdAt: new Date('2099-03-29T03:00:00.000Z'),
-        },
-      ],
-    });
-
-    expect(summary.totalSpent).toBe(0);
-    expect(summary.entries).toEqual([
-      expect.objectContaining({
-        userId: 'user_2',
-        amountSpent: 0,
-        tradeCount: 2,
-      }),
-    ]);
-  });
-
-  it('supports selling a specific number of long shares', async () => {
-    const positionedMarket = {
-      ...market,
-      totalVolume: 100,
-      outcomes: [
-        { ...market.outcomes[0], outstandingShares: 5, pricingShares: 5 },
-        market.outcomes[1],
-      ],
-      positions: [makeLongPosition()],
-    };
-
-    transaction.market.findUnique.mockResolvedValue(positionedMarket);
-    transaction.market.update
-      .mockResolvedValueOnce({
-        ...positionedMarket,
-        updatedAt: new Date('2099-03-29T00:00:01.000Z'),
-      })
-      .mockResolvedValueOnce({
-        ...positionedMarket,
-        totalVolume: 140,
-      });
-    runTransaction();
-
-    const result = await executeMarketTrade({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'sell',
-      amount: 2.5,
-      amountMode: 'shares',
-    });
-
-    expect(result.shareDelta).toBeCloseTo(-2.5, 2);
-    expect(result.positionSide).toBe('long');
-    expect(result.cashAmount).toBeGreaterThan(0);
-    expect(transaction.market.update).toHaveBeenLastCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        totalVolume: positionedMarket.totalVolume + result.cashAmount,
-        trades: expect.objectContaining({
-          create: expect.objectContaining({
-            side: 'sell',
-            cashDelta: result.cashAmount,
-          }),
-        }),
-      }),
-    }));
-  });
-
-  it('opens a short position using a share amount', async () => {
-    runTransaction();
-
-    const result = await executeMarketTrade({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'short',
-      amount: 3,
-      amountMode: 'shares',
-    });
-
-    expect(result.shareDelta).toBeCloseTo(-3, 5);
-    expect(result.positionSide).toBe('short');
-    expect(result.cashAmount).toBeGreaterThan(0);
-    expect(transaction.marketPosition.upsert).toHaveBeenCalledWith(expect.objectContaining({
-      create: expect.objectContaining({
-        side: 'short',
-        shares: 3,
-        proceeds: result.cashAmount,
-        collateralLocked: 3,
-      }),
-    }));
-    expect(transaction.market.update).toHaveBeenLastCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        trades: expect.objectContaining({
-          create: expect.objectContaining({
-            side: 'short',
-            cashDelta: result.cashAmount,
-            shareDelta: -3,
-          }),
-        }),
-      }),
-    }));
-  });
-
-  it('rejects opening a short when a long already exists on that outcome', async () => {
-    transaction.market.findUnique.mockResolvedValue({
-      ...market,
-      positions: [makeLongPosition()],
-    });
-    runTransaction();
-
-    await expect(executeMarketTrade({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'short',
-      amount: 20,
-    })).rejects.toThrow('You must sell your long position in that outcome before shorting it.');
-  });
-
-  it('rejects buying an outcome while a short is open on it', async () => {
-    transaction.market.findUnique.mockResolvedValue({
-      ...market,
-      positions: [makeShortPosition()],
-    });
-    runTransaction();
-
-    await expect(executeMarketTrade({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'buy',
-      amount: 20,
-    })).rejects.toThrow('You must cover your short position in that outcome before buying it.');
-  });
-
-  it('ignores another user’s short position when buying an outcome', async () => {
-    transaction.market.findUnique.mockResolvedValue({
-      ...market,
-      positions: [
-        makeShortPosition({
-          userId: 'user_3',
-        }),
-      ],
-    });
-    runTransaction();
-
-    const result = await executeMarketTrade({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'buy',
-      amount: 20,
-    });
-
-    expect(result.positionSide).toBe('long');
-    expect(result.cashAmount).toBe(20);
-    expect(transaction.marketPosition.upsert).toHaveBeenCalledWith(expect.objectContaining({
-      create: expect.objectContaining({
-        userId: 'user_2',
-        side: 'long',
-      }),
-    }));
-  });
-
-  it('rejects trading an outcome that has already been resolved', async () => {
-    transaction.market.findUnique.mockResolvedValue({
-      ...market,
-      outcomes: [
-        { ...market.outcomes[0], settlementValue: 0, resolvedAt: new Date('2099-03-30T00:00:00.000Z') },
-        market.outcomes[1],
-      ],
-    });
-    runTransaction();
-
-    await expect(executeMarketTrade({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'buy',
-      amount: 20,
-    })).rejects.toThrow('Trading on Yes is closed because that outcome has already been resolved.');
-  });
-
-  it('rejects buying an outcome above the 98% lock threshold', async () => {
-    transaction.market.findUnique.mockResolvedValue({
-      ...market,
-      outcomes: [
-        { ...market.outcomes[0], outstandingShares: 600, pricingShares: 600 },
-        { ...market.outcomes[1], outstandingShares: 0, pricingShares: 0 },
-      ],
-    });
-    runTransaction();
-
-    await expect(executeMarketTrade({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'buy',
-      amount: 20,
-    })).rejects.toThrow('Yes on **Yes** is locked above 98%.');
-  });
-
-  it('rejects shorting an outcome below the 2% lock threshold', async () => {
-    transaction.market.findUnique.mockResolvedValue({
-      ...market,
-      outcomes: [
-        { ...market.outcomes[0], outstandingShares: -600, pricingShares: -600 },
-        { ...market.outcomes[1], outstandingShares: 0, pricingShares: 0 },
-      ],
-    });
-    runTransaction();
-
-    await expect(executeMarketTrade({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'short',
-      amount: 20,
-    })).rejects.toThrow('No on **Yes** is locked below 2%.');
-  });
-
-  it('rejects shorts that cannot be fully collateralized', async () => {
-    transaction.marketAccount.upsert.mockResolvedValue({
-      ...baseAccount,
-      bankroll: 0,
-      lastTopUpAt: new Date(),
-    });
-    runTransaction();
-
-    await expect(executeMarketTrade({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'short',
-      amount: 4,
-      amountMode: 'shares',
-    })).rejects.toThrow('You do not have enough bankroll to collateralize that short.');
-  });
-
-  it('covers a short position and realizes profit', async () => {
-    const positionedMarket = {
-      ...market,
-      totalVolume: 125,
-      outcomes: [
-        { ...market.outcomes[0], outstandingShares: -5, pricingShares: -5 },
-        market.outcomes[1],
-      ],
-      positions: [makeShortPosition()],
-    };
-
-    transaction.market.findUnique.mockResolvedValue(positionedMarket);
-    transaction.market.update
-      .mockResolvedValueOnce({
-        ...positionedMarket,
-        updatedAt: new Date('2099-03-29T00:00:01.000Z'),
-      })
-      .mockResolvedValueOnce({
-        ...positionedMarket,
-        totalVolume: 140,
-      });
-    runTransaction();
-
-    const result = await executeMarketTrade({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'cover',
-      amount: 2,
-      amountMode: 'shares',
-    });
-
-    expect(result.shareDelta).toBeCloseTo(2, 5);
-    expect(result.positionSide).toBe('short');
-    expect(result.realizedProfitDelta).toBeGreaterThan(0);
-    expect(transaction.market.update).toHaveBeenLastCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        trades: expect.objectContaining({
-          create: expect.objectContaining({
-            side: 'cover',
-            cashDelta: -result.cashAmount,
-            shareDelta: 2,
-          }),
-        }),
-      }),
-    }));
-  });
-
-  it('removes a short position after it is fully covered', async () => {
-    const positionedMarket = {
-      ...market,
-      outcomes: [
-        { ...market.outcomes[0], outstandingShares: -5, pricingShares: -5 },
-        market.outcomes[1],
-      ],
-      positions: [makeShortPosition()],
-    };
-
-    transaction.market.findUnique.mockResolvedValue(positionedMarket);
-    runTransaction();
-
-    await executeMarketTrade({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'cover',
-      amount: 5,
-      amountMode: 'shares',
-    });
-
-    expect(transaction.marketPosition.deleteMany).toHaveBeenCalledWith(expect.objectContaining({
-      where: expect.objectContaining({
-        side: 'short',
-      }),
-    }));
-  });
-
-  it('rejects covering an outcome without an open short', async () => {
-    runTransaction();
-
-    await expect(executeMarketTrade({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'cover',
-      amount: 20,
-    })).rejects.toThrow('You do not have a short position in that outcome yet.');
-  });
-
-  it('resolves shorts against the winning outcome as losses', async () => {
-    const shortMarket = {
-      ...market,
-      tradingClosedAt: new Date('2099-03-30T00:00:00.000Z'),
-      positions: [makeShortPosition({ proceeds: 3, collateralLocked: 5 })],
-    };
-
-    transaction.market.findUnique.mockResolvedValue(shortMarket);
-    transaction.market.update.mockResolvedValue({
-      ...shortMarket,
-      resolvedAt: new Date('2099-03-30T12:00:00.000Z'),
-      winningOutcomeId: 'outcome_yes',
-    });
-    runTransaction();
-
-    const result = await resolveMarket({
-      marketId: 'market_1',
-      actorId: 'user_1',
-      winningOutcomeId: 'outcome_yes',
-    });
-
-    expect(result.payouts).toEqual([
-      expect.objectContaining({
-        userId: 'user_2',
-        payout: 0,
-        profit: -2,
-        bonus: 0,
-      }),
-    ]);
-    expect(transaction.marketAccount.update).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        bankroll: 1_000,
-        realizedProfit: -2,
-      }),
-    }));
-  });
-
-  it('resolves an eliminated outcome without closing the whole market', async () => {
-    const openMarket = {
-      ...market,
-      supplementaryBonusPool: 12,
-      positions: [
-        makeLongPosition(),
-        makeShortPosition({ outcomeId: 'outcome_no', proceeds: 4, collateralLocked: 6, shares: 6 }),
-      ],
-    };
-    const updatedMarket = {
-      ...openMarket,
-      outcomes: [
-        { ...openMarket.outcomes[0], outstandingShares: 0, pricingShares: 0, settlementValue: 0, resolvedAt: new Date('2099-03-30T12:00:00.000Z') },
-        openMarket.outcomes[1],
-      ],
-      supplementaryBonusPool: 12,
-      supplementaryBonusDistributedAt: null,
-      positions: [
-        makeShortPosition({ outcomeId: 'outcome_no', proceeds: 4, collateralLocked: 6, shares: 6 }),
-      ],
-    };
-
-    transaction.market.findUnique.mockResolvedValue(openMarket);
-    transaction.market.findUniqueOrThrow.mockResolvedValue(updatedMarket);
-    runTransaction();
-
-    const result = await resolveMarketOutcome({
-      marketId: 'market_1',
-      actorId: 'user_1',
-      outcomeId: 'outcome_yes',
-      note: 'Knocked out in the semifinal.',
-    });
-
-    expect(result.market.resolvedAt).toBeNull();
-    expect(result.market.supplementaryBonusPool).toBe(12);
-    expect(result.market.supplementaryBonusDistributedAt).toBeNull();
-    expect(result.outcome.settlementValue).toBe(0);
-    expect(result.payouts).toEqual([
-      {
-        userId: 'user_2',
-        payout: 0,
-        profit: -60,
-        bonus: 0,
-      },
-    ]);
-    expect(transaction.marketPosition.deleteMany).toHaveBeenCalledWith({
-      where: {
-        marketId: 'market_1',
-        outcomeId: 'outcome_yes',
-      },
-    });
-    expect(transaction.marketOutcome.update).toHaveBeenCalledWith(expect.objectContaining({
-      where: {
-        id: 'outcome_yes',
-      },
-      data: expect.objectContaining({
-        outstandingShares: 0,
-        settlementValue: 0,
-        resolutionNote: 'Knocked out in the semifinal.',
-      }),
-    }));
-  });
-
-  it('resolves shorts on losing outcomes by releasing collateral', async () => {
-    const shortMarket = {
-      ...market,
-      tradingClosedAt: new Date('2099-03-30T00:00:00.000Z'),
-      trades: [
-        {
-          id: 'trade_1',
-          marketId: 'market_1',
-          outcomeId: 'outcome_yes',
-          userId: 'user_2',
-          side: 'short' as const,
-          cashDelta: 20,
-          shareDelta: -3,
-          feeCharged: 0,
-          probabilitySnapshot: 0.4,
-          cumulativeVolume: 20,
-          createdAt: new Date('2099-03-29T01:00:00.000Z'),
-        },
-        {
-          id: 'trade_2',
-          marketId: 'market_1',
-          outcomeId: 'outcome_no',
-          userId: 'user_2',
-          side: 'buy' as const,
-          cashDelta: -10,
-          shareDelta: 2,
-          feeCharged: 0,
-          probabilitySnapshot: 0.6,
-          cumulativeVolume: 30,
-          createdAt: new Date('2099-03-29T02:00:00.000Z'),
-        },
-      ],
-      positions: [makeShortPosition({ proceeds: 3, collateralLocked: 5 })],
-    };
-
-    transaction.market.findUnique.mockResolvedValue(shortMarket);
-    transaction.market.update.mockResolvedValue({
-      ...shortMarket,
-      resolvedAt: new Date('2099-03-30T12:00:00.000Z'),
-      winningOutcomeId: 'outcome_no',
-    });
-    runTransaction();
-
-    const result = await resolveMarket({
-      marketId: 'market_1',
-      actorId: 'user_1',
-      winningOutcomeId: 'outcome_no',
-    });
-
-    expect(result.payouts).toEqual([
-      expect.objectContaining({
-        userId: 'user_2',
-        payout: 5,
-        profit: 3,
-        bonus: 0,
-      }),
-    ]);
-    expect(transaction.marketAccount.update).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        bankroll: 1_005,
-        realizedProfit: 3,
-      }),
-    }));
-  });
-
-  it('injects supplementary liquidity by rebasing pricing shares without changing outstanding exposure', async () => {
-    const now = new Date('2099-03-29T02:00:00.000Z');
-    const liquidMarket = {
-      ...market,
-      outcomes: [
-        { ...market.outcomes[0], outstandingShares: 10, pricingShares: 10 },
-        market.outcomes[1],
-      ],
-    };
-    const updatedMarket = {
-      ...liquidMarket,
-      liquidityParameter: 169,
-      lastLiquidityInjectionAt: now,
-      supplementaryBonusPool: 6.58,
-      liquidityEvents: [{
-        id: 'liquidity_1',
-        marketId: 'market_1',
-        previousLiquidityParameter: 150,
-        nextLiquidityParameter: 169,
-        scaleFactor: 169 / 150,
-        bonusAccrued: 6.58,
-        createdAt: now,
-      }],
-    };
-
-    transaction.market.findUnique.mockResolvedValue(liquidMarket);
-    transaction.market.update.mockResolvedValue(updatedMarket);
-    runTransaction();
-
-    const result = await injectMarketLiquidity('market_1', now);
-
-    expect(result.didInject).toBe(true);
-    expect(transaction.marketOutcome.update).toHaveBeenCalledWith(expect.objectContaining({
-      where: {
-        id: 'outcome_yes',
-      },
-      data: expect.objectContaining({
-        outstandingShares: 10,
-        pricingShares: expect.closeTo(11.27, 2),
-      }),
-    }));
-    expect(transaction.marketLiquidityEvent.create).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        previousLiquidityParameter: 150,
-        nextLiquidityParameter: 169,
-        scaleFactor: expect.closeTo(169 / 150, 5),
-        bonusAccrued: 6.58,
-      }),
-    }));
-    expect(transaction.market.update).toHaveBeenLastCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        liquidityParameter: 169,
-        supplementaryBonusPool: 6.58,
-      }),
-    }));
-  });
-
-  it('skips liquidity injection when the target liquidity matches the current market', async () => {
-    const now = new Date('2099-03-29T00:30:00.000Z');
-    runTransaction();
-
-    const result = await injectMarketLiquidity('market_1', now);
-
-    expect(result.didInject).toBe(false);
-    expect(result.bonusAccrued).toBe(0);
-    expect(result.nextInjectionAt?.toISOString()).toBe('2099-03-29T01:00:00.000Z');
-    expect(result.market).toBe(market);
-    expect(transaction.marketOutcome.update).not.toHaveBeenCalled();
-    expect(transaction.marketLiquidityEvent.create).not.toHaveBeenCalled();
-    expect(transaction.market.update).not.toHaveBeenCalled();
-  });
-
-  it('distributes the supplementary bonus pool in proportion to positive market profit', async () => {
-    const resolvedAt = new Date('2099-03-30T12:00:00.000Z');
-    const bonusMarket = {
-      ...market,
-      tradingClosedAt: new Date('2099-03-30T00:00:00.000Z'),
-      supplementaryBonusPool: 12,
-      positions: [
-        makeLongPosition({ userId: 'user_2', shares: 10, costBasis: 8 }),
-        makeShortPosition({ userId: 'user_3', outcomeId: 'outcome_no', shares: 4, proceeds: 6, collateralLocked: 4 }),
-      ],
-    };
-
-    vi.useFakeTimers();
-    vi.setSystemTime(resolvedAt);
-    transaction.market.findUnique.mockResolvedValue(bonusMarket);
-    transaction.marketAccount.upsert.mockImplementation(async ({ where }: {
-      where: {
-        guildId_userId: {
-          guildId: string;
-          userId: string;
-        };
-      };
-    }) => ({
-      ...baseAccount,
-      id: `account_${where.guildId_userId.userId}`,
-      userId: where.guildId_userId.userId,
-    }));
-    transaction.market.update.mockResolvedValue({
-      ...bonusMarket,
-      resolvedAt,
-      winningOutcomeId: 'outcome_yes',
-      supplementaryBonusDistributedAt: resolvedAt,
-    });
-    runTransaction();
-
-    try {
-      const result = await resolveMarket({
-        marketId: 'market_1',
-        actorId: 'user_1',
-        winningOutcomeId: 'outcome_yes',
-      });
-
-      expect(result.payouts).toEqual(expect.arrayContaining([
-        expect.objectContaining({
-          userId: 'user_2',
-          payout: 10,
-          profit: 2,
-          bonus: 3,
-        }),
-        expect.objectContaining({
-          userId: 'user_3',
-          payout: 4,
-          profit: 6,
-          bonus: 9,
-        }),
-      ]));
-      expect(transaction.market.update).toHaveBeenCalledWith(expect.objectContaining({
-        data: expect.objectContaining({
-          supplementaryBonusDistributedAt: resolvedAt,
-          supplementaryBonusExpiredAt: null,
-        }),
-      }));
-      expect(transaction.marketAccount.update).toHaveBeenNthCalledWith(1, expect.objectContaining({
-        where: {
-          id: 'account_user_2',
-        },
-        data: expect.objectContaining({
-          bankroll: 1013,
-          realizedProfit: 5,
-        }),
-      }));
-      expect(transaction.marketAccount.update).toHaveBeenNthCalledWith(2, expect.objectContaining({
-        where: {
-          id: 'account_user_3',
-        },
-        data: expect.objectContaining({
-          bankroll: 1013,
-          realizedProfit: 15,
-        }),
-      }));
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('quotes a buy trade with payout information before execution', async () => {
-    prisma.market.findUnique.mockResolvedValue(market);
-    prisma.marketAccount.findUnique.mockResolvedValue(baseAccount);
-
-    const quote = await calculateMarketTradeQuote({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'buy',
-      amount: 50,
-      amountMode: 'points',
-      rawAmount: '50',
-    });
-
-    expect(quote.action).toBe('buy');
-    expect(quote.immediateCash).toBe(50);
-    expect(quote.settlementIfChosen).toBeGreaterThan(0);
-    expect(quote.maxLossIfNotChosen).toBe(50);
-  });
-
-  it('quotes a short trade with both outcome scenarios', async () => {
-    prisma.market.findUnique.mockResolvedValue(market);
-    prisma.marketAccount.findUnique.mockResolvedValue(baseAccount);
-
-    const quote = await calculateMarketTradeQuote({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'short',
-      amount: 10,
-      amountMode: 'points',
-      rawAmount: '10 pts',
-    });
-
-    expect(quote.action).toBe('short');
-    expect(quote.immediateCash).toBe(10);
-    expect(quote.collateralLocked).toBeGreaterThan(0);
-    expect(quote.settlementIfChosen).toBe(0);
-    expect(quote.settlementIfNotChosen).toBeGreaterThan(0);
-  });
-
-  it('quotes incremental long loss protection against the current position basis', async () => {
-    prisma.market.findUnique.mockResolvedValue({
-      ...market,
-      positions: [makeLongPosition({ costBasis: 80, shares: 10 })],
-      lossProtections: [{
-        id: 'protection_1',
-        marketId: 'market_1',
-        outcomeId: 'outcome_yes',
-        userId: 'user_2',
-        insuredCostBasis: 20,
-        premiumPaid: 5,
-        createdAt: new Date('2099-03-29T00:30:00.000Z'),
-        updatedAt: new Date('2099-03-29T00:30:00.000Z'),
-      }],
-      outcomes: [
-        { ...market.outcomes[0], pricingShares: 20, outstandingShares: 20 },
-        { ...market.outcomes[1], pricingShares: 0, outstandingShares: 0 },
-      ],
-    });
-
-    const quote = await calculateLossProtectionQuote({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      targetCoverage: 0.5,
-    });
-
-    expect(quote.currentLongCostBasis).toBe(80);
-    expect(quote.alreadyInsuredCostBasis).toBe(20);
-    expect(quote.targetInsuredCostBasis).toBe(40);
-    expect(quote.incrementalInsuredCostBasis).toBe(20);
-    expect(quote.premium).toBeGreaterThan(0);
-  });
-
-  it('purchases long loss protection and debits bankroll/profit by the premium', async () => {
-    runTransaction();
-    transaction.market.findUnique.mockResolvedValue({
-      ...market,
-      positions: [makeLongPosition({ costBasis: 60, shares: 6 })],
-      lossProtections: [],
-    });
-    transaction.market.findUniqueOrThrow.mockResolvedValue({
-      ...market,
-      positions: [makeLongPosition({ costBasis: 60, shares: 6 })],
-      lossProtections: [{
-        id: 'protection_1',
-        marketId: 'market_1',
-        outcomeId: 'outcome_yes',
-        userId: 'user_2',
-        insuredCostBasis: 30,
-        premiumPaid: 15.75,
-        createdAt: new Date('2099-03-29T00:30:00.000Z'),
-        updatedAt: new Date('2099-03-29T00:30:00.000Z'),
-      }],
-    });
-
-    const result = await purchaseLossProtection({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      targetCoverage: 0.5,
-    });
-
-    expect(transaction.marketLossProtection.upsert).toHaveBeenCalledWith(expect.objectContaining({
-      create: expect.objectContaining({
-        insuredCostBasis: 30,
-      }),
-    }));
-    expect(transaction.marketAccount.update).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        bankroll: expect.any(Number),
-        realizedProfit: expect.any(Number),
-      }),
-    }));
-    expect(result.insuredCostBasis).toBe(30);
-    expect(result.premiumCharged).toBeGreaterThan(0);
-    expect(result.account.bankroll).toBeLessThan(baseAccount.bankroll);
-    expect(result.account.realizedProfit).toBeLessThanOrEqual(baseAccount.realizedProfit);
-  });
-
-  it('shrinks insured basis proportionally after a partial sell', async () => {
-    runTransaction();
-
-    await syncLossProtectionForSellTx(transaction as never, {
-      existingProtection: {
-        id: 'protection_1',
-        marketId: 'market_1',
-        outcomeId: 'outcome_yes',
-        userId: 'user_2',
-        insuredCostBasis: 60,
-      },
-      previousLongCostBasis: 100,
-      nextLongCostBasis: 40,
-    });
-
-    expect(transaction.marketLossProtection.update).toHaveBeenCalledWith(expect.objectContaining({
-      data: {
-        insuredCostBasis: 24,
-      },
-    }));
-  });
-
-  it('rejects buy quotes requested in shares mode', async () => {
-    await expect(calculateMarketTradeQuote({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'buy',
-      amount: 5,
-      amountMode: 'shares',
-      rawAmount: '5 shares',
-    } as never)).rejects.toThrow('Buy quotes only support point amounts.');
-  });
-
-  it('rejects non-positive trade amounts in quote calculation', async () => {
-    await expect(calculateMarketTradeQuote({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'buy',
-      amount: 0,
-      rawAmount: '0',
-    })).rejects.toThrow('Trade amount must be a finite value greater than zero.');
-  });
-
-  it('rejects non-positive trade amounts in execution', async () => {
-    runTransaction();
-
-    await expect(executeMarketTrade({
-      marketId: 'market_1',
-      userId: 'user_2',
-      outcomeId: 'outcome_yes',
-      action: 'buy',
-      amount: -10,
-    })).rejects.toThrow('Trade amount must be a finite value greater than zero.');
-  });
-
-  it('reconstructs the full probability vector for multi-outcome forecast records', async () => {
-    const resolvedAt = new Date('2099-03-30T12:00:00.000Z');
-    const threeOutcomeMarket = {
-      ...market,
-      outcomes: [
-        { ...market.outcomes[0], id: 'outcome_a', label: 'A' },
-        { ...market.outcomes[1], id: 'outcome_b', label: 'B' },
-        { ...market.outcomes[1], id: 'outcome_c', label: 'C', sortOrder: 2 },
-      ],
-      trades: [
-        {
-          id: 'trade_1',
-          marketId: 'market_1',
-          outcomeId: 'outcome_a',
-          userId: 'user_2',
-          side: 'buy' as const,
-          shareDelta: 30,
-          cashDelta: -30,
-          feeCharged: 0,
-          probabilitySnapshot: 0.3792,
-          cumulativeVolume: 30,
-          createdAt: new Date('2099-03-29T01:00:00.000Z'),
-        },
-        {
-          id: 'trade_2',
-          marketId: 'market_1',
-          outcomeId: 'outcome_b',
-          userId: 'user_2',
-          side: 'buy' as const,
-          shareDelta: 30,
-          cashDelta: -30,
-          feeCharged: 0,
-          probabilitySnapshot: 0.3649,
-          cumulativeVolume: 60,
-          createdAt: new Date('2099-03-29T02:00:00.000Z'),
-        },
-      ],
-      positions: [],
-    };
-    const resolvedMarket = {
-      ...threeOutcomeMarket,
-      resolvedAt,
-      tradingClosedAt: resolvedAt,
-      winningOutcomeId: 'outcome_b',
-      outcomes: threeOutcomeMarket.outcomes.map((outcome) => ({
-        ...outcome,
-        settlementValue: outcome.id === 'outcome_b' ? 1 : 0,
-        resolvedAt,
-        resolvedByUserId: 'user_1',
-      })),
-    };
-
-    transaction.market.findUnique.mockResolvedValue(threeOutcomeMarket);
-    transaction.market.update.mockReset();
-    transaction.market.update.mockResolvedValue(resolvedMarket);
-    runTransaction();
-
-    await resolveMarket({
-      marketId: 'market_1',
-      actorId: 'user_1',
-      winningOutcomeId: 'outcome_b',
-    });
-
-    const persistedRecord = transaction.marketForecastRecord.upsert.mock.calls[0]?.[0]?.create;
-    const forecastByOutcome = Object.fromEntries(
-      persistedRecord.forecastVector.map((entry: { outcomeId: string; probability: number }) => [entry.outcomeId, entry.probability]),
-    );
-
-    expect(forecastByOutcome.outcome_a).toBeGreaterThan(0.35);
-    expect(forecastByOutcome.outcome_a).toBeLessThan(0.38);
-    expect(forecastByOutcome.outcome_b).toBeGreaterThan(0.32);
-    expect(forecastByOutcome.outcome_b).toBeLessThan(0.34);
-    expect(forecastByOutcome.outcome_c).toBeGreaterThan(0.29);
-    expect(forecastByOutcome.outcome_c).toBeLessThan(0.31);
-  });
-
-  it('builds forecast leaderboard and profile aggregates from stored forecast records', async () => {
-    const now = new Date();
-    prisma.market.findMany.mockResolvedValue([]);
-    prisma.marketForecastRecord.findMany.mockResolvedValue([
-      {
-        id: 'forecast_1',
-        guildId: 'guild_1',
-        marketId: 'market_1',
-        userId: 'user_2',
-        resolvedAt: new Date(now.getTime() - (5 * 24 * 60 * 60 * 1_000)),
-        marketTagSnapshot: ['meta'],
-        forecastVector: [{ outcomeId: 'outcome_yes', probability: 0.7 }, { outcomeId: 'outcome_no', probability: 0.3 }],
-        winningOutcomeId: 'outcome_yes',
-        winningOutcomeProbability: 0.7,
-        predictedOutcomeId: 'outcome_yes',
-        brierScore: 0.12,
-        wasCorrect: true,
-        realizedProfit: 5,
-        tradeCount: 3,
-        stakeWeight: 80,
-        createdAt: now,
-        updatedAt: now,
-      },
-      {
-        id: 'forecast_2',
-        guildId: 'guild_1',
-        marketId: 'market_2',
-        userId: 'user_2',
-        resolvedAt: new Date(now.getTime() - (3 * 24 * 60 * 60 * 1_000)),
-        marketTagSnapshot: ['meta'],
-        forecastVector: [{ outcomeId: 'outcome_yes', probability: 0.4 }, { outcomeId: 'outcome_no', probability: 0.6 }],
-        winningOutcomeId: 'outcome_no',
-        winningOutcomeProbability: 0.6,
-        predictedOutcomeId: 'outcome_no',
-        brierScore: 0.2,
-        wasCorrect: true,
-        realizedProfit: 2,
-        tradeCount: 2,
-        stakeWeight: 40,
-        createdAt: now,
-        updatedAt: now,
-      },
-      {
-        id: 'forecast_3',
-        guildId: 'guild_1',
-        marketId: 'market_3',
-        userId: 'user_2',
-        resolvedAt: new Date(now.getTime() - (1 * 24 * 60 * 60 * 1_000)),
-        marketTagSnapshot: ['meta'],
-        forecastVector: [{ outcomeId: 'outcome_yes', probability: 0.8 }, { outcomeId: 'outcome_no', probability: 0.2 }],
-        winningOutcomeId: 'outcome_no',
-        winningOutcomeProbability: 0.2,
-        predictedOutcomeId: 'outcome_yes',
-        brierScore: 0.3,
-        wasCorrect: false,
-        realizedProfit: -3,
-        tradeCount: 4,
-        stakeWeight: 60,
-        createdAt: now,
-        updatedAt: now,
-      },
-      {
-        id: 'forecast_4',
-        guildId: 'guild_1',
-        marketId: 'market_4',
-        userId: 'user_3',
-        resolvedAt: new Date(now.getTime() - (2 * 24 * 60 * 60 * 1_000)),
-        marketTagSnapshot: ['meta'],
-        forecastVector: [{ outcomeId: 'outcome_yes', probability: 0.55 }, { outcomeId: 'outcome_no', probability: 0.45 }],
-        winningOutcomeId: 'outcome_yes',
-        winningOutcomeProbability: 0.55,
-        predictedOutcomeId: 'outcome_yes',
-        brierScore: 0.16,
-        wasCorrect: true,
-        realizedProfit: 1,
-        tradeCount: 2,
-        stakeWeight: 30,
-        createdAt: now,
-        updatedAt: now,
-      },
-      {
-        id: 'forecast_5',
-        guildId: 'guild_1',
-        marketId: 'market_5',
-        userId: 'user_2',
-        resolvedAt: new Date(now.getTime() - (35 * 24 * 60 * 60 * 1_000)),
-        marketTagSnapshot: ['meta'],
-        forecastVector: [{ outcomeId: 'outcome_yes', probability: 0.6 }, { outcomeId: 'outcome_no', probability: 0.4 }],
-        winningOutcomeId: 'outcome_yes',
-        winningOutcomeProbability: 0.6,
-        predictedOutcomeId: 'outcome_yes',
-        brierScore: 0.1,
-        wasCorrect: true,
-        realizedProfit: 4,
-        tradeCount: 2,
-        stakeWeight: 35,
-        createdAt: now,
-        updatedAt: now,
-      },
-      {
-        id: 'forecast_6',
-        guildId: 'guild_1',
-        marketId: 'market_6',
-        userId: 'user_2',
-        resolvedAt: new Date(now.getTime() - (20 * 24 * 60 * 60 * 1_000)),
-        marketTagSnapshot: ['meta'],
-        forecastVector: [{ outcomeId: 'outcome_yes', probability: 0.52 }, { outcomeId: 'outcome_no', probability: 0.48 }],
-        winningOutcomeId: 'outcome_yes',
-        winningOutcomeProbability: 0.52,
-        predictedOutcomeId: 'outcome_yes',
-        brierScore: 0.18,
-        wasCorrect: true,
-        realizedProfit: 3,
-        tradeCount: 2,
-        stakeWeight: 35,
-        createdAt: now,
-        updatedAt: now,
-      },
-    ]);
-
-    const profile = await getMarketForecastProfile('guild_1', 'user_2');
-    const leaderboard = await getMarketForecastLeaderboard({
-      guildId: 'guild_1',
-      window: 'all_time',
-      tag: 'meta',
-    });
-
-    expect(profile.allTimeSampleCount).toBe(5);
-    expect(profile.thirtyDaySampleCount).toBe(4);
-    expect(profile.thirtyDayMeanBrier).toBe(0.2);
-    expect(profile.topTags[0]).toEqual(expect.objectContaining({
-      tag: 'meta',
-    }));
-    expect(leaderboard).toHaveLength(1);
-    expect(leaderboard[0]).toEqual(expect.objectContaining({
-      userId: 'user_2',
-    }));
-  });
-
-  it('returns empty forecast metrics when no forecast records exist', async () => {
-    const profile = await getMarketForecastProfile('guild_empty', 'user_9');
-    const leaderboard = await getMarketForecastLeaderboard({
-      guildId: 'guild_empty',
-      window: '30d',
-    });
-
-    expect(profile).toEqual(expect.objectContaining({
-      allTimeMeanBrier: null,
-      thirtyDayMeanBrier: null,
-      allTimeSampleCount: 0,
-      thirtyDaySampleCount: 0,
-      rank: null,
-      percentileRank: null,
-    }));
-    expect(leaderboard).toEqual([]);
-  });
-
-  it('does not block forecast reads on a historical backfill pass', async () => {
-    prisma.market.findMany.mockImplementation(() => new Promise(() => undefined));
-    prisma.marketForecastRecord.findMany.mockResolvedValue([
-      {
-        id: 'forecast_pending',
-        guildId: 'guild_pending_backfill',
-        marketId: 'market_1',
-        userId: 'user_2',
-        resolvedAt: new Date('2099-03-29T00:00:00.000Z'),
-        marketTagSnapshot: ['meta'],
-        forecastVector: [{ outcomeId: 'outcome_yes', probability: 0.7 }, { outcomeId: 'outcome_no', probability: 0.3 }],
-        winningOutcomeId: 'outcome_yes',
-        winningOutcomeProbability: 0.7,
-        predictedOutcomeId: 'outcome_yes',
-        brierScore: 0.12,
-        wasCorrect: true,
-        realizedProfit: 5,
-        tradeCount: 3,
-        stakeWeight: 80,
-        createdAt: new Date('2099-03-29T00:00:00.000Z'),
-        updatedAt: new Date('2099-03-29T00:00:00.000Z'),
-      },
-    ]);
-
-    const profile = await getMarketForecastProfile('guild_pending_backfill', 'user_2');
-
-    expect(profile.allTimeSampleCount).toBe(1);
-    expect(profile.allTimeMeanBrier).toBe(0.12);
-  });
-
-  it('rejects grants above the configured maximum', async () => {
-    await expect(grantMarketBankroll({
-      guildId: 'guild_1',
-      userId: 'user_2',
-      amount: 1_000_000.01,
-    })).rejects.toThrow('Grant amount cannot exceed 1000000.00 points.');
-  });
-
-  it('cancels a market by refunding long basis and unwinding short proceeds', async () => {
-    const cancelledMarket = {
-      ...market,
-      positions: [
-        makeLongPosition(),
-        makeShortPosition({ outcomeId: 'outcome_no', proceeds: 4, collateralLocked: 6, shares: 6 }),
-      ],
-    };
-
-    transaction.market.findUnique.mockResolvedValue(cancelledMarket);
-    transaction.market.update.mockResolvedValue({
-      ...cancelledMarket,
-      cancelledAt: new Date('2099-03-30T12:00:00.000Z'),
-    });
-    runTransaction();
-
-    await cancelMarket({
-      marketId: 'market_1',
-      actorId: 'user_1',
-    });
-
-    expect(transaction.marketAccount.update).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        bankroll: 1_062,
-      }),
-    }));
-  });
+describe("market service", () => {
+	beforeAll(async () => {
+		({ cancelMarket } = await import(
+			"../src/features/markets/services/trading/cancel.js"
+		));
+		({
+			calculateLossProtectionQuote,
+			purchaseLossProtection,
+			syncLossProtectionForSellTx,
+		} = await import("../src/features/markets/services/trading/protection.js"));
+		({ calculateMarketTradeQuote } = await import(
+			"../src/features/markets/services/trading/quotes.js"
+		));
+		({ executeMarketTrade } = await import(
+			"../src/features/markets/services/trading/execution.js"
+		));
+		({ resolveMarket, resolveMarketOutcome } = await import(
+			"../src/features/markets/services/trading/resolution.js"
+		));
+		({
+			getMarketForecastLeaderboard,
+			getMarketForecastProfile,
+			getMarketForecastProfileDetails,
+		} = await import("../src/features/markets/services/forecast/queries.js"));
+		({ grantMarketBankroll } = await import(
+			"../src/features/markets/services/account.js"
+		));
+		({ injectMarketLiquidity } = await import(
+			"../src/features/markets/services/liquidity.js"
+		));
+		({ appendMarketOutcomes, editMarketRecord, summarizeMarketTraders } =
+			await import("../src/features/markets/services/records.js"));
+	});
+
+	beforeEach(() => {
+		prisma.$transaction.mockReset();
+		transaction.guildConfig.upsert.mockReset();
+		transaction.market.findUnique.mockReset();
+		transaction.market.findUniqueOrThrow.mockReset();
+		transaction.market.update.mockReset();
+		prisma.market.findMany.mockReset();
+		transaction.marketOutcome.update.mockReset();
+		transaction.marketOutcome.deleteMany.mockReset();
+		transaction.marketPosition.deleteMany.mockReset();
+		transaction.marketPosition.upsert.mockReset();
+		transaction.marketAccount.findUnique.mockReset();
+		transaction.marketAccount.upsert.mockReset();
+		transaction.marketAccount.update.mockReset();
+		transaction.marketForecastRecord.upsert.mockReset();
+		transaction.marketLiquidityEvent.create.mockReset();
+		transaction.marketLossProtection.findMany.mockReset();
+		transaction.marketLossProtection.upsert.mockReset();
+		transaction.marketLossProtection.update.mockReset();
+		transaction.marketLossProtection.deleteMany.mockReset();
+		prisma.guildConfig.findUnique.mockReset();
+		prisma.marketAccount.findUnique.mockReset();
+		prisma.marketForecastRecord.findMany.mockReset();
+
+		transaction.guildConfig.upsert.mockResolvedValue({
+			id: "guild_config_1",
+		});
+		transaction.market.findUnique.mockResolvedValue(market);
+		transaction.market.findUniqueOrThrow.mockResolvedValue(market);
+		transaction.marketOutcome.update.mockResolvedValue(undefined);
+		transaction.marketOutcome.deleteMany.mockResolvedValue({ count: 0 });
+		prisma.market.findMany.mockResolvedValue([]);
+		transaction.marketPosition.deleteMany.mockResolvedValue({ count: 0 });
+		transaction.marketPosition.upsert.mockResolvedValue(undefined);
+		transaction.marketAccount.findUnique.mockResolvedValue(baseAccount);
+		transaction.marketAccount.upsert.mockResolvedValue(baseAccount);
+		transaction.marketAccount.update.mockImplementation(
+			async ({ data }: { data: Partial<typeof baseAccount> }) => ({
+				...baseAccount,
+				...data,
+			}),
+		);
+		transaction.marketForecastRecord.upsert.mockResolvedValue(undefined);
+		transaction.marketLiquidityEvent.create.mockResolvedValue(undefined);
+		transaction.marketLossProtection.findMany.mockResolvedValue([]);
+		transaction.marketLossProtection.upsert.mockResolvedValue(undefined);
+		transaction.marketLossProtection.update.mockResolvedValue(undefined);
+		transaction.marketLossProtection.deleteMany.mockResolvedValue({ count: 0 });
+		prisma.guildConfig.findUnique.mockResolvedValue({
+			casinoEnabled: false,
+		});
+		prisma.marketAccount.findUnique.mockResolvedValue(baseAccount);
+		prisma.marketForecastRecord.findMany.mockResolvedValue([]);
+		transaction.market.update
+			.mockResolvedValueOnce({
+				...market,
+				updatedAt: new Date("2099-03-29T00:00:01.000Z"),
+			})
+			.mockResolvedValueOnce({
+				...market,
+				totalVolume: 50,
+			});
+	});
+
+	it("retries serializable conflicts while executing a trade", async () => {
+		prisma.$transaction
+			.mockImplementationOnce(async () => {
+				const error = new Error("Serializable conflict");
+				(error as Error & { code?: string }).code = "P2034";
+				throw error;
+			})
+			.mockImplementationOnce(
+				async (callback: (tx: typeof transaction) => Promise<unknown>) =>
+					callback(transaction),
+			);
+
+		const result = await executeMarketTrade({
+			marketId: "market_1",
+			userId: "user_2",
+			outcomeId: "outcome_yes",
+			action: "buy",
+			amount: 50,
+		});
+
+		expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+		expect(prisma.$transaction).toHaveBeenNthCalledWith(
+			1,
+			expect.any(Function),
+			expect.objectContaining({
+				isolationLevel: "Serializable",
+			}),
+		);
+		expect(result.cashAmount).toBe(50);
+		expect(transaction.market.findUnique).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries serializable conflicts while resolving an outcome", async () => {
+		prisma.$transaction
+			.mockImplementationOnce(async () => {
+				const error = new Error("Serializable conflict");
+				(error as Error & { code?: string }).code = "P2034";
+				throw error;
+			})
+			.mockImplementationOnce(
+				async (callback: (tx: typeof transaction) => Promise<unknown>) =>
+					callback(transaction),
+			);
+
+		const updatedMarket = {
+			...market,
+			outcomes: [
+				{
+					...market.outcomes[0],
+					settlementValue: 0,
+					resolvedAt: new Date("2099-03-30T12:00:00.000Z"),
+				},
+				market.outcomes[1],
+			],
+		};
+		transaction.market.findUnique.mockResolvedValue(market);
+		transaction.market.findUniqueOrThrow.mockResolvedValue(updatedMarket);
+
+		const result = await resolveMarketOutcome({
+			marketId: "market_1",
+			actorId: "user_1",
+			outcomeId: "outcome_yes",
+			note: "Eliminated.",
+		});
+
+		expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+		expect(prisma.$transaction).toHaveBeenNthCalledWith(
+			1,
+			expect.any(Function),
+			expect.objectContaining({
+				isolationLevel: "Serializable",
+			}),
+		);
+		expect(result.outcome.settlementValue).toBe(0);
+	});
+
+	it("appends outcomes to an open market without disturbing existing outcomes", async () => {
+		const updatedMarket = {
+			...market,
+			outcomes: [
+				...market.outcomes,
+				{
+					id: "outcome_maybe",
+					marketId: "market_1",
+					label: "Maybe",
+					sortOrder: 2,
+					outstandingShares: 0,
+					pricingShares: 0,
+					settlementValue: null,
+					resolvedAt: null,
+					resolvedByUserId: null,
+					resolutionNote: null,
+					resolutionEvidenceUrl: null,
+					createdAt: new Date("2099-03-29T00:00:00.000Z"),
+				},
+			],
+		};
+
+		runTransaction();
+		transaction.market.update.mockResolvedValueOnce(updatedMarket);
+		transaction.market.findUniqueOrThrow.mockResolvedValueOnce(updatedMarket);
+
+		const result = await appendMarketOutcomes("market_1", "user_1", ["Maybe"]);
+
+		expect(transaction.market.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					id: "market_1",
+				},
+				data: {
+					outcomes: {
+						create: [
+							{
+								label: "Maybe",
+								sortOrder: 2,
+								pricingShares: 0,
+							},
+						],
+					},
+				},
+			}),
+		);
+		expect(result.outcomes.map((outcome) => outcome.label)).toEqual([
+			"Yes",
+			"No",
+			"Maybe",
+		]);
+	});
+
+	it("rejects appending an outcome label that already exists", async () => {
+		runTransaction();
+
+		await expect(
+			appendMarketOutcomes("market_1", "user_1", ["yes"]),
+		).rejects.toThrow('Outcome "yes" already exists in this market.');
+
+		expect(transaction.market.update).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["title", { title: "Updated title" }],
+		["description", { description: "Updated description" }],
+		["tags", { tags: ["updated"] }],
+		["outcomes", { outcomes: ["Yes", "No", "Maybe"] }],
+	])("rejects editing %s after the first trade", async (_field, input) => {
+		runTransaction();
+		transaction.market.findUnique.mockResolvedValue({
+			...market,
+			trades: [
+				{
+					id: "trade_1",
+					marketId: "market_1",
+					outcomeId: "outcome_yes",
+					userId: "user_2",
+					side: "buy",
+					shareDelta: 5,
+					cashDelta: -40,
+					feeCharged: 0,
+					probabilitySnapshot: 0.55,
+					cumulativeVolume: 40,
+					createdAt: new Date("2099-03-29T01:00:00.000Z"),
+				},
+			],
+		});
+
+		await expect(editMarketRecord("market_1", "user_1", input)).rejects.toThrow(
+			"After the first trade, only close time and button style can be edited.",
+		);
+
+		expect(transaction.market.update).not.toHaveBeenCalled();
+		expect(transaction.marketOutcome.deleteMany).not.toHaveBeenCalled();
+	});
+
+	it("summarizes market traders by outgoing spend and trade count", () => {
+		const summary = summarizeMarketTraders({
+			...market,
+			trades: [
+				{
+					id: "trade_1",
+					marketId: "market_1",
+					outcomeId: "outcome_yes",
+					userId: "user_2",
+					side: "buy",
+					shareDelta: 5,
+					cashDelta: -40,
+					feeCharged: 0,
+					probabilitySnapshot: 0.55,
+					cumulativeVolume: 40,
+					createdAt: new Date("2099-03-29T01:00:00.000Z"),
+				},
+				{
+					id: "trade_2",
+					marketId: "market_1",
+					outcomeId: "outcome_yes",
+					userId: "user_2",
+					side: "sell",
+					shareDelta: -2,
+					cashDelta: 15,
+					feeCharged: 0,
+					probabilitySnapshot: 0.58,
+					cumulativeVolume: 55,
+					createdAt: new Date("2099-03-29T02:00:00.000Z"),
+				},
+				{
+					id: "trade_3",
+					marketId: "market_1",
+					outcomeId: "outcome_no",
+					userId: "user_3",
+					side: "short",
+					shareDelta: -3,
+					cashDelta: 20,
+					feeCharged: 0,
+					probabilitySnapshot: 0.35,
+					cumulativeVolume: 75,
+					createdAt: new Date("2099-03-29T03:00:00.000Z"),
+				},
+				{
+					id: "trade_4",
+					marketId: "market_1",
+					outcomeId: "outcome_no",
+					userId: "user_4",
+					side: "buy",
+					shareDelta: 1,
+					cashDelta: -10,
+					feeCharged: 0,
+					probabilitySnapshot: 0.31,
+					cumulativeVolume: 85,
+					createdAt: new Date("2099-03-29T04:00:00.000Z"),
+				},
+			],
+		});
+
+		expect(summary).toMatchObject({
+			marketId: "market_1",
+			marketTitle: "Will turnout exceed 40%?",
+			traderCount: 3,
+			totalSpent: 50,
+		});
+		expect(summary.entries).toEqual([
+			expect.objectContaining({
+				userId: "user_2",
+				amountSpent: 40,
+				tradeCount: 2,
+			}),
+			expect.objectContaining({
+				userId: "user_4",
+				amountSpent: 10,
+				tradeCount: 1,
+			}),
+			expect.objectContaining({
+				userId: "user_3",
+				amountSpent: 0,
+				tradeCount: 1,
+			}),
+		]);
+	});
+
+	it("returns an empty trader summary when a market has no trades", () => {
+		expect(summarizeMarketTraders(market)).toEqual({
+			marketId: "market_1",
+			marketTitle: "Will turnout exceed 40%?",
+			traderCount: 0,
+			totalSpent: 0,
+			entries: [],
+		});
+	});
+
+	it("does not count profitable trades as spend in the trader summary", () => {
+		const summary = summarizeMarketTraders({
+			...market,
+			trades: [
+				{
+					id: "trade_1",
+					marketId: "market_1",
+					outcomeId: "outcome_yes",
+					userId: "user_2",
+					side: "sell",
+					shareDelta: -2,
+					cashDelta: 15,
+					feeCharged: 0,
+					probabilitySnapshot: 0.58,
+					cumulativeVolume: 15,
+					createdAt: new Date("2099-03-29T02:00:00.000Z"),
+				},
+				{
+					id: "trade_2",
+					marketId: "market_1",
+					outcomeId: "outcome_no",
+					userId: "user_2",
+					side: "short",
+					shareDelta: -3,
+					cashDelta: 20,
+					feeCharged: 0,
+					probabilitySnapshot: 0.35,
+					cumulativeVolume: 35,
+					createdAt: new Date("2099-03-29T03:00:00.000Z"),
+				},
+			],
+		});
+
+		expect(summary.totalSpent).toBe(0);
+		expect(summary.entries).toEqual([
+			expect.objectContaining({
+				userId: "user_2",
+				amountSpent: 0,
+				tradeCount: 2,
+			}),
+		]);
+	});
+
+	it("supports selling a specific number of long shares", async () => {
+		const positionedMarket = {
+			...market,
+			totalVolume: 100,
+			outcomes: [
+				{ ...market.outcomes[0], outstandingShares: 5, pricingShares: 5 },
+				market.outcomes[1],
+			],
+			positions: [makeLongPosition()],
+		};
+
+		transaction.market.findUnique.mockResolvedValue(positionedMarket);
+		transaction.market.update
+			.mockResolvedValueOnce({
+				...positionedMarket,
+				updatedAt: new Date("2099-03-29T00:00:01.000Z"),
+			})
+			.mockResolvedValueOnce({
+				...positionedMarket,
+				totalVolume: 140,
+			});
+		runTransaction();
+
+		const result = await executeMarketTrade({
+			marketId: "market_1",
+			userId: "user_2",
+			outcomeId: "outcome_yes",
+			action: "sell",
+			amount: 2.5,
+			amountMode: "shares",
+		});
+
+		expect(result.shareDelta).toBeCloseTo(-2.5, 2);
+		expect(result.positionSide).toBe("long");
+		expect(result.cashAmount).toBeGreaterThan(0);
+		expect(transaction.market.update).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					totalVolume: positionedMarket.totalVolume + result.cashAmount,
+					trades: expect.objectContaining({
+						create: expect.objectContaining({
+							side: "sell",
+							cashDelta: result.cashAmount,
+						}),
+					}),
+				}),
+			}),
+		);
+	});
+
+	it("opens a short position using a share amount", async () => {
+		runTransaction();
+
+		const result = await executeMarketTrade({
+			marketId: "market_1",
+			userId: "user_2",
+			outcomeId: "outcome_yes",
+			action: "short",
+			amount: 3,
+			amountMode: "shares",
+		});
+
+		expect(result.shareDelta).toBeCloseTo(-3, 5);
+		expect(result.positionSide).toBe("short");
+		expect(result.cashAmount).toBeGreaterThan(0);
+		expect(transaction.marketPosition.upsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				create: expect.objectContaining({
+					side: "short",
+					shares: 3,
+					proceeds: result.cashAmount,
+					collateralLocked: 3,
+				}),
+			}),
+		);
+		expect(transaction.market.update).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					trades: expect.objectContaining({
+						create: expect.objectContaining({
+							side: "short",
+							cashDelta: result.cashAmount,
+							shareDelta: -3,
+						}),
+					}),
+				}),
+			}),
+		);
+	});
+
+	it("rejects opening a short when a long already exists on that outcome", async () => {
+		transaction.market.findUnique.mockResolvedValue({
+			...market,
+			positions: [makeLongPosition()],
+		});
+		runTransaction();
+
+		await expect(
+			executeMarketTrade({
+				marketId: "market_1",
+				userId: "user_2",
+				outcomeId: "outcome_yes",
+				action: "short",
+				amount: 20,
+			}),
+		).rejects.toThrow(
+			"You must sell your long position in that outcome before shorting it.",
+		);
+	});
+
+	it("rejects buying an outcome while a short is open on it", async () => {
+		transaction.market.findUnique.mockResolvedValue({
+			...market,
+			positions: [makeShortPosition()],
+		});
+		runTransaction();
+
+		await expect(
+			executeMarketTrade({
+				marketId: "market_1",
+				userId: "user_2",
+				outcomeId: "outcome_yes",
+				action: "buy",
+				amount: 20,
+			}),
+		).rejects.toThrow(
+			"You must cover your short position in that outcome before buying it.",
+		);
+	});
+
+	it("ignores another user’s short position when buying an outcome", async () => {
+		transaction.market.findUnique.mockResolvedValue({
+			...market,
+			positions: [
+				makeShortPosition({
+					userId: "user_3",
+				}),
+			],
+		});
+		runTransaction();
+
+		const result = await executeMarketTrade({
+			marketId: "market_1",
+			userId: "user_2",
+			outcomeId: "outcome_yes",
+			action: "buy",
+			amount: 20,
+		});
+
+		expect(result.positionSide).toBe("long");
+		expect(result.cashAmount).toBe(20);
+		expect(transaction.marketPosition.upsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				create: expect.objectContaining({
+					userId: "user_2",
+					side: "long",
+				}),
+			}),
+		);
+	});
+
+	it("rejects trading an outcome that has already been resolved", async () => {
+		transaction.market.findUnique.mockResolvedValue({
+			...market,
+			outcomes: [
+				{
+					...market.outcomes[0],
+					settlementValue: 0,
+					resolvedAt: new Date("2099-03-30T00:00:00.000Z"),
+				},
+				market.outcomes[1],
+			],
+		});
+		runTransaction();
+
+		await expect(
+			executeMarketTrade({
+				marketId: "market_1",
+				userId: "user_2",
+				outcomeId: "outcome_yes",
+				action: "buy",
+				amount: 20,
+			}),
+		).rejects.toThrow(
+			"Trading on Yes is closed because that outcome has already been resolved.",
+		);
+	});
+
+	it("rejects buying an outcome above the 98% lock threshold", async () => {
+		transaction.market.findUnique.mockResolvedValue({
+			...market,
+			outcomes: [
+				{ ...market.outcomes[0], outstandingShares: 600, pricingShares: 600 },
+				{ ...market.outcomes[1], outstandingShares: 0, pricingShares: 0 },
+			],
+		});
+		runTransaction();
+
+		await expect(
+			executeMarketTrade({
+				marketId: "market_1",
+				userId: "user_2",
+				outcomeId: "outcome_yes",
+				action: "buy",
+				amount: 20,
+			}),
+		).rejects.toThrow("Yes on **Yes** is locked above 98%.");
+	});
+
+	it("rejects shorting an outcome below the 2% lock threshold", async () => {
+		transaction.market.findUnique.mockResolvedValue({
+			...market,
+			outcomes: [
+				{ ...market.outcomes[0], outstandingShares: -600, pricingShares: -600 },
+				{ ...market.outcomes[1], outstandingShares: 0, pricingShares: 0 },
+			],
+		});
+		runTransaction();
+
+		await expect(
+			executeMarketTrade({
+				marketId: "market_1",
+				userId: "user_2",
+				outcomeId: "outcome_yes",
+				action: "short",
+				amount: 20,
+			}),
+		).rejects.toThrow("No on **Yes** is locked below 2%.");
+	});
+
+	it("rejects shorts that cannot be fully collateralized", async () => {
+		transaction.marketAccount.upsert.mockResolvedValue({
+			...baseAccount,
+			bankroll: 0,
+			lastTopUpAt: new Date(),
+		});
+		runTransaction();
+
+		await expect(
+			executeMarketTrade({
+				marketId: "market_1",
+				userId: "user_2",
+				outcomeId: "outcome_yes",
+				action: "short",
+				amount: 4,
+				amountMode: "shares",
+			}),
+		).rejects.toThrow(
+			"You do not have enough bankroll to collateralize that short.",
+		);
+	});
+
+	it("covers a short position and realizes profit", async () => {
+		const positionedMarket = {
+			...market,
+			totalVolume: 125,
+			outcomes: [
+				{ ...market.outcomes[0], outstandingShares: -5, pricingShares: -5 },
+				market.outcomes[1],
+			],
+			positions: [makeShortPosition()],
+		};
+
+		transaction.market.findUnique.mockResolvedValue(positionedMarket);
+		transaction.market.update
+			.mockResolvedValueOnce({
+				...positionedMarket,
+				updatedAt: new Date("2099-03-29T00:00:01.000Z"),
+			})
+			.mockResolvedValueOnce({
+				...positionedMarket,
+				totalVolume: 140,
+			});
+		runTransaction();
+
+		const result = await executeMarketTrade({
+			marketId: "market_1",
+			userId: "user_2",
+			outcomeId: "outcome_yes",
+			action: "cover",
+			amount: 2,
+			amountMode: "shares",
+		});
+
+		expect(result.shareDelta).toBeCloseTo(2, 5);
+		expect(result.positionSide).toBe("short");
+		expect(result.realizedProfitDelta).toBeGreaterThan(0);
+		expect(transaction.market.update).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					trades: expect.objectContaining({
+						create: expect.objectContaining({
+							side: "cover",
+							cashDelta: -result.cashAmount,
+							shareDelta: 2,
+						}),
+					}),
+				}),
+			}),
+		);
+	});
+
+	it("removes a short position after it is fully covered", async () => {
+		const positionedMarket = {
+			...market,
+			outcomes: [
+				{ ...market.outcomes[0], outstandingShares: -5, pricingShares: -5 },
+				market.outcomes[1],
+			],
+			positions: [makeShortPosition()],
+		};
+
+		transaction.market.findUnique.mockResolvedValue(positionedMarket);
+		runTransaction();
+
+		await executeMarketTrade({
+			marketId: "market_1",
+			userId: "user_2",
+			outcomeId: "outcome_yes",
+			action: "cover",
+			amount: 5,
+			amountMode: "shares",
+		});
+
+		expect(transaction.marketPosition.deleteMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({
+					side: "short",
+				}),
+			}),
+		);
+	});
+
+	it("rejects covering an outcome without an open short", async () => {
+		runTransaction();
+
+		await expect(
+			executeMarketTrade({
+				marketId: "market_1",
+				userId: "user_2",
+				outcomeId: "outcome_yes",
+				action: "cover",
+				amount: 20,
+			}),
+		).rejects.toThrow("You do not have a short position in that outcome yet.");
+	});
+
+	it("resolves shorts against the winning outcome as losses", async () => {
+		const shortMarket = {
+			...market,
+			tradingClosedAt: new Date("2099-03-30T00:00:00.000Z"),
+			positions: [makeShortPosition({ proceeds: 3, collateralLocked: 5 })],
+		};
+
+		transaction.market.findUnique.mockResolvedValue(shortMarket);
+		transaction.market.update.mockResolvedValue({
+			...shortMarket,
+			resolvedAt: new Date("2099-03-30T12:00:00.000Z"),
+			winningOutcomeId: "outcome_yes",
+		});
+		runTransaction();
+
+		const result = await resolveMarket({
+			marketId: "market_1",
+			actorId: "user_1",
+			winningOutcomeId: "outcome_yes",
+		});
+
+		expect(result.payouts).toEqual([
+			expect.objectContaining({
+				userId: "user_2",
+				payout: 0,
+				profit: -2,
+				bonus: 0,
+			}),
+		]);
+		expect(transaction.marketAccount.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					bankroll: 1_000,
+					realizedProfit: -2,
+				}),
+			}),
+		);
+	});
+
+	it("resolves an eliminated outcome without closing the whole market", async () => {
+		const openMarket = {
+			...market,
+			supplementaryBonusPool: 12,
+			positions: [
+				makeLongPosition(),
+				makeShortPosition({
+					outcomeId: "outcome_no",
+					proceeds: 4,
+					collateralLocked: 6,
+					shares: 6,
+				}),
+			],
+		};
+		const updatedMarket = {
+			...openMarket,
+			outcomes: [
+				{
+					...openMarket.outcomes[0],
+					outstandingShares: 0,
+					pricingShares: 0,
+					settlementValue: 0,
+					resolvedAt: new Date("2099-03-30T12:00:00.000Z"),
+				},
+				openMarket.outcomes[1],
+			],
+			supplementaryBonusPool: 12,
+			supplementaryBonusDistributedAt: null,
+			positions: [
+				makeShortPosition({
+					outcomeId: "outcome_no",
+					proceeds: 4,
+					collateralLocked: 6,
+					shares: 6,
+				}),
+			],
+		};
+
+		transaction.market.findUnique.mockResolvedValue(openMarket);
+		transaction.market.findUniqueOrThrow.mockResolvedValue(updatedMarket);
+		runTransaction();
+
+		const result = await resolveMarketOutcome({
+			marketId: "market_1",
+			actorId: "user_1",
+			outcomeId: "outcome_yes",
+			note: "Knocked out in the semifinal.",
+		});
+
+		expect(result.market.resolvedAt).toBeNull();
+		expect(result.market.supplementaryBonusPool).toBe(12);
+		expect(result.market.supplementaryBonusDistributedAt).toBeNull();
+		expect(result.outcome.settlementValue).toBe(0);
+		expect(result.payouts).toEqual([
+			{
+				userId: "user_2",
+				payout: 0,
+				profit: -60,
+				bonus: 0,
+			},
+		]);
+		expect(transaction.marketPosition.deleteMany).toHaveBeenCalledWith({
+			where: {
+				marketId: "market_1",
+				outcomeId: "outcome_yes",
+			},
+		});
+		expect(transaction.marketOutcome.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					id: "outcome_yes",
+				},
+				data: expect.objectContaining({
+					outstandingShares: 0,
+					settlementValue: 0,
+					resolutionNote: "Knocked out in the semifinal.",
+				}),
+			}),
+		);
+	});
+
+	it("resolves shorts on losing outcomes by releasing collateral", async () => {
+		const shortMarket = {
+			...market,
+			tradingClosedAt: new Date("2099-03-30T00:00:00.000Z"),
+			trades: [
+				{
+					id: "trade_1",
+					marketId: "market_1",
+					outcomeId: "outcome_yes",
+					userId: "user_2",
+					side: "short" as const,
+					cashDelta: 20,
+					shareDelta: -3,
+					feeCharged: 0,
+					probabilitySnapshot: 0.4,
+					cumulativeVolume: 20,
+					createdAt: new Date("2099-03-29T01:00:00.000Z"),
+				},
+				{
+					id: "trade_2",
+					marketId: "market_1",
+					outcomeId: "outcome_no",
+					userId: "user_2",
+					side: "buy" as const,
+					cashDelta: -10,
+					shareDelta: 2,
+					feeCharged: 0,
+					probabilitySnapshot: 0.6,
+					cumulativeVolume: 30,
+					createdAt: new Date("2099-03-29T02:00:00.000Z"),
+				},
+			],
+			positions: [makeShortPosition({ proceeds: 3, collateralLocked: 5 })],
+		};
+
+		transaction.market.findUnique.mockResolvedValue(shortMarket);
+		transaction.market.update.mockResolvedValue({
+			...shortMarket,
+			resolvedAt: new Date("2099-03-30T12:00:00.000Z"),
+			winningOutcomeId: "outcome_no",
+		});
+		runTransaction();
+
+		const result = await resolveMarket({
+			marketId: "market_1",
+			actorId: "user_1",
+			winningOutcomeId: "outcome_no",
+		});
+
+		expect(result.payouts).toEqual([
+			expect.objectContaining({
+				userId: "user_2",
+				payout: 5,
+				profit: 3,
+				bonus: 0,
+			}),
+		]);
+		expect(transaction.marketAccount.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					bankroll: 1_005,
+					realizedProfit: 3,
+				}),
+			}),
+		);
+	});
+
+	it("injects supplementary liquidity by rebasing pricing shares without changing outstanding exposure", async () => {
+		const now = new Date("2099-03-29T02:00:00.000Z");
+		const liquidMarket = {
+			...market,
+			outcomes: [
+				{ ...market.outcomes[0], outstandingShares: 10, pricingShares: 10 },
+				market.outcomes[1],
+			],
+		};
+		const updatedMarket = {
+			...liquidMarket,
+			liquidityParameter: 169,
+			lastLiquidityInjectionAt: now,
+			supplementaryBonusPool: 6.58,
+			liquidityEvents: [
+				{
+					id: "liquidity_1",
+					marketId: "market_1",
+					previousLiquidityParameter: 150,
+					nextLiquidityParameter: 169,
+					scaleFactor: 169 / 150,
+					bonusAccrued: 6.58,
+					createdAt: now,
+				},
+			],
+		};
+
+		transaction.market.findUnique.mockResolvedValue(liquidMarket);
+		transaction.market.update.mockResolvedValue(updatedMarket);
+		runTransaction();
+
+		const result = await injectMarketLiquidity("market_1", now);
+
+		expect(result.didInject).toBe(true);
+		expect(transaction.marketOutcome.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					id: "outcome_yes",
+				},
+				data: expect.objectContaining({
+					outstandingShares: 10,
+					pricingShares: expect.closeTo(11.27, 2),
+				}),
+			}),
+		);
+		expect(transaction.marketLiquidityEvent.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					previousLiquidityParameter: 150,
+					nextLiquidityParameter: 169,
+					scaleFactor: expect.closeTo(169 / 150, 5),
+					bonusAccrued: 6.58,
+				}),
+			}),
+		);
+		expect(transaction.market.update).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					liquidityParameter: 169,
+					supplementaryBonusPool: 6.58,
+				}),
+			}),
+		);
+	});
+
+	it("skips liquidity injection when the target liquidity matches the current market", async () => {
+		const now = new Date("2099-03-29T00:30:00.000Z");
+		runTransaction();
+
+		const result = await injectMarketLiquidity("market_1", now);
+
+		expect(result.didInject).toBe(false);
+		expect(result.bonusAccrued).toBe(0);
+		expect(result.nextInjectionAt?.toISOString()).toBe(
+			"2099-03-29T01:00:00.000Z",
+		);
+		expect(result.market).toBe(market);
+		expect(transaction.marketOutcome.update).not.toHaveBeenCalled();
+		expect(transaction.marketLiquidityEvent.create).not.toHaveBeenCalled();
+		expect(transaction.market.update).not.toHaveBeenCalled();
+	});
+
+	it("distributes the supplementary bonus pool in proportion to positive market profit", async () => {
+		const resolvedAt = new Date("2099-03-30T12:00:00.000Z");
+		const bonusMarket = {
+			...market,
+			tradingClosedAt: new Date("2099-03-30T00:00:00.000Z"),
+			supplementaryBonusPool: 12,
+			positions: [
+				makeLongPosition({ userId: "user_2", shares: 10, costBasis: 8 }),
+				makeShortPosition({
+					userId: "user_3",
+					outcomeId: "outcome_no",
+					shares: 4,
+					proceeds: 6,
+					collateralLocked: 4,
+				}),
+			],
+		};
+
+		vi.useFakeTimers();
+		vi.setSystemTime(resolvedAt);
+		transaction.market.findUnique.mockResolvedValue(bonusMarket);
+		transaction.marketAccount.upsert.mockImplementation(
+			async ({
+				where,
+			}: {
+				where: {
+					guildId_userId: {
+						guildId: string;
+						userId: string;
+					};
+				};
+			}) => ({
+				...baseAccount,
+				id: `account_${where.guildId_userId.userId}`,
+				userId: where.guildId_userId.userId,
+			}),
+		);
+		transaction.market.update.mockResolvedValue({
+			...bonusMarket,
+			resolvedAt,
+			winningOutcomeId: "outcome_yes",
+			supplementaryBonusDistributedAt: resolvedAt,
+		});
+		runTransaction();
+
+		try {
+			const result = await resolveMarket({
+				marketId: "market_1",
+				actorId: "user_1",
+				winningOutcomeId: "outcome_yes",
+			});
+
+			expect(result.payouts).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						userId: "user_2",
+						payout: 10,
+						profit: 2,
+						bonus: 3,
+					}),
+					expect.objectContaining({
+						userId: "user_3",
+						payout: 4,
+						profit: 6,
+						bonus: 9,
+					}),
+				]),
+			);
+			expect(transaction.market.update).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						supplementaryBonusDistributedAt: resolvedAt,
+						supplementaryBonusExpiredAt: null,
+					}),
+				}),
+			);
+			expect(transaction.marketAccount.update).toHaveBeenNthCalledWith(
+				1,
+				expect.objectContaining({
+					where: {
+						id: "account_user_2",
+					},
+					data: expect.objectContaining({
+						bankroll: 1013,
+						realizedProfit: 5,
+					}),
+				}),
+			);
+			expect(transaction.marketAccount.update).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining({
+					where: {
+						id: "account_user_3",
+					},
+					data: expect.objectContaining({
+						bankroll: 1013,
+						realizedProfit: 15,
+					}),
+				}),
+			);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("quotes a buy trade with payout information before execution", async () => {
+		prisma.market.findUnique.mockResolvedValue(market);
+		prisma.marketAccount.findUnique.mockResolvedValue(baseAccount);
+
+		const quote = await calculateMarketTradeQuote({
+			marketId: "market_1",
+			userId: "user_2",
+			outcomeId: "outcome_yes",
+			action: "buy",
+			amount: 50,
+			amountMode: "points",
+			rawAmount: "50",
+		});
+
+		expect(quote.action).toBe("buy");
+		expect(quote.immediateCash).toBe(50);
+		expect(quote.settlementIfChosen).toBeGreaterThan(0);
+		expect(quote.maxLossIfNotChosen).toBe(50);
+	});
+
+	it("quotes a short trade with both outcome scenarios", async () => {
+		prisma.market.findUnique.mockResolvedValue(market);
+		prisma.marketAccount.findUnique.mockResolvedValue(baseAccount);
+
+		const quote = await calculateMarketTradeQuote({
+			marketId: "market_1",
+			userId: "user_2",
+			outcomeId: "outcome_yes",
+			action: "short",
+			amount: 10,
+			amountMode: "points",
+			rawAmount: "10 pts",
+		});
+
+		expect(quote.action).toBe("short");
+		expect(quote.immediateCash).toBe(10);
+		expect(quote.collateralLocked).toBeGreaterThan(0);
+		expect(quote.settlementIfChosen).toBe(0);
+		expect(quote.settlementIfNotChosen).toBeGreaterThan(0);
+	});
+
+	it("quotes a sell trade against the remaining long position", async () => {
+		prisma.market.findUnique.mockResolvedValue({
+			...market,
+			positions: [makeLongPosition()],
+		});
+		prisma.marketAccount.findUnique.mockResolvedValue(baseAccount);
+
+		const quote = await calculateMarketTradeQuote({
+			marketId: "market_1",
+			userId: "user_2",
+			outcomeId: "outcome_yes",
+			action: "sell",
+			amount: 1.5,
+			amountMode: "shares",
+			rawAmount: "1.5 shares",
+		});
+
+		expect(quote.action).toBe("sell");
+		expect(quote.immediateCash).toBeGreaterThan(0);
+		expect(quote.positionSharesAfter).toBeLessThan(5);
+		expect(quote.positionCostBasisAfter).toBeLessThan(60);
+		expect(quote.realizedProfitDelta).toBeTypeOf("number");
+	});
+
+	it("quotes a cover trade against the remaining short position", async () => {
+		prisma.market.findUnique.mockResolvedValue({
+			...market,
+			positions: [makeShortPosition()],
+		});
+		prisma.marketAccount.findUnique.mockResolvedValue(baseAccount);
+
+		const quote = await calculateMarketTradeQuote({
+			marketId: "market_1",
+			userId: "user_2",
+			outcomeId: "outcome_yes",
+			action: "cover",
+			amount: 1.5,
+			amountMode: "shares",
+			rawAmount: "1.5 shares",
+		});
+
+		expect(quote.action).toBe("cover");
+		expect(quote.immediateCash).toBeGreaterThan(0);
+		expect(quote.collateralReleased).toBeGreaterThan(0);
+		expect(quote.positionSharesAfter).toBeLessThan(5);
+		expect(quote.positionCollateralAfter).toBeLessThan(5);
+	});
+
+	it("quotes incremental long loss protection against the current position basis", async () => {
+		prisma.market.findUnique.mockResolvedValue({
+			...market,
+			positions: [makeLongPosition({ costBasis: 80, shares: 10 })],
+			lossProtections: [
+				{
+					id: "protection_1",
+					marketId: "market_1",
+					outcomeId: "outcome_yes",
+					userId: "user_2",
+					insuredCostBasis: 20,
+					premiumPaid: 5,
+					createdAt: new Date("2099-03-29T00:30:00.000Z"),
+					updatedAt: new Date("2099-03-29T00:30:00.000Z"),
+				},
+			],
+			outcomes: [
+				{ ...market.outcomes[0], pricingShares: 20, outstandingShares: 20 },
+				{ ...market.outcomes[1], pricingShares: 0, outstandingShares: 0 },
+			],
+		});
+
+		const quote = await calculateLossProtectionQuote({
+			marketId: "market_1",
+			userId: "user_2",
+			outcomeId: "outcome_yes",
+			targetCoverage: 0.5,
+		});
+
+		expect(quote.currentLongCostBasis).toBe(80);
+		expect(quote.alreadyInsuredCostBasis).toBe(20);
+		expect(quote.targetInsuredCostBasis).toBe(40);
+		expect(quote.incrementalInsuredCostBasis).toBe(20);
+		expect(quote.premium).toBeGreaterThan(0);
+	});
+
+	it("purchases long loss protection and debits bankroll/profit by the premium", async () => {
+		runTransaction();
+		transaction.market.findUnique.mockResolvedValue({
+			...market,
+			positions: [makeLongPosition({ costBasis: 60, shares: 6 })],
+			lossProtections: [],
+		});
+		transaction.market.findUniqueOrThrow.mockResolvedValue({
+			...market,
+			positions: [makeLongPosition({ costBasis: 60, shares: 6 })],
+			lossProtections: [
+				{
+					id: "protection_1",
+					marketId: "market_1",
+					outcomeId: "outcome_yes",
+					userId: "user_2",
+					insuredCostBasis: 30,
+					premiumPaid: 15.75,
+					createdAt: new Date("2099-03-29T00:30:00.000Z"),
+					updatedAt: new Date("2099-03-29T00:30:00.000Z"),
+				},
+			],
+		});
+
+		const result = await purchaseLossProtection({
+			marketId: "market_1",
+			userId: "user_2",
+			outcomeId: "outcome_yes",
+			targetCoverage: 0.5,
+		});
+
+		expect(transaction.marketLossProtection.upsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				create: expect.objectContaining({
+					insuredCostBasis: 30,
+				}),
+			}),
+		);
+		expect(transaction.marketAccount.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					bankroll: expect.any(Number),
+					realizedProfit: expect.any(Number),
+				}),
+			}),
+		);
+		expect(result.insuredCostBasis).toBe(30);
+		expect(result.premiumCharged).toBeGreaterThan(0);
+		expect(result.account.bankroll).toBeLessThan(baseAccount.bankroll);
+		expect(result.account.realizedProfit).toBeLessThanOrEqual(
+			baseAccount.realizedProfit,
+		);
+	});
+
+	it("shrinks insured basis proportionally after a partial sell", async () => {
+		runTransaction();
+
+		await syncLossProtectionForSellTx(transaction as never, {
+			existingProtection: {
+				id: "protection_1",
+				marketId: "market_1",
+				outcomeId: "outcome_yes",
+				userId: "user_2",
+				insuredCostBasis: 60,
+			},
+			previousLongCostBasis: 100,
+			nextLongCostBasis: 40,
+		});
+
+		expect(transaction.marketLossProtection.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: {
+					insuredCostBasis: 24,
+				},
+			}),
+		);
+	});
+
+	it("rejects buy quotes requested in shares mode", async () => {
+		await expect(
+			calculateMarketTradeQuote({
+				marketId: "market_1",
+				userId: "user_2",
+				outcomeId: "outcome_yes",
+				action: "buy",
+				amount: 5,
+				amountMode: "shares",
+				rawAmount: "5 shares",
+			} as never),
+		).rejects.toThrow("Buy quotes only support point amounts.");
+	});
+
+	it("rejects non-positive trade amounts in quote calculation", async () => {
+		await expect(
+			calculateMarketTradeQuote({
+				marketId: "market_1",
+				userId: "user_2",
+				outcomeId: "outcome_yes",
+				action: "buy",
+				amount: 0,
+				rawAmount: "0",
+			}),
+		).rejects.toThrow("Trade amount must be a finite value greater than zero.");
+	});
+
+	it("rejects non-positive trade amounts in execution", async () => {
+		runTransaction();
+
+		await expect(
+			executeMarketTrade({
+				marketId: "market_1",
+				userId: "user_2",
+				outcomeId: "outcome_yes",
+				action: "buy",
+				amount: -10,
+			}),
+		).rejects.toThrow("Trade amount must be a finite value greater than zero.");
+	});
+
+	it("reconstructs the full probability vector for multi-outcome forecast records", async () => {
+		const resolvedAt = new Date("2099-03-30T12:00:00.000Z");
+		const threeOutcomeMarket = {
+			...market,
+			outcomes: [
+				{ ...market.outcomes[0], id: "outcome_a", label: "A" },
+				{ ...market.outcomes[1], id: "outcome_b", label: "B" },
+				{ ...market.outcomes[1], id: "outcome_c", label: "C", sortOrder: 2 },
+			],
+			trades: [
+				{
+					id: "trade_1",
+					marketId: "market_1",
+					outcomeId: "outcome_a",
+					userId: "user_2",
+					side: "buy" as const,
+					shareDelta: 30,
+					cashDelta: -30,
+					feeCharged: 0,
+					probabilitySnapshot: 0.3792,
+					cumulativeVolume: 30,
+					createdAt: new Date("2099-03-29T01:00:00.000Z"),
+				},
+				{
+					id: "trade_2",
+					marketId: "market_1",
+					outcomeId: "outcome_b",
+					userId: "user_2",
+					side: "buy" as const,
+					shareDelta: 30,
+					cashDelta: -30,
+					feeCharged: 0,
+					probabilitySnapshot: 0.3649,
+					cumulativeVolume: 60,
+					createdAt: new Date("2099-03-29T02:00:00.000Z"),
+				},
+			],
+			positions: [],
+		};
+		const resolvedMarket = {
+			...threeOutcomeMarket,
+			resolvedAt,
+			tradingClosedAt: resolvedAt,
+			winningOutcomeId: "outcome_b",
+			outcomes: threeOutcomeMarket.outcomes.map((outcome) => ({
+				...outcome,
+				settlementValue: outcome.id === "outcome_b" ? 1 : 0,
+				resolvedAt,
+				resolvedByUserId: "user_1",
+			})),
+		};
+
+		transaction.market.findUnique.mockResolvedValue(threeOutcomeMarket);
+		transaction.market.update.mockReset();
+		transaction.market.update.mockResolvedValue(resolvedMarket);
+		runTransaction();
+
+		await resolveMarket({
+			marketId: "market_1",
+			actorId: "user_1",
+			winningOutcomeId: "outcome_b",
+		});
+
+		const persistedRecord =
+			transaction.marketForecastRecord.upsert.mock.calls[0]?.[0]?.create;
+		const forecastByOutcome = Object.fromEntries(
+			persistedRecord.forecastVector.map(
+				(entry: { outcomeId: string; probability: number }) => [
+					entry.outcomeId,
+					entry.probability,
+				],
+			),
+		);
+
+		expect(forecastByOutcome.outcome_a).toBeGreaterThan(0.35);
+		expect(forecastByOutcome.outcome_a).toBeLessThan(0.38);
+		expect(forecastByOutcome.outcome_b).toBeGreaterThan(0.32);
+		expect(forecastByOutcome.outcome_b).toBeLessThan(0.34);
+		expect(forecastByOutcome.outcome_c).toBeGreaterThan(0.29);
+		expect(forecastByOutcome.outcome_c).toBeLessThan(0.31);
+	});
+
+	it("builds forecast leaderboard and profile aggregates from stored forecast records", async () => {
+		const now = new Date();
+		prisma.market.findMany.mockResolvedValue([]);
+		prisma.marketForecastRecord.findMany.mockResolvedValue([
+			{
+				id: "forecast_1",
+				guildId: "guild_1",
+				marketId: "market_1",
+				userId: "user_2",
+				resolvedAt: new Date(now.getTime() - 5 * 24 * 60 * 60 * 1_000),
+				marketTagSnapshot: ["meta"],
+				forecastVector: [
+					{ outcomeId: "outcome_yes", probability: 0.7 },
+					{ outcomeId: "outcome_no", probability: 0.3 },
+				],
+				winningOutcomeId: "outcome_yes",
+				winningOutcomeProbability: 0.7,
+				predictedOutcomeId: "outcome_yes",
+				brierScore: 0.12,
+				wasCorrect: true,
+				realizedProfit: 5,
+				tradeCount: 3,
+				stakeWeight: 80,
+				createdAt: now,
+				updatedAt: now,
+			},
+			{
+				id: "forecast_2",
+				guildId: "guild_1",
+				marketId: "market_2",
+				userId: "user_2",
+				resolvedAt: new Date(now.getTime() - 3 * 24 * 60 * 60 * 1_000),
+				marketTagSnapshot: ["meta"],
+				forecastVector: [
+					{ outcomeId: "outcome_yes", probability: 0.4 },
+					{ outcomeId: "outcome_no", probability: 0.6 },
+				],
+				winningOutcomeId: "outcome_no",
+				winningOutcomeProbability: 0.6,
+				predictedOutcomeId: "outcome_no",
+				brierScore: 0.2,
+				wasCorrect: true,
+				realizedProfit: 2,
+				tradeCount: 2,
+				stakeWeight: 40,
+				createdAt: now,
+				updatedAt: now,
+			},
+			{
+				id: "forecast_3",
+				guildId: "guild_1",
+				marketId: "market_3",
+				userId: "user_2",
+				resolvedAt: new Date(now.getTime() - 1 * 24 * 60 * 60 * 1_000),
+				marketTagSnapshot: ["meta"],
+				forecastVector: [
+					{ outcomeId: "outcome_yes", probability: 0.8 },
+					{ outcomeId: "outcome_no", probability: 0.2 },
+				],
+				winningOutcomeId: "outcome_no",
+				winningOutcomeProbability: 0.2,
+				predictedOutcomeId: "outcome_yes",
+				brierScore: 0.3,
+				wasCorrect: false,
+				realizedProfit: -3,
+				tradeCount: 4,
+				stakeWeight: 60,
+				createdAt: now,
+				updatedAt: now,
+			},
+			{
+				id: "forecast_4",
+				guildId: "guild_1",
+				marketId: "market_4",
+				userId: "user_3",
+				resolvedAt: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1_000),
+				marketTagSnapshot: ["meta"],
+				forecastVector: [
+					{ outcomeId: "outcome_yes", probability: 0.55 },
+					{ outcomeId: "outcome_no", probability: 0.45 },
+				],
+				winningOutcomeId: "outcome_yes",
+				winningOutcomeProbability: 0.55,
+				predictedOutcomeId: "outcome_yes",
+				brierScore: 0.16,
+				wasCorrect: true,
+				realizedProfit: 1,
+				tradeCount: 2,
+				stakeWeight: 30,
+				createdAt: now,
+				updatedAt: now,
+			},
+			{
+				id: "forecast_5",
+				guildId: "guild_1",
+				marketId: "market_5",
+				userId: "user_2",
+				resolvedAt: new Date(now.getTime() - 35 * 24 * 60 * 60 * 1_000),
+				marketTagSnapshot: ["meta"],
+				forecastVector: [
+					{ outcomeId: "outcome_yes", probability: 0.6 },
+					{ outcomeId: "outcome_no", probability: 0.4 },
+				],
+				winningOutcomeId: "outcome_yes",
+				winningOutcomeProbability: 0.6,
+				predictedOutcomeId: "outcome_yes",
+				brierScore: 0.1,
+				wasCorrect: true,
+				realizedProfit: 4,
+				tradeCount: 2,
+				stakeWeight: 35,
+				createdAt: now,
+				updatedAt: now,
+			},
+			{
+				id: "forecast_6",
+				guildId: "guild_1",
+				marketId: "market_6",
+				userId: "user_2",
+				resolvedAt: new Date(now.getTime() - 20 * 24 * 60 * 60 * 1_000),
+				marketTagSnapshot: ["meta"],
+				forecastVector: [
+					{ outcomeId: "outcome_yes", probability: 0.52 },
+					{ outcomeId: "outcome_no", probability: 0.48 },
+				],
+				winningOutcomeId: "outcome_yes",
+				winningOutcomeProbability: 0.52,
+				predictedOutcomeId: "outcome_yes",
+				brierScore: 0.18,
+				wasCorrect: true,
+				realizedProfit: 3,
+				tradeCount: 2,
+				stakeWeight: 35,
+				createdAt: now,
+				updatedAt: now,
+			},
+		]);
+
+		const profile = await getMarketForecastProfile("guild_1", "user_2");
+		const leaderboard = await getMarketForecastLeaderboard({
+			guildId: "guild_1",
+			window: "all_time",
+			tag: "meta",
+		});
+
+		expect(profile.allTimeSampleCount).toBe(5);
+		expect(profile.thirtyDaySampleCount).toBe(4);
+		expect(profile.thirtyDayMeanBrier).toBe(0.2);
+		expect(profile.topTags[0]).toEqual(
+			expect.objectContaining({
+				tag: "meta",
+			}),
+		);
+		expect(leaderboard).toHaveLength(1);
+		expect(leaderboard[0]).toEqual(
+			expect.objectContaining({
+				userId: "user_2",
+			}),
+		);
+	});
+
+	it("builds forecast profile details with recent markets and trends", async () => {
+		const now = new Date();
+		prisma.market.findMany.mockImplementation(
+			async (input?: { where?: { id?: { in?: string[] } } }) => {
+				const ids = input?.where?.id?.in;
+				if (ids) {
+					return ids.map((id) => ({
+						id,
+						title: `Market title for ${id}`,
+					}));
+				}
+
+				return [];
+			},
+		);
+		prisma.marketForecastRecord.findMany.mockResolvedValue([
+			{
+				id: "forecast_1",
+				guildId: "guild_1",
+				marketId: "market_1",
+				userId: "user_2",
+				resolvedAt: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1_000),
+				marketTagSnapshot: ["meta"],
+				forecastVector: [
+					{ outcomeId: "yes", probability: 0.7 },
+					{ outcomeId: "no", probability: 0.3 },
+				],
+				winningOutcomeId: "yes",
+				winningOutcomeProbability: 0.7,
+				predictedOutcomeId: "yes",
+				brierScore: 0.12,
+				wasCorrect: true,
+				realizedProfit: 5,
+				tradeCount: 3,
+				stakeWeight: 80,
+				createdAt: now,
+				updatedAt: now,
+			},
+			{
+				id: "forecast_2",
+				guildId: "guild_1",
+				marketId: "market_2",
+				userId: "user_2",
+				resolvedAt: new Date(now.getTime() - 5 * 24 * 60 * 60 * 1_000),
+				marketTagSnapshot: ["meta"],
+				forecastVector: [
+					{ outcomeId: "yes", probability: 0.4 },
+					{ outcomeId: "no", probability: 0.6 },
+				],
+				winningOutcomeId: "no",
+				winningOutcomeProbability: 0.6,
+				predictedOutcomeId: "no",
+				brierScore: 0.2,
+				wasCorrect: true,
+				realizedProfit: 2,
+				tradeCount: 2,
+				stakeWeight: 40,
+				createdAt: now,
+				updatedAt: now,
+			},
+			{
+				id: "forecast_3",
+				guildId: "guild_1",
+				marketId: "market_3",
+				userId: "user_2",
+				resolvedAt: new Date(now.getTime() - 3 * 24 * 60 * 60 * 1_000),
+				marketTagSnapshot: ["sports"],
+				forecastVector: [
+					{ outcomeId: "yes", probability: 0.8 },
+					{ outcomeId: "no", probability: 0.2 },
+				],
+				winningOutcomeId: "no",
+				winningOutcomeProbability: 0.2,
+				predictedOutcomeId: "yes",
+				brierScore: 0.3,
+				wasCorrect: false,
+				realizedProfit: -3,
+				tradeCount: 4,
+				stakeWeight: 60,
+				createdAt: now,
+				updatedAt: now,
+			},
+			{
+				id: "forecast_4",
+				guildId: "guild_1",
+				marketId: "market_4",
+				userId: "user_2",
+				resolvedAt: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1_000),
+				marketTagSnapshot: ["sports"],
+				forecastVector: [
+					{ outcomeId: "yes", probability: 0.65 },
+					{ outcomeId: "no", probability: 0.35 },
+				],
+				winningOutcomeId: "yes",
+				winningOutcomeProbability: 0.65,
+				predictedOutcomeId: "yes",
+				brierScore: 0.11,
+				wasCorrect: true,
+				realizedProfit: 6,
+				tradeCount: 2,
+				stakeWeight: 50,
+				createdAt: now,
+				updatedAt: now,
+			},
+			{
+				id: "forecast_5",
+				guildId: "guild_1",
+				marketId: "market_5",
+				userId: "user_2",
+				resolvedAt: new Date(now.getTime() - 1 * 24 * 60 * 60 * 1_000),
+				marketTagSnapshot: ["meta"],
+				forecastVector: [
+					{ outcomeId: "yes", probability: 0.58 },
+					{ outcomeId: "no", probability: 0.42 },
+				],
+				winningOutcomeId: "yes",
+				winningOutcomeProbability: 0.58,
+				predictedOutcomeId: "yes",
+				brierScore: 0.18,
+				wasCorrect: true,
+				realizedProfit: 1,
+				tradeCount: 2,
+				stakeWeight: 35,
+				createdAt: now,
+				updatedAt: now,
+			},
+			{
+				id: "forecast_6",
+				guildId: "guild_1",
+				marketId: "market_6",
+				userId: "user_2",
+				resolvedAt: new Date(now.getTime() - 12 * 60 * 60 * 1_000),
+				marketTagSnapshot: ["meta"],
+				forecastVector: [
+					{ outcomeId: "yes", probability: 0.52 },
+					{ outcomeId: "no", probability: 0.48 },
+				],
+				winningOutcomeId: "yes",
+				winningOutcomeProbability: 0.52,
+				predictedOutcomeId: "yes",
+				brierScore: 0.16,
+				wasCorrect: true,
+				realizedProfit: 3,
+				tradeCount: 2,
+				stakeWeight: 35,
+				createdAt: now,
+				updatedAt: now,
+			},
+			{
+				id: "forecast_7",
+				guildId: "guild_1",
+				marketId: "market_7",
+				userId: "user_2",
+				resolvedAt: new Date(now.getTime() - 6 * 60 * 60 * 1_000),
+				marketTagSnapshot: ["meta"],
+				forecastVector: [
+					{ outcomeId: "yes", probability: 0.54 },
+					{ outcomeId: "no", probability: 0.46 },
+				],
+				winningOutcomeId: "yes",
+				winningOutcomeProbability: 0.54,
+				predictedOutcomeId: "yes",
+				brierScore: 0.15,
+				wasCorrect: true,
+				realizedProfit: 2.5,
+				tradeCount: 2,
+				stakeWeight: 34,
+				createdAt: now,
+				updatedAt: now,
+			},
+		]);
+
+		const details = await getMarketForecastProfileDetails("guild_1", "user_2");
+
+		expect(details.recentRecords).toHaveLength(6);
+		expect(details.recentRecords[0]).toEqual(
+			expect.objectContaining({
+				marketId: "market_7",
+				marketTitle: "Market title for market_7",
+			}),
+		);
+		expect(details.recentRecords[5]).toEqual(
+			expect.objectContaining({
+				marketId: "market_2",
+			}),
+		);
+		expect(details.brierTrend).toHaveLength(7);
+		expect(details.profitTrend.at(-1)).toEqual(
+			expect.objectContaining({
+				cumulativeProfit: 16.5,
+			}),
+		);
+	});
+
+	it("returns empty forecast metrics when no forecast records exist", async () => {
+		const profile = await getMarketForecastProfile("guild_empty", "user_9");
+		const details = await getMarketForecastProfileDetails(
+			"guild_empty",
+			"user_9",
+		);
+		const leaderboard = await getMarketForecastLeaderboard({
+			guildId: "guild_empty",
+			window: "30d",
+		});
+
+		expect(profile).toEqual(
+			expect.objectContaining({
+				allTimeMeanBrier: null,
+				thirtyDayMeanBrier: null,
+				allTimeSampleCount: 0,
+				thirtyDaySampleCount: 0,
+				rank: null,
+				percentileRank: null,
+			}),
+		);
+		expect(details).toEqual(
+			expect.objectContaining({
+				allTimeMeanBrier: null,
+				thirtyDayMeanBrier: null,
+				recentRecords: [],
+				brierTrend: [],
+				profitTrend: [],
+			}),
+		);
+		expect(leaderboard).toEqual([]);
+	});
+
+	it("does not block forecast reads on a historical backfill pass", async () => {
+		prisma.market.findMany.mockImplementation(
+			() => new Promise(() => undefined),
+		);
+		prisma.marketForecastRecord.findMany.mockResolvedValue([
+			{
+				id: "forecast_pending",
+				guildId: "guild_pending_backfill",
+				marketId: "market_1",
+				userId: "user_2",
+				resolvedAt: new Date("2099-03-29T00:00:00.000Z"),
+				marketTagSnapshot: ["meta"],
+				forecastVector: [
+					{ outcomeId: "outcome_yes", probability: 0.7 },
+					{ outcomeId: "outcome_no", probability: 0.3 },
+				],
+				winningOutcomeId: "outcome_yes",
+				winningOutcomeProbability: 0.7,
+				predictedOutcomeId: "outcome_yes",
+				brierScore: 0.12,
+				wasCorrect: true,
+				realizedProfit: 5,
+				tradeCount: 3,
+				stakeWeight: 80,
+				createdAt: new Date("2099-03-29T00:00:00.000Z"),
+				updatedAt: new Date("2099-03-29T00:00:00.000Z"),
+			},
+		]);
+
+		const profile = await getMarketForecastProfile(
+			"guild_pending_backfill",
+			"user_2",
+		);
+
+		expect(profile.allTimeSampleCount).toBe(1);
+		expect(profile.allTimeMeanBrier).toBe(0.12);
+	});
+
+	it("rejects grants above the configured maximum", async () => {
+		await expect(
+			grantMarketBankroll({
+				guildId: "guild_1",
+				userId: "user_2",
+				amount: 1_000_000.01,
+			}),
+		).rejects.toThrow("Grant amount cannot exceed 1000000.00 points.");
+	});
+
+	it("cancels a market by refunding long basis and unwinding short proceeds", async () => {
+		const cancelledMarket = {
+			...market,
+			positions: [
+				makeLongPosition(),
+				makeShortPosition({
+					outcomeId: "outcome_no",
+					proceeds: 4,
+					collateralLocked: 6,
+					shares: 6,
+				}),
+			],
+		};
+
+		transaction.market.findUnique.mockResolvedValue(cancelledMarket);
+		transaction.market.update.mockResolvedValue({
+			...cancelledMarket,
+			cancelledAt: new Date("2099-03-30T12:00:00.000Z"),
+		});
+		runTransaction();
+
+		await cancelMarket({
+			marketId: "market_1",
+			actorId: "user_1",
+		});
+
+		expect(transaction.marketAccount.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					bankroll: 1_062,
+				}),
+			}),
+		);
+	});
 });


### PR DESCRIPTION
## Summary
- Replace ad-hoc market trade/protect entry points with a session-driven interaction flow for trade/manage actions, including persisted interaction state and richer quote previews for buy/sell/short/cover.
- Expand forecast profile data and rendering to include detailed records/trends plus generated chart imagery for `/market profile` responses.
- Update market UI components, handlers, and tests to support the new session custom IDs, profile details output, and stricter interaction custom-id parsing.

## Validation
- `pnpm test`
- `pnpm build`