### PR TITLE
feat(markets): add pause trading, refunds DM, and sell/cover shortcuts

### DIFF
--- a/prisma/migrations/20260415103000_add_market_contract_mode_and_forecast_resolution_vector/migration.sql
+++ b/prisma/migrations/20260415103000_add_market_contract_mode_and_forecast_resolution_vector/migration.sql
@@ -1,0 +1,8 @@
+-- CreateEnum
+CREATE TYPE "MarketContractMode" AS ENUM ('categorical_single_winner', 'independent_binary_set');
+
+-- AlterTable
+ALTER TABLE "Market" ADD COLUMN "contractMode" "MarketContractMode" NOT NULL DEFAULT 'categorical_single_winner';
+
+-- AlterTable
+ALTER TABLE "MarketForecastRecord" ADD COLUMN "resolutionVector" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,11 @@ enum MarketButtonStyle {
   danger
 }
 
+enum MarketContractMode {
+  categorical_single_winner
+  independent_binary_set
+}
+
 enum CasinoGameKind {
   slots
   blackjack
@@ -325,6 +330,7 @@ model Market {
   title                  String
   description            String?
   buttonStyle            MarketButtonStyle @default(primary)
+  contractMode           MarketContractMode @default(categorical_single_winner)
   tags                   String[]         @default([])
   baseLiquidityParameter Int              @default(150)
   liquidityParameter     Int              @default(150)
@@ -367,6 +373,7 @@ model MarketForecastRecord {
   resolvedAt               DateTime
   marketTagSnapshot        String[] @default([])
   forecastVector           Json
+  resolutionVector         Json?
   winningOutcomeId         String
   winningOutcomeProbability Float
   predictedOutcomeId       String

--- a/src/features/markets/commands/definition.ts
+++ b/src/features/markets/commands/definition.ts
@@ -1,390 +1,432 @@
-import { ChannelType, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import {
+	ChannelType,
+	PermissionFlagsBits,
+	SlashCommandBuilder,
+} from "discord.js";
 
 export const marketCommand = new SlashCommandBuilder()
-  .setName('market')
-  .setDescription('Create, trade, and manage prediction markets.')
-  .addSubcommandGroup((group) =>
-    group
-      .setName('config')
-      .setDescription('Configure prediction markets for this server.')
-      .addSubcommand((subcommand) =>
-        subcommand
-          .setName('set')
-          .setDescription('Choose the official forum where markets are posted.')
-          .addChannelOption((option) =>
-            option
-              .setName('channel')
-              .setDescription('Official prediction market forum')
-              .addChannelTypes(ChannelType.GuildForum)
-              .setRequired(true),
-          ),
-      )
-      .addSubcommand((subcommand) =>
-        subcommand
-          .setName('view')
-          .setDescription('Show the current market configuration.'),
-      )
-      .addSubcommand((subcommand) =>
-        subcommand
-          .setName('disable')
-          .setDescription('Disable prediction markets for this server.'),
-      ),
-  )
-  .addSubcommand((subcommand) =>
-    subcommand
-      .setName('create')
-      .setDescription('Create a prediction market.')
-      .addStringOption((option) =>
-        option
-          .setName('title')
-          .setDescription('Market title')
-          .setRequired(true),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('outcomes')
-          .setDescription('Comma-separated outcomes, for example Yes,No')
-          .setRequired(true),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('close')
-          .setDescription('Trading duration or close time, for example 24h or April 6 2026 10:00pm CDT')
-          .setRequired(true),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('description')
-          .setDescription('Optional market description')
-          .setRequired(false),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('button_style')
-          .setDescription('Optional outcome button style')
-          .setRequired(false)
-          .addChoices(
-            { name: 'Primary', value: 'primary' },
-            { name: 'Secondary', value: 'secondary' },
-            { name: 'Success', value: 'success' },
-            { name: 'Danger', value: 'danger' },
-          ),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('tags')
-          .setDescription('Optional comma-separated tags')
-          .setRequired(false),
-      ),
-  )
-  .addSubcommand((subcommand) =>
-    subcommand
-      .setName('edit')
-      .setDescription('Edit a market. After trading starts, only close time and button style can change.')
-      .addStringOption((option) =>
-        option
-          .setName('query')
-          .setDescription('Market ID, message ID, or message link')
-          .setRequired(true),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('title')
-          .setDescription('Updated market title')
-          .setRequired(false),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('outcomes')
-          .setDescription('Updated comma-separated outcomes')
-          .setRequired(false),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('close')
-          .setDescription('Updated duration or close time')
-          .setRequired(false),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('description')
-          .setDescription('Updated description')
-          .setRequired(false),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('button_style')
-          .setDescription('Updated outcome button style')
-          .setRequired(false)
-          .addChoices(
-            { name: 'Primary', value: 'primary' },
-            { name: 'Secondary', value: 'secondary' },
-            { name: 'Success', value: 'success' },
-            { name: 'Danger', value: 'danger' },
-          ),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('tags')
-          .setDescription('Updated comma-separated tags')
-          .setRequired(false),
-      ),
-  )
-  .addSubcommand((subcommand) =>
-    subcommand
-      .setName('add-outcomes')
-      .setDescription('Append new outcomes to an open market without resetting trades.')
-      .addStringOption((option) =>
-        option
-          .setName('query')
-          .setDescription('Market ID, message ID, or message link')
-          .setRequired(true),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('outcomes')
-          .setDescription('Comma-separated outcomes to append')
-          .setRequired(true),
-      ),
-  )
-  .addSubcommand((subcommand) =>
-    subcommand
-      .setName('view')
-      .setDescription('Show a market by ID or message link.')
-      .addStringOption((option) =>
-        option
-          .setName('query')
-          .setDescription('Market ID, message ID, or message link')
-          .setRequired(true),
-      ),
-  )
-  .addSubcommand((subcommand) =>
-    subcommand
-      .setName('list')
-      .setDescription('Browse markets in this server.')
-      .addStringOption((option) =>
-        option
-          .setName('status')
-          .setDescription('Market status')
-          .setRequired(false)
-          .addChoices(
-            { name: 'Open', value: 'open' },
-            { name: 'Closed', value: 'closed' },
-            { name: 'Resolved', value: 'resolved' },
-            { name: 'Cancelled', value: 'cancelled' },
-          ),
-      )
-      .addUserOption((option) =>
-        option
-          .setName('creator')
-          .setDescription('Only show markets created by this user')
-          .setRequired(false),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('tag')
-          .setDescription('Only show markets with this tag')
-          .setRequired(false),
-      ),
-  )
-  .addSubcommand((subcommand) =>
-    subcommand
-      .setName('trade')
-      .setDescription('Buy or sell positions in a market.')
-      .addStringOption((option) =>
-        option
-          .setName('query')
-          .setDescription('Market ID, message ID, or message link')
-          .setRequired(true),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('action')
-          .setDescription('Trade action')
-          .setRequired(true)
-          .addChoices(
-            { name: 'Buy', value: 'buy' },
-            { name: 'Sell', value: 'sell' },
-            { name: 'Short', value: 'short' },
-            { name: 'Cover', value: 'cover' },
-          ),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('outcome')
-          .setDescription('Outcome number, outcome ID, or exact label')
-          .setRequired(true),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('amount')
-          .setDescription('Trade amount: buy 50 or 50 pts; sell/short/cover 10 pts or 2.5 shares')
-          .setRequired(true)
-      ),
-  )
-  .addSubcommand((subcommand) =>
-    subcommand
-      .setName('resolve-outcome')
-      .setDescription('Resolve a specific outcome as impossible while leaving the market open.')
-      .addStringOption((option) =>
-        option
-          .setName('query')
-          .setDescription('Market ID, message ID, or message link')
-          .setRequired(true),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('outcome')
-          .setDescription('Outcome number, outcome ID, or exact label')
-          .setRequired(true),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('note')
-          .setDescription('Optional resolution note')
-          .setRequired(false),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('evidence_url')
-          .setDescription('Optional evidence URL')
-          .setRequired(false),
-      ),
-  )
-  .addSubcommand((subcommand) =>
-    subcommand
-      .setName('resolve')
-      .setDescription('Resolve a market by naming the winner.')
-      .addStringOption((option) =>
-        option
-          .setName('query')
-          .setDescription('Market ID, message ID, or message link')
-          .setRequired(true),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('winning_outcome')
-          .setDescription('Winning outcome number, ID, or exact label')
-          .setRequired(true),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('note')
-          .setDescription('Optional resolution note')
-          .setRequired(false),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('evidence_url')
-          .setDescription('Optional evidence URL')
-          .setRequired(false),
-      ),
-  )
-  .addSubcommand((subcommand) =>
-    subcommand
-      .setName('cancel')
-      .setDescription('Cancel a market and refund open positions.')
-      .addStringOption((option) =>
-        option
-          .setName('query')
-          .setDescription('Market ID, message ID, or message link')
-          .setRequired(true),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('reason')
-          .setDescription('Optional cancellation reason')
-          .setRequired(false),
-      ),
-  )
-  .addSubcommand((subcommand) =>
-    subcommand
-      .setName('traders')
-      .setDescription('Show everyone who traded in a market and how much they spent.')
-      .addStringOption((option) =>
-        option
-          .setName('query')
-          .setDescription('Market ID, message ID, or message link')
-          .setRequired(true),
-      ),
-  )
-  .addSubcommand((subcommand) =>
-    subcommand
-      .setName('portfolio')
-      .setDescription('Show a user portfolio and bankroll.')
-      .addUserOption((option) =>
-        option
-          .setName('user')
-          .setDescription('Optional portfolio owner')
-          .setRequired(false),
-      ),
-  )
-  .addSubcommand((subcommand) =>
-    subcommand
-      .setName('profile')
-      .setDescription('Show a user forecasting profile.')
-      .addUserOption((option) =>
-        option
-          .setName('user')
-          .setDescription('Optional profile owner')
-          .setRequired(false),
-      ),
-  )
-  .addSubcommand((subcommand) =>
-    subcommand
-      .setName('grant')
-      .setDescription('Grant market currency to a user and notify them by DM.')
-      .addUserOption((option) =>
-        option
-          .setName('user')
-          .setDescription('Recipient of the grant')
-          .setRequired(true),
-      )
-      .addNumberOption((option) =>
-        option
-          .setName('amount')
-          .setDescription('Amount of market currency to grant')
-          .setMinValue(0.01)
-          .setRequired(true),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('reason')
-          .setDescription('Why this grant is being issued')
-          .setMaxLength(500)
-          .setRequired(true),
-      ),
-  )
-  .addSubcommand((subcommand) =>
-    subcommand
-      .setName('leaderboard')
-      .setDescription('Show the current market leaderboard.')
-      .addStringOption((option) =>
-        option
-          .setName('board')
-          .setDescription('Choose which leaderboard to display')
-          .setRequired(false)
-          .addChoices(
-            { name: 'Bankroll', value: 'bankroll' },
-            { name: 'Forecast', value: 'forecast' },
-          ),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('window')
-          .setDescription('Forecast leaderboard time window')
-          .setRequired(false)
-          .addChoices(
-            { name: 'All Time', value: 'all_time' },
-            { name: 'Last 30 Days', value: '30d' },
-          ),
-      )
-      .addStringOption((option) =>
-        option
-          .setName('tag')
-          .setDescription('Optional forecast leaderboard tag filter')
-          .setRequired(false),
-      ),
-  );
+	.setName("market")
+	.setDescription("Create, trade, and manage prediction markets.")
+	.addSubcommandGroup((group) =>
+		group
+			.setName("config")
+			.setDescription("Configure prediction markets for this server.")
+			.addSubcommand((subcommand) =>
+				subcommand
+					.setName("set")
+					.setDescription("Choose the official forum where markets are posted.")
+					.addChannelOption((option) =>
+						option
+							.setName("channel")
+							.setDescription("Official prediction market forum")
+							.addChannelTypes(ChannelType.GuildForum)
+							.setRequired(true),
+					),
+			)
+			.addSubcommand((subcommand) =>
+				subcommand
+					.setName("view")
+					.setDescription("Show the current market configuration."),
+			)
+			.addSubcommand((subcommand) =>
+				subcommand
+					.setName("disable")
+					.setDescription("Disable prediction markets for this server."),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("create")
+			.setDescription("Create a prediction market.")
+			.addStringOption((option) =>
+				option
+					.setName("title")
+					.setDescription("Market title")
+					.setRequired(true),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("outcomes")
+					.setDescription("Comma-separated outcomes, for example Yes,No")
+					.setRequired(true),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("close")
+					.setDescription(
+						"Trading duration or close time, for example 24h or April 6 2026 10:00pm CDT",
+					)
+					.setRequired(true),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("description")
+					.setDescription("Optional market description")
+					.setRequired(false),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("button_style")
+					.setDescription("Optional outcome button style")
+					.setRequired(false)
+					.addChoices(
+						{ name: "Primary", value: "primary" },
+						{ name: "Secondary", value: "secondary" },
+						{ name: "Success", value: "success" },
+						{ name: "Danger", value: "danger" },
+					),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("contract_mode")
+					.setDescription("How outcomes settle at resolution")
+					.setRequired(false)
+					.addChoices(
+						{
+							name: "Single Winner (sum ~100%)",
+							value: "categorical_single_winner",
+						},
+						{
+							name: "Independent Set (sum can exceed 100%)",
+							value: "independent_binary_set",
+						},
+					),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("tags")
+					.setDescription("Optional comma-separated tags")
+					.setRequired(false),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("edit")
+			.setDescription(
+				"Edit a market. After trading starts, only close time and button style can change.",
+			)
+			.addStringOption((option) =>
+				option
+					.setName("query")
+					.setDescription("Market ID, message ID, or message link")
+					.setRequired(true),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("title")
+					.setDescription("Updated market title")
+					.setRequired(false),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("outcomes")
+					.setDescription("Updated comma-separated outcomes")
+					.setRequired(false),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("close")
+					.setDescription("Updated duration or close time")
+					.setRequired(false),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("description")
+					.setDescription("Updated description")
+					.setRequired(false),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("button_style")
+					.setDescription("Updated outcome button style")
+					.setRequired(false)
+					.addChoices(
+						{ name: "Primary", value: "primary" },
+						{ name: "Secondary", value: "secondary" },
+						{ name: "Success", value: "success" },
+						{ name: "Danger", value: "danger" },
+					),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("tags")
+					.setDescription("Updated comma-separated tags")
+					.setRequired(false),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("add-outcomes")
+			.setDescription(
+				"Append new outcomes to an open market without resetting trades.",
+			)
+			.addStringOption((option) =>
+				option
+					.setName("query")
+					.setDescription("Market ID, message ID, or message link")
+					.setRequired(true),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("outcomes")
+					.setDescription("Comma-separated outcomes to append")
+					.setRequired(true),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("view")
+			.setDescription("Show a market by ID or message link.")
+			.addStringOption((option) =>
+				option
+					.setName("query")
+					.setDescription("Market ID, message ID, or message link")
+					.setRequired(true),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("list")
+			.setDescription("Browse markets in this server.")
+			.addStringOption((option) =>
+				option
+					.setName("status")
+					.setDescription("Market status")
+					.setRequired(false)
+					.addChoices(
+						{ name: "Open", value: "open" },
+						{ name: "Closed", value: "closed" },
+						{ name: "Resolved", value: "resolved" },
+						{ name: "Cancelled", value: "cancelled" },
+					),
+			)
+			.addUserOption((option) =>
+				option
+					.setName("creator")
+					.setDescription("Only show markets created by this user")
+					.setRequired(false),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("tag")
+					.setDescription("Only show markets with this tag")
+					.setRequired(false),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("trade")
+			.setDescription("Buy or sell positions in a market.")
+			.addStringOption((option) =>
+				option
+					.setName("query")
+					.setDescription("Market ID, message ID, or message link")
+					.setRequired(true),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("action")
+					.setDescription("Trade action")
+					.setRequired(true)
+					.addChoices(
+						{ name: "Buy", value: "buy" },
+						{ name: "Sell", value: "sell" },
+						{ name: "Short", value: "short" },
+						{ name: "Cover", value: "cover" },
+					),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("outcome")
+					.setDescription("Outcome number, outcome ID, or exact label")
+					.setRequired(true),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("amount")
+					.setDescription(
+						"Trade amount: buy 50 or 50 pts; sell/short/cover 10 pts or 2.5 shares",
+					)
+					.setRequired(true),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("resolve-outcome")
+			.setDescription(
+				"Resolve a specific outcome with a settlement value while leaving the market open.",
+			)
+			.addStringOption((option) =>
+				option
+					.setName("query")
+					.setDescription("Market ID, message ID, or message link")
+					.setRequired(true),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("outcome")
+					.setDescription("Outcome number, outcome ID, or exact label")
+					.setRequired(true),
+			)
+			.addNumberOption((option) =>
+				option
+					.setName("value")
+					.setDescription(
+						"Settlement value from 0 to 1 (independent markets only, defaults to 0)",
+					)
+					.setRequired(false)
+					.setMinValue(0)
+					.setMaxValue(1),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("note")
+					.setDescription("Optional resolution note")
+					.setRequired(false),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("evidence_url")
+					.setDescription("Optional evidence URL")
+					.setRequired(false),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("resolve")
+			.setDescription("Resolve a market by naming the winner.")
+			.addStringOption((option) =>
+				option
+					.setName("query")
+					.setDescription("Market ID, message ID, or message link")
+					.setRequired(true),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("winning_outcome")
+					.setDescription("Winning outcome number, ID, or exact label")
+					.setRequired(true),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("note")
+					.setDescription("Optional resolution note")
+					.setRequired(false),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("evidence_url")
+					.setDescription("Optional evidence URL")
+					.setRequired(false),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("cancel")
+			.setDescription("Cancel a market and refund open positions.")
+			.addStringOption((option) =>
+				option
+					.setName("query")
+					.setDescription("Market ID, message ID, or message link")
+					.setRequired(true),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("reason")
+					.setDescription("Optional cancellation reason")
+					.setRequired(false),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("traders")
+			.setDescription(
+				"Show everyone who traded in a market and how much they spent.",
+			)
+			.addStringOption((option) =>
+				option
+					.setName("query")
+					.setDescription("Market ID, message ID, or message link")
+					.setRequired(true),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("portfolio")
+			.setDescription("Show a user portfolio and bankroll.")
+			.addUserOption((option) =>
+				option
+					.setName("user")
+					.setDescription("Optional portfolio owner")
+					.setRequired(false),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("profile")
+			.setDescription("Show a user forecasting profile.")
+			.addUserOption((option) =>
+				option
+					.setName("user")
+					.setDescription("Optional profile owner")
+					.setRequired(false),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("grant")
+			.setDescription("Grant market currency to a user and notify them by DM.")
+			.addUserOption((option) =>
+				option
+					.setName("user")
+					.setDescription("Recipient of the grant")
+					.setRequired(true),
+			)
+			.addNumberOption((option) =>
+				option
+					.setName("amount")
+					.setDescription("Amount of market currency to grant")
+					.setMinValue(0.01)
+					.setRequired(true),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("reason")
+					.setDescription("Why this grant is being issued")
+					.setMaxLength(500)
+					.setRequired(true),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("leaderboard")
+			.setDescription("Show the current market leaderboard.")
+			.addStringOption((option) =>
+				option
+					.setName("board")
+					.setDescription("Choose which leaderboard to display")
+					.setRequired(false)
+					.addChoices(
+						{ name: "Bankroll", value: "bankroll" },
+						{ name: "Forecast", value: "forecast" },
+					),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("window")
+					.setDescription("Forecast leaderboard time window")
+					.setRequired(false)
+					.addChoices(
+						{ name: "All Time", value: "all_time" },
+						{ name: "Last 30 Days", value: "30d" },
+					),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("tag")
+					.setDescription("Optional forecast leaderboard tag filter")
+					.setRequired(false),
+			),
+	);
 
 marketCommand.setDefaultMemberPermissions(PermissionFlagsBits.SendMessages);

--- a/src/features/markets/commands/definition.ts
+++ b/src/features/markets/commands/definition.ts
@@ -245,7 +245,7 @@ export const marketCommand = new SlashCommandBuilder()
 				option
 					.setName("amount")
 					.setDescription(
-						"Trade amount: buy 50 or 50 pts; sell/cover 50%, all, 10 pts, or 2.5 shares; short 10 pts or 2.5 shares",
+						"Amount: buy 50 pts; sell/cover all, 50%, 10 pts, or 2.5 shares; short 10 pts or 2.5 shares",
 					)
 					.setRequired(true),
 			),

--- a/src/features/markets/commands/definition.ts
+++ b/src/features/markets/commands/definition.ts
@@ -245,7 +245,7 @@ export const marketCommand = new SlashCommandBuilder()
 				option
 					.setName("amount")
 					.setDescription(
-						"Trade amount: buy 50 or 50 pts; sell/short/cover 10 pts or 2.5 shares",
+						"Trade amount: buy 50 or 50 pts; sell/cover 50%, all, 10 pts, or 2.5 shares; short 10 pts or 2.5 shares",
 					)
 					.setRequired(true),
 			),
@@ -318,6 +318,17 @@ export const marketCommand = new SlashCommandBuilder()
 					.setName("evidence_url")
 					.setDescription("Optional evidence URL")
 					.setRequired(false),
+			),
+	)
+	.addSubcommand((subcommand) =>
+		subcommand
+			.setName("pause-trading")
+			.setDescription("Pause trading on a market immediately.")
+			.addStringOption((option) =>
+				option
+					.setName("query")
+					.setDescription("Market ID, message ID, or message link")
+					.setRequired(true),
 			),
 	)
 	.addSubcommand((subcommand) =>

--- a/src/features/markets/core/math.ts
+++ b/src/features/markets/core/math.ts
@@ -1,149 +1,303 @@
 const binarySearchIterations = 60;
 
-const clampSmall = (value: number): number => Math.abs(value) < 1e-9 ? 0 : value;
+const clampSmall = (value: number): number =>
+	Math.abs(value) < 1e-9 ? 0 : value;
 
-export const computeLmsrCost = (shares: number[], liquidity: number): number => {
-  const scaled = shares.map((value) => value / liquidity);
-  const max = Math.max(...scaled);
-  const total = scaled.reduce((sum, value) => sum + Math.exp(value - max), 0);
-  return liquidity * (max + Math.log(total));
+export const computeLmsrCost = (
+	shares: number[],
+	liquidity: number,
+): number => {
+	const scaled = shares.map((value) => value / liquidity);
+	const max = Math.max(...scaled);
+	const total = scaled.reduce((sum, value) => sum + Math.exp(value - max), 0);
+	return liquidity * (max + Math.log(total));
 };
 
-export const computeLmsrProbabilities = (shares: number[], liquidity: number): number[] => {
-  const scaled = shares.map((value) => value / liquidity);
-  const max = Math.max(...scaled);
-  const exps = scaled.map((value) => Math.exp(value - max));
-  const total = exps.reduce((sum, value) => sum + value, 0);
-  return exps.map((value) => value / total);
+export const computeLmsrProbabilities = (
+	shares: number[],
+	liquidity: number,
+): number[] => {
+	const scaled = shares.map((value) => value / liquidity);
+	const max = Math.max(...scaled);
+	const exps = scaled.map((value) => Math.exp(value - max));
+	const total = exps.reduce((sum, value) => sum + value, 0);
+	return exps.map((value) => value / total);
+};
+
+export const computeBinaryLmsrCost = (
+	shares: number,
+	liquidity: number,
+): number => liquidity * Math.log1p(Math.exp(shares / liquidity));
+
+export const computeBinaryLmsrProbability = (
+	shares: number,
+	liquidity: number,
+): number => 1 / (1 + Math.exp(-(shares / liquidity)));
+
+export const computeBinaryBuyCost = (
+	shares: number,
+	sharesToBuy: number,
+	liquidity: number,
+): number =>
+	clampSmall(
+		computeBinaryLmsrCost(shares + sharesToBuy, liquidity) -
+			computeBinaryLmsrCost(shares, liquidity),
+	);
+
+export const computeBinarySellPayout = (
+	shares: number,
+	sharesToSell: number,
+	liquidity: number,
+): number =>
+	clampSmall(
+		computeBinaryLmsrCost(shares, liquidity) -
+			computeBinaryLmsrCost(shares - sharesToSell, liquidity),
+	);
+
+export const solveBinaryBuySharesForAmount = (
+	shares: number,
+	amount: number,
+	liquidity: number,
+): number => {
+	const baseline = computeBinaryLmsrCost(shares, liquidity);
+	let low = 0;
+	let high = Math.max(1, amount);
+
+	while (computeBinaryLmsrCost(shares + high, liquidity) - baseline < amount) {
+		high *= 2;
+	}
+
+	for (let index = 0; index < binarySearchIterations; index += 1) {
+		const mid = (low + high) / 2;
+		const costDelta = computeBinaryLmsrCost(shares + mid, liquidity) - baseline;
+		if (costDelta < amount) {
+			low = mid;
+		} else {
+			high = mid;
+		}
+	}
+
+	return clampSmall(high);
+};
+
+export const solveBinarySellSharesForAmount = (
+	shares: number,
+	desiredPayout: number,
+	ownedShares: number,
+	liquidity: number,
+): number => {
+	const maxPayout = computeBinarySellPayout(shares, ownedShares, liquidity);
+	if (desiredPayout > maxPayout + 1e-6) {
+		throw new Error(
+			"You do not have enough shares in that outcome to sell that much.",
+		);
+	}
+
+	let low = 0;
+	let high = ownedShares;
+
+	for (let index = 0; index < binarySearchIterations; index += 1) {
+		const mid = (low + high) / 2;
+		const payout = computeBinarySellPayout(shares, mid, liquidity);
+		if (payout < desiredPayout) {
+			low = mid;
+		} else {
+			high = mid;
+		}
+	}
+
+	return clampSmall(high);
+};
+
+export const solveBinaryShortSharesForAmount = (
+	shares: number,
+	desiredPayout: number,
+	liquidity: number,
+): number => {
+	const maxPayout = computeBinaryLmsrCost(shares, liquidity);
+	if (desiredPayout > maxPayout + 1e-6) {
+		throw new Error(
+			"That short cannot pay out that many points. Try a smaller point amount or specify shares.",
+		);
+	}
+
+	let low = 0;
+	let high = Math.max(1, desiredPayout);
+
+	while (computeBinarySellPayout(shares, high, liquidity) < desiredPayout) {
+		high *= 2;
+	}
+
+	for (let index = 0; index < binarySearchIterations; index += 1) {
+		const mid = (low + high) / 2;
+		const payout = computeBinarySellPayout(shares, mid, liquidity);
+		if (payout < desiredPayout) {
+			low = mid;
+		} else {
+			high = mid;
+		}
+	}
+
+	return clampSmall(high);
 };
 
 export const solveBuySharesForAmount = (
-  shares: number[],
-  outcomeIndex: number,
-  amount: number,
-  liquidity: number,
+	shares: number[],
+	outcomeIndex: number,
+	amount: number,
+	liquidity: number,
 ): number => {
-  const baseline = computeLmsrCost(shares, liquidity);
-  let low = 0;
-  let high = Math.max(1, amount);
+	const baseline = computeLmsrCost(shares, liquidity);
+	let low = 0;
+	let high = Math.max(1, amount);
 
-  while ((computeLmsrCost(shares.map((value, index) => index === outcomeIndex ? value + high : value), liquidity) - baseline) < amount) {
-    high *= 2;
-  }
+	while (
+		computeLmsrCost(
+			shares.map((value, index) =>
+				index === outcomeIndex ? value + high : value,
+			),
+			liquidity,
+		) -
+			baseline <
+		amount
+	) {
+		high *= 2;
+	}
 
-  for (let index = 0; index < binarySearchIterations; index += 1) {
-    const mid = (low + high) / 2;
-    const nextShares = shares.map((value, shareIndex) => shareIndex === outcomeIndex ? value + mid : value);
-    const costDelta = computeLmsrCost(nextShares, liquidity) - baseline;
-    if (costDelta < amount) {
-      low = mid;
-    } else {
-      high = mid;
-    }
-  }
+	for (let index = 0; index < binarySearchIterations; index += 1) {
+		const mid = (low + high) / 2;
+		const nextShares = shares.map((value, shareIndex) =>
+			shareIndex === outcomeIndex ? value + mid : value,
+		);
+		const costDelta = computeLmsrCost(nextShares, liquidity) - baseline;
+		if (costDelta < amount) {
+			low = mid;
+		} else {
+			high = mid;
+		}
+	}
 
-  return clampSmall(high);
+	return clampSmall(high);
 };
 
 export const computeBuyCost = (
-  shares: number[],
-  outcomeIndex: number,
-  sharesToBuy: number,
-  liquidity: number,
+	shares: number[],
+	outcomeIndex: number,
+	sharesToBuy: number,
+	liquidity: number,
 ): number => {
-  const baseline = computeLmsrCost(shares, liquidity);
-  const nextShares = shares.map((value, index) => index === outcomeIndex ? value + sharesToBuy : value);
-  return clampSmall(computeLmsrCost(nextShares, liquidity) - baseline);
+	const baseline = computeLmsrCost(shares, liquidity);
+	const nextShares = shares.map((value, index) =>
+		index === outcomeIndex ? value + sharesToBuy : value,
+	);
+	return clampSmall(computeLmsrCost(nextShares, liquidity) - baseline);
 };
 
 export const computeSellPayout = (
-  shares: number[],
-  outcomeIndex: number,
-  sharesToSell: number,
-  liquidity: number,
+	shares: number[],
+	outcomeIndex: number,
+	sharesToSell: number,
+	liquidity: number,
 ): number => {
-  const baseline = computeLmsrCost(shares, liquidity);
-  const nextShares = shares.map((value, index) => index === outcomeIndex ? value - sharesToSell : value);
-  return clampSmall(baseline - computeLmsrCost(nextShares, liquidity));
+	const baseline = computeLmsrCost(shares, liquidity);
+	const nextShares = shares.map((value, index) =>
+		index === outcomeIndex ? value - sharesToSell : value,
+	);
+	return clampSmall(baseline - computeLmsrCost(nextShares, liquidity));
 };
 
 const computeMaxShortPayout = (
-  shares: number[],
-  outcomeIndex: number,
-  liquidity: number,
+	shares: number[],
+	outcomeIndex: number,
+	liquidity: number,
 ): number => {
-  const baseline = computeLmsrCost(shares, liquidity);
-  const remainingScaled = shares
-    .filter((_, index) => index !== outcomeIndex)
-    .map((value) => value / liquidity);
+	const baseline = computeLmsrCost(shares, liquidity);
+	const remainingScaled = shares
+		.filter((_, index) => index !== outcomeIndex)
+		.map((value) => value / liquidity);
 
-  if (remainingScaled.length === 0) {
-    return 0;
-  }
+	if (remainingScaled.length === 0) {
+		return 0;
+	}
 
-  const max = Math.max(...remainingScaled);
-  const total = remainingScaled.reduce((sum, value) => sum + Math.exp(value - max), 0);
-  const minCost = liquidity * (max + Math.log(total));
-  return clampSmall(baseline - minCost);
+	const max = Math.max(...remainingScaled);
+	const total = remainingScaled.reduce(
+		(sum, value) => sum + Math.exp(value - max),
+		0,
+	);
+	const minCost = liquidity * (max + Math.log(total));
+	return clampSmall(baseline - minCost);
 };
 
 export const solveSellSharesForAmount = (
-  shares: number[],
-  outcomeIndex: number,
-  desiredPayout: number,
-  ownedShares: number,
-  liquidity: number,
+	shares: number[],
+	outcomeIndex: number,
+	desiredPayout: number,
+	ownedShares: number,
+	liquidity: number,
 ): number => {
-  const maxPayout = computeSellPayout(shares, outcomeIndex, ownedShares, liquidity);
-  if (desiredPayout > maxPayout + 1e-6) {
-    throw new Error('You do not have enough shares in that outcome to sell that much.');
-  }
+	const maxPayout = computeSellPayout(
+		shares,
+		outcomeIndex,
+		ownedShares,
+		liquidity,
+	);
+	if (desiredPayout > maxPayout + 1e-6) {
+		throw new Error(
+			"You do not have enough shares in that outcome to sell that much.",
+		);
+	}
 
-  let low = 0;
-  let high = ownedShares;
+	let low = 0;
+	let high = ownedShares;
 
-  for (let index = 0; index < binarySearchIterations; index += 1) {
-    const mid = (low + high) / 2;
-    const payout = computeSellPayout(shares, outcomeIndex, mid, liquidity);
-    if (payout < desiredPayout) {
-      low = mid;
-    } else {
-      high = mid;
-    }
-  }
+	for (let index = 0; index < binarySearchIterations; index += 1) {
+		const mid = (low + high) / 2;
+		const payout = computeSellPayout(shares, outcomeIndex, mid, liquidity);
+		if (payout < desiredPayout) {
+			low = mid;
+		} else {
+			high = mid;
+		}
+	}
 
-  return clampSmall(high);
+	return clampSmall(high);
 };
 
 export const solveShortSharesForAmount = (
-  shares: number[],
-  outcomeIndex: number,
-  desiredPayout: number,
-  liquidity: number,
+	shares: number[],
+	outcomeIndex: number,
+	desiredPayout: number,
+	liquidity: number,
 ): number => {
-  const maxPayout = computeMaxShortPayout(shares, outcomeIndex, liquidity);
-  if (desiredPayout > maxPayout + 1e-6) {
-    throw new Error('That short cannot pay out that many points. Try a smaller point amount or specify shares.');
-  }
+	const maxPayout = computeMaxShortPayout(shares, outcomeIndex, liquidity);
+	if (desiredPayout > maxPayout + 1e-6) {
+		throw new Error(
+			"That short cannot pay out that many points. Try a smaller point amount or specify shares.",
+		);
+	}
 
-  let low = 0;
-  let high = Math.max(1, desiredPayout);
+	let low = 0;
+	let high = Math.max(1, desiredPayout);
 
-  while (computeSellPayout(shares, outcomeIndex, high, liquidity) < desiredPayout) {
-    high *= 2;
-  }
+	while (
+		computeSellPayout(shares, outcomeIndex, high, liquidity) < desiredPayout
+	) {
+		high *= 2;
+	}
 
-  for (let index = 0; index < binarySearchIterations; index += 1) {
-    const mid = (low + high) / 2;
-    const payout = computeSellPayout(shares, outcomeIndex, mid, liquidity);
-    if (payout < desiredPayout) {
-      low = mid;
-    } else {
-      high = mid;
-    }
-  }
+	for (let index = 0; index < binarySearchIterations; index += 1) {
+		const mid = (low + high) / 2;
+		const payout = computeSellPayout(shares, outcomeIndex, mid, liquidity);
+		if (payout < desiredPayout) {
+			low = mid;
+		} else {
+			high = mid;
+		}
+	}
 
-  return clampSmall(high);
+	return clampSmall(high);
 };
 
-export const formatProbabilityPercent = (value: number): string => `${(value * 100).toFixed(1)}%`;
+export const formatProbabilityPercent = (value: number): string =>
+	`${(value * 100).toFixed(1)}%`;

--- a/src/features/markets/core/shared.ts
+++ b/src/features/markets/core/shared.ts
@@ -1,23 +1,26 @@
 import type {
-  Market,
-  MarketLossProtection,
-  MarketOutcome,
-  MarketPosition,
-  MarketPositionSide,
-  MarketTradeSide,
-  Prisma,
-} from '@prisma/client';
-import { PermissionFlagsBits, type PermissionsBitField } from 'discord.js';
+	Market,
+	MarketContractMode,
+	MarketLossProtection,
+	MarketOutcome,
+	MarketPosition,
+	MarketPositionSide,
+	MarketTradeSide,
+	Prisma,
+} from "@prisma/client";
+import { PermissionFlagsBits, type PermissionsBitField } from "discord.js";
 
 import {
-  defaultDailyTopUpFloor,
-  startingBankroll as sharedStartingBankroll,
-} from '../../../lib/economy.js';
-import { computeLmsrProbabilities, computeSellPayout } from './math.js';
-import type {
-  MarketStatus,
-  MarketWithRelations,
-} from './types.js';
+	defaultDailyTopUpFloor,
+	startingBankroll as sharedStartingBankroll,
+} from "../../../lib/economy.js";
+import {
+	computeBinaryLmsrProbability,
+	computeBinarySellPayout,
+	computeLmsrProbabilities,
+	computeSellPayout,
+} from "./math.js";
+import type { MarketStatus, MarketWithRelations } from "./types.js";
 
 export const startingBankroll = sharedStartingBankroll;
 export const dailyTopUpFloor = defaultDailyTopUpFloor;
@@ -32,538 +35,663 @@ export const minOpenProbability = 0.02;
 export const protectionPremiumMultiplier = 1.05;
 
 export const marketInclude = {
-  outcomes: {
-    orderBy: {
-      sortOrder: 'asc',
-    },
-  },
-  trades: {
-    orderBy: {
-      createdAt: 'asc',
-    },
-  },
-  positions: true,
-  lossProtections: true,
-  winningOutcome: true,
-  forecastRecords: false,
-  liquidityEvents: {
-    orderBy: {
-      createdAt: 'asc',
-    },
-  },
+	outcomes: {
+		orderBy: {
+			sortOrder: "asc",
+		},
+	},
+	trades: {
+		orderBy: {
+			createdAt: "asc",
+		},
+	},
+	positions: true,
+	lossProtections: true,
+	winningOutcome: true,
+	forecastRecords: false,
+	liquidityEvents: {
+		orderBy: {
+			createdAt: "asc",
+		},
+	},
 } as const;
 
-export const getQueueJobId = (id: string): string => Buffer.from(id).toString('base64url');
+export const getQueueJobId = (id: string): string =>
+	Buffer.from(id).toString("base64url");
 
 export const startOfUtcDay = (date: Date): Date =>
-  new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+	new Date(
+		Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+	);
 
-export const roundCurrency = (value: number): number => Math.round(value * 100) / 100;
-export const roundProbability = (value: number): number => Math.round(value * 10_000) / 10_000;
-export const clampSmall = (value: number): number => Math.abs(value) < 1e-9 ? 0 : value;
-export const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
+export const roundCurrency = (value: number): number =>
+	Math.round(value * 100) / 100;
+export const roundProbability = (value: number): number =>
+	Math.round(value * 10_000) / 10_000;
+export const clampSmall = (value: number): number =>
+	Math.abs(value) < 1e-9 ? 0 : value;
+export const clamp = (value: number, min: number, max: number): number =>
+	Math.min(max, Math.max(min, value));
+
+const resolveMarketContractMode = (
+	contractMode?: MarketContractMode | null,
+): MarketContractMode => contractMode ?? "categorical_single_winner";
 
 export const compareMarketHistoryEvents = <
-  T extends {
-    kind: 'trade' | 'liquidity';
-    createdAt: Date;
-  },
->(left: T, right: T): number => {
-  const delta = left.createdAt.getTime() - right.createdAt.getTime();
-  if (delta !== 0) {
-    return delta;
-  }
+	T extends {
+		kind: "trade" | "liquidity";
+		createdAt: Date;
+	},
+>(
+	left: T,
+	right: T,
+): number => {
+	const delta = left.createdAt.getTime() - right.createdAt.getTime();
+	if (delta !== 0) {
+		return delta;
+	}
 
-  // Liquidity rebases pricing shares. When a rebase and trade share a timestamp,
-  // replay the liquidity event first so later consumers reconstruct the same state.
-  return left.kind === right.kind
-    ? 0
-    : left.kind === 'liquidity'
-      ? -1
-      : 1;
+	// Liquidity rebases pricing shares. When a rebase and trade share a timestamp,
+	// replay the liquidity event first so later consumers reconstruct the same state.
+	return left.kind === right.kind ? 0 : left.kind === "liquidity" ? -1 : 1;
 };
 
 const canModerateMarkets = (
-  permissions: PermissionsBitField | Readonly<PermissionsBitField> | null | undefined,
+	permissions:
+		| PermissionsBitField
+		| Readonly<PermissionsBitField>
+		| null
+		| undefined,
 ): boolean => Boolean(permissions?.has(PermissionFlagsBits.ManageGuild));
 
-export const getPositionMap = (positions: MarketPosition[]): Map<string, MarketPosition> =>
-  new Map(positions.map((position) => [`${position.outcomeId}:${position.side}`, position]));
+export const getPositionMap = (
+	positions: MarketPosition[],
+): Map<string, MarketPosition> =>
+	new Map(
+		positions.map((position) => [
+			`${position.outcomeId}:${position.side}`,
+			position,
+		]),
+	);
 
 export const getPosition = (
-  positions: Map<string, MarketPosition>,
-  outcomeId: string,
-  side: MarketPositionSide,
-): MarketPosition | undefined =>
-  positions.get(`${outcomeId}:${side}`);
+	positions: Map<string, MarketPosition>,
+	outcomeId: string,
+	side: MarketPositionSide,
+): MarketPosition | undefined => positions.get(`${outcomeId}:${side}`);
 
 export const getLossProtectionMap = (
-  protections: MarketLossProtection[],
+	protections: MarketLossProtection[],
 ): Map<string, MarketLossProtection> =>
-  new Map(protections.map((protection) => [`${protection.userId}:${protection.outcomeId}`, protection]));
+	new Map(
+		protections.map((protection) => [
+			`${protection.userId}:${protection.outcomeId}`,
+			protection,
+		]),
+	);
 
 export const getLossProtection = (
-  protections: Map<string, MarketLossProtection>,
-  userId: string,
-  outcomeId: string,
+	protections: Map<string, MarketLossProtection>,
+	userId: string,
+	outcomeId: string,
 ): MarketLossProtection | undefined =>
-  protections.get(`${userId}:${outcomeId}`);
+	protections.get(`${userId}:${outcomeId}`);
 
 export const isMarketOutcomeResolved = (
-  outcome: Pick<MarketOutcome, 'settlementValue'>,
+	outcome: Pick<MarketOutcome, "settlementValue">,
 ): boolean => outcome.settlementValue !== null;
 
+export const isIndependentMarketMode = (market: {
+	contractMode?: MarketContractMode | null;
+}): boolean =>
+	resolveMarketContractMode(market.contractMode) === "independent_binary_set";
+
+export const getMarketResolutionVector = (
+	market: Pick<Market, "winningOutcomeId"> & {
+		contractMode?: MarketContractMode | null;
+		outcomes: Array<Pick<MarketOutcome, "id" | "settlementValue">>;
+	},
+): number[] => {
+	if (isIndependentMarketMode(market)) {
+		return market.outcomes.map((outcome) =>
+			clamp(outcome.settlementValue ?? 0, 0, 1),
+		);
+	}
+
+	return market.outcomes.map((outcome) =>
+		outcome.id === market.winningOutcomeId ? 1 : 0,
+	);
+};
+
 export const getActiveOutcomeIndexes = (
-  outcomes: Array<Pick<MarketOutcome, 'settlementValue'>>,
+	outcomes: Array<Pick<MarketOutcome, "settlementValue">>,
 ): number[] =>
-  outcomes.reduce<number[]>((indexes, outcome, index) => {
-    if (!isMarketOutcomeResolved(outcome)) {
-      indexes.push(index);
-    }
-    return indexes;
-  }, []);
+	outcomes.reduce<number[]>((indexes, outcome, index) => {
+		if (!isMarketOutcomeResolved(outcome)) {
+			indexes.push(index);
+		}
+		return indexes;
+	}, []);
 
 export const getMarketProbabilities = (
-  market: Pick<Market, 'resolvedAt' | 'winningOutcomeId' | 'liquidityParameter'> & {
-    outcomes: Array<Pick<MarketOutcome, 'id' | 'pricingShares' | 'settlementValue'>>;
-  },
+	market: Pick<
+		Market,
+		"resolvedAt" | "winningOutcomeId" | "liquidityParameter"
+	> & {
+		contractMode?: MarketContractMode | null;
+		outcomes: Array<
+			Pick<MarketOutcome, "id" | "pricingShares" | "settlementValue">
+		>;
+	},
 ): number[] => {
-  if (market.outcomes.length === 0) {
-    return [];
-  }
+	if (market.outcomes.length === 0) {
+		return [];
+	}
 
-  if (market.resolvedAt) {
-    return market.outcomes.map((outcome) => (outcome.id === market.winningOutcomeId ? 1 : 0));
-  }
+	if (market.resolvedAt) {
+		return getMarketResolutionVector(market);
+	}
 
-  const activeIndexes = getActiveOutcomeIndexes(market.outcomes);
-  if (activeIndexes.length === 0) {
-    return market.outcomes.map((outcome) => outcome.settlementValue ?? 0);
-  }
+	if (isIndependentMarketMode(market)) {
+		return market.outcomes.map((outcome) =>
+			isMarketOutcomeResolved(outcome)
+				? clamp(outcome.settlementValue ?? 0, 0, 1)
+				: computeBinaryLmsrProbability(
+						outcome.pricingShares,
+						market.liquidityParameter,
+					),
+		);
+	}
 
-  const activeProbabilities = computeLmsrProbabilities(
-    activeIndexes.map((index) => market.outcomes[index]?.pricingShares ?? 0),
-    market.liquidityParameter,
-  );
+	const activeIndexes = getActiveOutcomeIndexes(market.outcomes);
+	if (activeIndexes.length === 0) {
+		return market.outcomes.map((outcome) => outcome.settlementValue ?? 0);
+	}
 
-  return market.outcomes.map((outcome, index) => {
-    if (isMarketOutcomeResolved(outcome)) {
-      return outcome.settlementValue ?? 0;
-    }
+	const activeProbabilities = computeLmsrProbabilities(
+		activeIndexes.map((index) => market.outcomes[index]?.pricingShares ?? 0),
+		market.liquidityParameter,
+	);
 
-    const activeIndex = activeIndexes.indexOf(index);
-    return activeIndex >= 0 ? (activeProbabilities[activeIndex] ?? 0) : 0;
-  });
+	return market.outcomes.map((outcome, index) => {
+		if (isMarketOutcomeResolved(outcome)) {
+			return outcome.settlementValue ?? 0;
+		}
+
+		const activeIndex = activeIndexes.indexOf(index);
+		return activeIndex >= 0 ? (activeProbabilities[activeIndex] ?? 0) : 0;
+	});
 };
 
 export const getTradableOutcomeIndexes = (
-  market: Pick<Market, 'resolvedAt' | 'cancelledAt'> & {
-    outcomes: Array<Pick<MarketOutcome, 'settlementValue'>>;
-  },
+	market: Pick<Market, "resolvedAt" | "cancelledAt"> & {
+		outcomes: Array<Pick<MarketOutcome, "settlementValue">>;
+	},
 ): number[] => {
-  if (market.resolvedAt || market.cancelledAt) {
-    return [];
-  }
+	if (market.resolvedAt || market.cancelledAt) {
+		return [];
+	}
 
-  return getActiveOutcomeIndexes(market.outcomes);
+	return getActiveOutcomeIndexes(market.outcomes);
 };
 
 export const getOutstandingShares = (market: MarketWithRelations): number[] =>
-  market.outcomes.map((outcome) => outcome.outstandingShares);
+	market.outcomes.map((outcome) => outcome.outstandingShares);
 
 export const getPricingShares = (market: MarketWithRelations): number[] =>
-  market.outcomes.map((outcome) => outcome.pricingShares);
+	market.outcomes.map((outcome) => outcome.pricingShares);
 
 export const getMarketForUpdate = async (
-  tx: Prisma.TransactionClient,
-  marketId: string,
+	tx: Prisma.TransactionClient,
+	marketId: string,
 ): Promise<MarketWithRelations | null> =>
-  tx.market.findUnique({
-    where: {
-      id: marketId,
-    },
-    include: marketInclude,
-  });
+	tx.market.findUnique({
+		where: {
+			id: marketId,
+		},
+		include: marketInclude,
+	});
 
-export const assertMarketEditable = (market: MarketWithRelations, actorId: string): void => {
-  if (market.creatorId !== actorId) {
-    throw new Error('Only the market creator can edit this market.');
-  }
+export const assertMarketEditable = (
+	market: MarketWithRelations,
+	actorId: string,
+): void => {
+	if (market.creatorId !== actorId) {
+		throw new Error("Only the market creator can edit this market.");
+	}
 
-  if (market.tradingClosedAt || market.resolvedAt || market.cancelledAt) {
-    throw new Error('Only open markets can be edited.');
-  }
+	if (market.tradingClosedAt || market.resolvedAt || market.cancelledAt) {
+		throw new Error("Only open markets can be edited.");
+	}
 };
 
 export const assertMarketCanAddOutcomes = (
-  market: MarketWithRelations,
-  actorId: string,
+	market: MarketWithRelations,
+	actorId: string,
 ): void => {
-  if (market.creatorId !== actorId) {
-    throw new Error('Only the market creator can add outcomes.');
-  }
+	if (market.creatorId !== actorId) {
+		throw new Error("Only the market creator can add outcomes.");
+	}
 
-  assertMarketOpen(market);
+	assertMarketOpen(market);
 };
 
 export const assertMarketOpen = (market: MarketWithRelations): void => {
-  if (market.cancelledAt) {
-    throw new Error('This market has been cancelled.');
-  }
+	if (market.cancelledAt) {
+		throw new Error("This market has been cancelled.");
+	}
 
-  if (market.resolvedAt) {
-    throw new Error('This market has already been resolved.');
-  }
+	if (market.resolvedAt) {
+		throw new Error("This market has already been resolved.");
+	}
 
-  if (market.tradingClosedAt || market.closeAt.getTime() <= Date.now()) {
-    throw new Error('Trading on this market is closed.');
-  }
+	if (market.tradingClosedAt || market.closeAt.getTime() <= Date.now()) {
+		throw new Error("Trading on this market is closed.");
+	}
 };
 
 export const assertOutcomeTradable = (
-  market: MarketWithRelations,
-  outcome: Pick<MarketOutcome, 'label' | 'settlementValue'>,
+	market: MarketWithRelations,
+	outcome: Pick<MarketOutcome, "label" | "settlementValue">,
 ): void => {
-  assertMarketOpen(market);
+	assertMarketOpen(market);
 
-  if (isMarketOutcomeResolved(outcome)) {
-    throw new Error(`Trading on ${outcome.label} is closed because that outcome has already been resolved.`);
-  }
+	if (isMarketOutcomeResolved(outcome)) {
+		throw new Error(
+			`Trading on ${outcome.label} is closed because that outcome has already been resolved.`,
+		);
+	}
 };
 
 export const getMarketStatus = (
-  market: Pick<Market, 'resolvedAt' | 'cancelledAt' | 'tradingClosedAt'>,
+	market: Pick<Market, "resolvedAt" | "cancelledAt" | "tradingClosedAt">,
 ): MarketStatus => {
-  if (market.cancelledAt) {
-    return 'cancelled';
-  }
+	if (market.cancelledAt) {
+		return "cancelled";
+	}
 
-  if (market.resolvedAt) {
-    return 'resolved';
-  }
+	if (market.resolvedAt) {
+		return "resolved";
+	}
 
-  if (market.tradingClosedAt) {
-    return 'closed';
-  }
+	if (market.tradingClosedAt) {
+		return "closed";
+	}
 
-  return 'open';
+	return "open";
 };
 
-export const computeMarketSummary = (market: MarketWithRelations): {
-  status: MarketStatus;
-  probabilities: Array<{
-    outcomeId: string;
-    label: string;
-    probability: number;
-    shares: number;
-    isResolved: boolean;
-    settlementValue: number | null;
-  }>;
-  totalVolume: number;
+export const computeMarketSummary = (
+	market: MarketWithRelations,
+): {
+	status: MarketStatus;
+	probabilities: Array<{
+		outcomeId: string;
+		label: string;
+		probability: number;
+		shares: number;
+		isResolved: boolean;
+		settlementValue: number | null;
+	}>;
+	totalVolume: number;
 } => {
-  const probabilities = getMarketProbabilities(market);
-  return {
-    status: getMarketStatus(market),
-    probabilities: market.outcomes.map((outcome, index) => {
-      const isResolved = market.resolvedAt ? true : isMarketOutcomeResolved(outcome);
-      const settlementValue = market.resolvedAt
-        ? (outcome.id === market.winningOutcomeId ? 1 : 0)
-        : outcome.settlementValue;
+	const probabilities = getMarketProbabilities(market);
+	const isIndependentMode = isIndependentMarketMode(market);
+	const resolutionVector = market.resolvedAt
+		? getMarketResolutionVector(market)
+		: null;
+	return {
+		status: getMarketStatus(market),
+		probabilities: market.outcomes.map((outcome, index) => {
+			const isResolved = market.resolvedAt
+				? true
+				: isMarketOutcomeResolved(outcome);
+			const settlementValue = market.resolvedAt
+				? (resolutionVector?.[index] ?? 0)
+				: outcome.settlementValue;
 
-      return {
-        outcomeId: outcome.id,
-        label: outcome.label,
-        probability: probabilities[index] ?? 0,
-        shares: outcome.outstandingShares,
-        isResolved,
-        settlementValue,
-      };
-    }),
-    totalVolume: market.totalVolume,
-  };
+			return {
+				outcomeId: outcome.id,
+				label: outcome.label,
+				probability: probabilities[index] ?? 0,
+				shares: outcome.outstandingShares,
+				isResolved,
+				settlementValue,
+			};
+		}),
+		totalVolume: market.totalVolume,
+	};
 };
 
 export const getTradeLockReason = (
-  market: MarketWithRelations,
-  outcomeId: string,
-  action: MarketTradeSide,
+	market: MarketWithRelations,
+	outcomeId: string,
+	action: MarketTradeSide,
 ): string | null => {
-  if (action !== 'buy' && action !== 'short') {
-    return null;
-  }
+	if (action !== "buy" && action !== "short") {
+		return null;
+	}
 
-  const summary = computeMarketSummary(market);
-  const outcome = summary.probabilities.find((entry) => entry.outcomeId === outcomeId);
-  if (!outcome || outcome.isResolved) {
-    return null;
-  }
+	const summary = computeMarketSummary(market);
+	const outcome = summary.probabilities.find(
+		(entry) => entry.outcomeId === outcomeId,
+	);
+	if (!outcome || outcome.isResolved) {
+		return null;
+	}
 
-  if (action === 'buy' && outcome.probability >= maxOpenProbability) {
-    return `Yes on **${outcome.label}** is locked above 98%.`;
-  }
+	if (action === "buy" && outcome.probability >= maxOpenProbability) {
+		return `${isIndependentMarketMode(market) ? "YES" : "Yes"} on **${outcome.label}** is locked above 98%.`;
+	}
 
-  if (action === 'short' && outcome.probability <= minOpenProbability) {
-    return `No on **${outcome.label}** is locked below 2%.`;
-  }
+	if (action === "short" && outcome.probability <= minOpenProbability) {
+		return `${isIndependentMarketMode(market) ? "NO" : "No"} on **${outcome.label}** is locked below 2%.`;
+	}
 
-  return null;
+	return null;
 };
 
 export const calculateProtectionPremium = (
-  incrementalInsuredCostBasis: number,
-  loseProbability: number,
-): number => roundCurrency(incrementalInsuredCostBasis * loseProbability * protectionPremiumMultiplier);
+	incrementalInsuredCostBasis: number,
+	loseProbability: number,
+): number =>
+	roundCurrency(
+		incrementalInsuredCostBasis * loseProbability * protectionPremiumMultiplier,
+	);
 
 export const getPositionCoverageRatio = (
-  costBasis: number,
-  insuredCostBasis: number,
+	costBasis: number,
+	insuredCostBasis: number,
 ): number => {
-  if (costBasis <= 1e-6) {
-    return 0;
-  }
+	if (costBasis <= 1e-6) {
+		return 0;
+	}
 
-  return roundCurrency(clamp(insuredCostBasis / costBasis, 0, 1));
+	return roundCurrency(clamp(insuredCostBasis / costBasis, 0, 1));
 };
 
 export const getPositionUninsuredCostBasis = (
-  costBasis: number,
-  insuredCostBasis: number,
+	costBasis: number,
+	insuredCostBasis: number,
 ): number => roundCurrency(Math.max(0, costBasis - insuredCostBasis));
 
 export const assertCanResolveMarket = (
-  market: MarketWithRelations,
-  actorId: string,
-  permissions?: PermissionsBitField | Readonly<PermissionsBitField> | null,
+	market: MarketWithRelations,
+	actorId: string,
+	permissions?: PermissionsBitField | Readonly<PermissionsBitField> | null,
 ): void => {
-  if (market.cancelledAt) {
-    throw new Error('Cancelled markets cannot be resolved.');
-  }
+	if (market.cancelledAt) {
+		throw new Error("Cancelled markets cannot be resolved.");
+	}
 
-  if (market.resolvedAt) {
-    throw new Error('This market is already resolved.');
-  }
+	if (market.resolvedAt) {
+		throw new Error("This market is already resolved.");
+	}
 
-  if (actorId === market.creatorId || canModerateMarkets(permissions)) {
-    return;
-  }
+	if (actorId === market.creatorId || canModerateMarkets(permissions)) {
+		return;
+	}
 
-  throw new Error('Only the creator or a moderator can resolve this market.');
+	throw new Error("Only the creator or a moderator can resolve this market.");
 };
 
 export const assertCanResolveOutcome = (
-  market: MarketWithRelations,
-  actorId: string,
-  permissions?: PermissionsBitField | Readonly<PermissionsBitField> | null,
+	market: MarketWithRelations,
+	actorId: string,
+	permissions?: PermissionsBitField | Readonly<PermissionsBitField> | null,
 ): void => {
-  if (market.cancelledAt) {
-    throw new Error('Cancelled markets cannot resolve outcomes.');
-  }
+	if (market.cancelledAt) {
+		throw new Error("Cancelled markets cannot resolve outcomes.");
+	}
 
-  if (market.resolvedAt) {
-    throw new Error('Resolved markets cannot resolve additional outcomes.');
-  }
+	if (market.resolvedAt) {
+		throw new Error("Resolved markets cannot resolve additional outcomes.");
+	}
 
-  if (actorId === market.creatorId || canModerateMarkets(permissions)) {
-    return;
-  }
+	if (actorId === market.creatorId || canModerateMarkets(permissions)) {
+		return;
+	}
 
-  throw new Error('Only the creator or a moderator can resolve individual outcomes.');
+	throw new Error(
+		"Only the creator or a moderator can resolve individual outcomes.",
+	);
 };
 
 export const assertCanCancelMarket = (
-  market: MarketWithRelations,
-  actorId: string,
-  permissions?: PermissionsBitField | Readonly<PermissionsBitField> | null,
+	market: MarketWithRelations,
+	actorId: string,
+	permissions?: PermissionsBitField | Readonly<PermissionsBitField> | null,
 ): void => {
-  if (market.cancelledAt) {
-    throw new Error('This market is already cancelled.');
-  }
+	if (market.cancelledAt) {
+		throw new Error("This market is already cancelled.");
+	}
 
-  if (market.resolvedAt) {
-    throw new Error('Resolved markets cannot be cancelled.');
-  }
+	if (market.resolvedAt) {
+		throw new Error("Resolved markets cannot be cancelled.");
+	}
 
-  if (market.outcomes.some((outcome) => isMarketOutcomeResolved(outcome))) {
-    throw new Error('Markets with resolved outcomes cannot be cancelled.');
-  }
+	if (market.outcomes.some((outcome) => isMarketOutcomeResolved(outcome))) {
+		throw new Error("Markets with resolved outcomes cannot be cancelled.");
+	}
 
-  if (actorId === market.creatorId) {
-    return;
-  }
+	if (actorId === market.creatorId) {
+		return;
+	}
 
-  const graceEnded = market.resolutionGraceEndsAt?.getTime()
-    ? market.resolutionGraceEndsAt.getTime() <= Date.now()
-    : false;
-  if (graceEnded && canModerateMarkets(permissions)) {
-    return;
-  }
+	const graceEnded = market.resolutionGraceEndsAt?.getTime()
+		? market.resolutionGraceEndsAt.getTime() <= Date.now()
+		: false;
+	if (graceEnded && canModerateMarkets(permissions)) {
+		return;
+	}
 
-  throw new Error('Only the creator can cancel this market until the grace window expires.');
+	throw new Error(
+		"Only the creator can cancel this market until the grace window expires.",
+	);
 };
 
 export const replaceOutcomeState = async (
-  tx: Prisma.TransactionClient,
-  marketId: string,
-  outcomes: Array<Pick<MarketOutcome, 'id'> & { outstandingShares: number; pricingShares: number }>,
+	tx: Prisma.TransactionClient,
+	marketId: string,
+	outcomes: Array<
+		Pick<MarketOutcome, "id"> & {
+			outstandingShares: number;
+			pricingShares: number;
+		}
+	>,
 ): Promise<void> => {
-  await Promise.all(outcomes.map((outcome) =>
-    tx.marketOutcome.update({
-      where: {
-        id: outcome.id,
-      },
-      data: {
-        outstandingShares: roundCurrency(outcome.outstandingShares),
-        pricingShares: roundCurrency(outcome.pricingShares),
-      },
-    })));
+	await Promise.all(
+		outcomes.map((outcome) =>
+			tx.marketOutcome.update({
+				where: {
+					id: outcome.id,
+				},
+				data: {
+					outstandingShares: roundCurrency(outcome.outstandingShares),
+					pricingShares: roundCurrency(outcome.pricingShares),
+				},
+			}),
+		),
+	);
 
-  await tx.market.update({
-    where: {
-      id: marketId,
-    },
-    data: {
-      updatedAt: new Date(),
-    },
-  });
+	await tx.market.update({
+		where: {
+			id: marketId,
+		},
+		data: {
+			updatedAt: new Date(),
+		},
+	});
 };
 
 export const upsertPosition = async (
-  tx: Prisma.TransactionClient,
-  input: {
-    marketId: string;
-    outcomeId: string;
-    userId: string;
-    side: MarketPositionSide;
-    shares: number;
-    costBasis: number;
-    proceeds: number;
-    collateralLocked: number;
-  },
+	tx: Prisma.TransactionClient,
+	input: {
+		marketId: string;
+		outcomeId: string;
+		userId: string;
+		side: MarketPositionSide;
+		shares: number;
+		costBasis: number;
+		proceeds: number;
+		collateralLocked: number;
+	},
 ): Promise<void> => {
-  if (input.shares <= 1e-6
-    && input.costBasis <= 1e-6
-    && input.proceeds <= 1e-6
-    && input.collateralLocked <= 1e-6) {
-    await tx.marketPosition.deleteMany({
-      where: {
-        marketId: input.marketId,
-        outcomeId: input.outcomeId,
-        userId: input.userId,
-        side: input.side,
-      },
-    });
-    return;
-  }
+	if (
+		input.shares <= 1e-6 &&
+		input.costBasis <= 1e-6 &&
+		input.proceeds <= 1e-6 &&
+		input.collateralLocked <= 1e-6
+	) {
+		await tx.marketPosition.deleteMany({
+			where: {
+				marketId: input.marketId,
+				outcomeId: input.outcomeId,
+				userId: input.userId,
+				side: input.side,
+			},
+		});
+		return;
+	}
 
-  await tx.marketPosition.upsert({
-    where: {
-      marketId_outcomeId_userId_side: {
-        marketId: input.marketId,
-        outcomeId: input.outcomeId,
-        userId: input.userId,
-        side: input.side,
-      },
-    },
-    create: {
-      marketId: input.marketId,
-      outcomeId: input.outcomeId,
-      userId: input.userId,
-      side: input.side,
-      shares: roundCurrency(input.shares),
-      costBasis: roundCurrency(input.costBasis),
-      proceeds: roundCurrency(input.proceeds),
-      collateralLocked: roundCurrency(input.collateralLocked),
-    },
-    update: {
-      shares: roundCurrency(input.shares),
-      costBasis: roundCurrency(input.costBasis),
-      proceeds: roundCurrency(input.proceeds),
-      collateralLocked: roundCurrency(input.collateralLocked),
-    },
-  });
+	await tx.marketPosition.upsert({
+		where: {
+			marketId_outcomeId_userId_side: {
+				marketId: input.marketId,
+				outcomeId: input.outcomeId,
+				userId: input.userId,
+				side: input.side,
+			},
+		},
+		create: {
+			marketId: input.marketId,
+			outcomeId: input.outcomeId,
+			userId: input.userId,
+			side: input.side,
+			shares: roundCurrency(input.shares),
+			costBasis: roundCurrency(input.costBasis),
+			proceeds: roundCurrency(input.proceeds),
+			collateralLocked: roundCurrency(input.collateralLocked),
+		},
+		update: {
+			shares: roundCurrency(input.shares),
+			costBasis: roundCurrency(input.costBasis),
+			proceeds: roundCurrency(input.proceeds),
+			collateralLocked: roundCurrency(input.collateralLocked),
+		},
+	});
 };
 
 export const getMaxSellPayout = (
-  market: MarketWithRelations,
-  outcomeId: string,
-  ownedShares: number,
+	market: MarketWithRelations,
+	outcomeId: string,
+	ownedShares: number,
 ): number => {
-  const index = market.outcomes.findIndex((outcome) => outcome.id === outcomeId);
-  if (index < 0) {
-    return 0;
-  }
+	const index = market.outcomes.findIndex(
+		(outcome) => outcome.id === outcomeId,
+	);
+	if (index < 0) {
+		return 0;
+	}
 
-  const tradableIndexes = getTradableOutcomeIndexes(market);
-  const tradableIndex = tradableIndexes.indexOf(index);
-  if (tradableIndex < 0) {
-    return 0;
-  }
+	if (isIndependentMarketMode(market)) {
+		return roundCurrency(
+			computeBinarySellPayout(
+				market.outcomes[index]?.pricingShares ?? 0,
+				ownedShares,
+				market.liquidityParameter,
+			),
+		);
+	}
 
-  return roundCurrency(computeSellPayout(
-    tradableIndexes.map((outcomeIndex) => market.outcomes[outcomeIndex]?.pricingShares ?? 0),
-    tradableIndex,
-    ownedShares,
-    market.liquidityParameter,
-  ));
+	const tradableIndexes = getTradableOutcomeIndexes(market);
+	const tradableIndex = tradableIndexes.indexOf(index);
+	if (tradableIndex < 0) {
+		return 0;
+	}
+
+	return roundCurrency(
+		computeSellPayout(
+			tradableIndexes.map(
+				(outcomeIndex) => market.outcomes[outcomeIndex]?.pricingShares ?? 0,
+			),
+			tradableIndex,
+			ownedShares,
+			market.liquidityParameter,
+		),
+	);
 };
 
 export const getLiquidityTargetForEpoch = (
-  market: Pick<Market, 'baseLiquidityParameter' | 'maxLiquidityParameter' | 'createdAt'>,
-  now = new Date(),
+	market: Pick<
+		Market,
+		"baseLiquidityParameter" | "maxLiquidityParameter" | "createdAt"
+	>,
+	now = new Date(),
 ): number => {
-  const elapsedMs = Math.max(0, now.getTime() - market.createdAt.getTime());
-  const epoch = Math.floor(elapsedMs / liquidityInjectionIntervalMs);
-  const target = market.baseLiquidityParameter * (liquidityGrowthFactor ** epoch);
-  return Math.min(market.maxLiquidityParameter, Math.round(target));
+	const elapsedMs = Math.max(0, now.getTime() - market.createdAt.getTime());
+	const epoch = Math.floor(elapsedMs / liquidityInjectionIntervalMs);
+	const target = market.baseLiquidityParameter * liquidityGrowthFactor ** epoch;
+	return Math.min(market.maxLiquidityParameter, Math.round(target));
 };
 
 export const getNextLiquidityInjectionAt = (
-  market: Pick<Market, 'createdAt' | 'closeAt'>,
-  now = new Date(),
+	market: Pick<Market, "createdAt" | "closeAt">,
+	now = new Date(),
 ): Date | null => {
-  const elapsedMs = Math.max(0, now.getTime() - market.createdAt.getTime());
-  const nextEpoch = Math.floor(elapsedMs / liquidityInjectionIntervalMs) + 1;
-  const nextAt = new Date(market.createdAt.getTime() + (nextEpoch * liquidityInjectionIntervalMs));
-  return nextAt.getTime() < market.closeAt.getTime() ? nextAt : null;
+	const elapsedMs = Math.max(0, now.getTime() - market.createdAt.getTime());
+	const nextEpoch = Math.floor(elapsedMs / liquidityInjectionIntervalMs) + 1;
+	const nextAt = new Date(
+		market.createdAt.getTime() + nextEpoch * liquidityInjectionIntervalMs,
+	);
+	return nextAt.getTime() < market.closeAt.getTime() ? nextAt : null;
 };
 
 export const computeLiquidityRebaseBonus = (
-  previousLiquidity: number,
-  nextLiquidity: number,
-  activeOutcomeCount: number,
+	previousLiquidity: number,
+	nextLiquidity: number,
+	activeOutcomeCount: number,
 ): number => {
-  if (nextLiquidity <= previousLiquidity || activeOutcomeCount <= 1) {
-    return 0;
-  }
+	if (nextLiquidity <= previousLiquidity || activeOutcomeCount <= 1) {
+		return 0;
+	}
 
-  return roundCurrency(0.5 * (nextLiquidity - previousLiquidity) * Math.log(activeOutcomeCount));
+	return roundCurrency(
+		0.5 * (nextLiquidity - previousLiquidity) * Math.log(activeOutcomeCount),
+	);
 };
 
 export const computeSupplementaryBonusDistribution = (
-  profits: Map<string, number>,
-  totalBonusPool: number,
+	profits: Map<string, number>,
+	totalBonusPool: number,
 ): Map<string, number> => {
-  if (totalBonusPool <= 1e-6) {
-    return new Map();
-  }
+	if (totalBonusPool <= 1e-6) {
+		return new Map();
+	}
 
-  const profitableEntries = [...profits.entries()].filter(([, profit]) => profit > 1e-6);
-  const totalProfits = profitableEntries.reduce((sum, [, profit]) => sum + profit, 0);
-  if (totalProfits <= 1e-6) {
-    return new Map();
-  }
+	const profitableEntries = [...profits.entries()].filter(
+		([, profit]) => profit > 1e-6,
+	);
+	const totalProfits = profitableEntries.reduce(
+		(sum, [, profit]) => sum + profit,
+		0,
+	);
+	if (totalProfits <= 1e-6) {
+		return new Map();
+	}
 
-  const bonuses = new Map<string, number>();
-  let distributed = 0;
-  profitableEntries.forEach(([userId, profit], index) => {
-    const bonus = index === profitableEntries.length - 1
-      ? roundCurrency(totalBonusPool - distributed)
-      : roundCurrency((totalBonusPool * profit) / totalProfits);
-    distributed += bonus;
-    bonuses.set(userId, bonus);
-  });
+	const bonuses = new Map<string, number>();
+	let distributed = 0;
+	profitableEntries.forEach(([userId, profit], index) => {
+		const bonus =
+			index === profitableEntries.length - 1
+				? roundCurrency(totalBonusPool - distributed)
+				: roundCurrency((totalBonusPool * profit) / totalProfits);
+		distributed += bonus;
+		bonuses.set(userId, bonus);
+	});
 
-  return bonuses;
+	return bonuses;
 };
 
 export const getResolutionGraceMs = (): number => resolutionGraceMs;

--- a/src/features/markets/core/shared.ts
+++ b/src/features/markets/core/shared.ts
@@ -336,7 +336,6 @@ export const computeMarketSummary = (
 	totalVolume: number;
 } => {
 	const probabilities = getMarketProbabilities(market);
-	const isIndependentMode = isIndependentMarketMode(market);
 	const resolutionVector = market.resolvedAt
 		? getMarketResolutionVector(market)
 		: null;

--- a/src/features/markets/core/types.ts
+++ b/src/features/markets/core/types.ts
@@ -2,6 +2,7 @@ import type {
 	Market,
 	MarketAccount,
 	MarketButtonStyle,
+	MarketContractMode,
 	MarketForecastRecord,
 	MarketLossProtection,
 	MarketLiquidityEvent,
@@ -11,7 +12,8 @@ import type {
 	MarketTrade,
 } from "@prisma/client";
 
-export type MarketWithRelations = Market & {
+export type MarketWithRelations = Omit<Market, "contractMode"> & {
+	contractMode?: MarketContractMode;
 	outcomes: MarketOutcome[];
 	trades: MarketTrade[];
 	positions: MarketPosition[];
@@ -21,7 +23,7 @@ export type MarketWithRelations = Market & {
 };
 
 export type MarketPositionWithProtection = MarketPosition & {
-	market: Market;
+	market: Omit<Market, "contractMode"> & { contractMode?: MarketContractMode };
 	outcome: MarketOutcome;
 	insuredCostBasis?: number;
 	premiumPaid?: number;
@@ -44,6 +46,7 @@ export type MarketCreationInput = {
 	title: string;
 	description: string | null;
 	buttonStyle: MarketButtonStyle;
+	contractMode?: MarketContractMode;
 	outcomes: string[];
 	tags: string[];
 	closeAt: Date;
@@ -66,6 +69,7 @@ export type MarketTradeQuoteAction = "buy" | "sell" | "short" | "cover";
 
 export type MarketTradeQuote = {
 	action: MarketTradeQuoteAction;
+	contractMode?: MarketContractMode;
 	marketId: string;
 	marketTitle: string;
 	outcomeId: string;
@@ -105,6 +109,7 @@ export type MarketTradeQuoteSession = {
 	kind: "trade";
 	sessionId: string;
 	action: MarketTradeQuoteAction;
+	contractMode?: MarketContractMode;
 	guildId: string;
 	marketId: string;
 	marketTitle: string;
@@ -242,6 +247,7 @@ export type MarketForecastProfileRecentRecord = {
 	realizedProfit: number;
 	wasCorrect: boolean;
 	predictedOutcomeId: string;
+	resolutionVector?: number[];
 	winningOutcomeId: string;
 	winningOutcomeProbability: number;
 	tradeCount: number;

--- a/src/features/markets/core/types.ts
+++ b/src/features/markets/core/types.ts
@@ -314,6 +314,13 @@ export type MarketResolutionResult = {
 	}>;
 };
 
+export type MarketCancellationRefund = {
+	userId: string;
+	refundAmount: number;
+	positionCount: number;
+	protectionRefund: number;
+};
+
 export type MarketOutcomeResolutionResult = {
 	market: MarketWithRelations;
 	outcome: MarketOutcome;

--- a/src/features/markets/handlers/interactions/buttons.ts
+++ b/src/features/markets/handlers/interactions/buttons.ts
@@ -39,6 +39,7 @@ import {
 	buildTradeExecutionDescription,
 	parseMarketSessionActionCustomId,
 	parseMarketSessionCoverageCustomId,
+	parseMarketSessionQuickSellCustomId,
 	parseMarketSessionId,
 	parseMarketSessionQuickAmountCustomId,
 	parseMarketSessionSideCustomId,
@@ -254,6 +255,31 @@ export const handleMarketButton = async (
 		const nextSession = await refreshRootMarketInteractionSessionPreview({
 			...session,
 			amountInput: `${sessionQuickAmount.amount}`,
+			targetCoverage: null,
+		});
+		await interaction.update(
+			await buildRootMarketInteractionSessionResponse(nextSession),
+		);
+		return;
+	}
+
+	const sessionQuickSell = parseMarketSessionQuickSellCustomId(
+		interaction.customId,
+	);
+	if (sessionQuickSell) {
+		const session = await getRootMarketInteractionSession(
+			sessionQuickSell.sessionId,
+			interaction.user.id,
+		).catch(() => null);
+		if (!session) {
+			await interaction.update(buildExpiredMarketInteractionResponse());
+			return;
+		}
+
+		const nextSession = await refreshRootMarketInteractionSessionPreview({
+			...session,
+			amountInput:
+				sessionQuickSell.value === "all" ? "all" : `${sessionQuickSell.value}%`,
 			targetCoverage: null,
 		});
 		await interaction.update(

--- a/src/features/markets/handlers/interactions/commands.ts
+++ b/src/features/markets/handlers/interactions/commands.ts
@@ -1,6 +1,7 @@
 import type { InteractionReplyOptions } from "discord.js";
 import {
 	MessageFlags,
+	PermissionFlagsBits,
 	type ChatInputCommandInteraction,
 	type Client,
 } from "discord.js";
@@ -22,6 +23,7 @@ import {
 	buildMarketViewResponse,
 	clearMarketLifecycle,
 	hydrateMarketMessage,
+	notifyMarketCancelled,
 	notifyMarketResolved,
 	refreshMarketMessage,
 } from "../../services/lifecycle.js";
@@ -46,10 +48,12 @@ import {
 import {
 	clearMarketJobs,
 	scheduleMarketClose,
+	scheduleMarketGrace,
 	scheduleMarketLiquidity,
 	scheduleMarketRefresh,
 } from "../../services/scheduler.js";
 import { cancelMarket } from "../../services/trading/cancel.js";
+import { closeMarketTrading } from "../../services/trading/close.js";
 import { executeMarketTrade } from "../../services/trading/execution.js";
 import {
 	resolveMarket,
@@ -117,6 +121,26 @@ const describeMarketEditChanges = (
 	}
 
 	return changes;
+};
+
+const resolvePositionSharesForAction = (input: {
+	market: MarketWithRelations;
+	userId: string;
+	outcomeId: string;
+	action: TradeAction;
+}): number | undefined => {
+	if (input.action !== "sell" && input.action !== "cover") {
+		return undefined;
+	}
+
+	const side = input.action === "sell" ? "long" : "short";
+	const position = input.market.positions.find(
+		(entry) =>
+			entry.userId === input.userId &&
+			entry.outcomeId === input.outcomeId &&
+			entry.side === side,
+	);
+	return position?.shares;
 };
 
 export const handleMarketCommand = async (
@@ -400,7 +424,17 @@ export const handleMarketCommand = async (
 				return;
 			}
 
-			const parsedAmount = parseTradeInputAmount(action, rawAmount);
+			const positionShares = resolvePositionSharesForAction({
+				market,
+				userId: interaction.user.id,
+				outcomeId: outcome.id,
+				action,
+			});
+			const parsedAmount = parseTradeInputAmount(
+				action,
+				rawAmount,
+				positionShares === undefined ? undefined : { positionShares },
+			);
 			const result = await executeMarketTrade({
 				marketId: market.id,
 				userId: interaction.user.id,
@@ -508,6 +542,57 @@ export const handleMarketCommand = async (
 			});
 			return;
 		}
+		case "pause-trading": {
+			await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+			const market = await getMarketByQuery(
+				interaction.options.getString("query", true),
+				interaction.guildId,
+			);
+			if (!market) {
+				throw new Error("Market not found.");
+			}
+
+			if (
+				market.creatorId !== interaction.user.id &&
+				!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)
+			) {
+				throw new Error(
+					"Only the market creator or a moderator can pause trading.",
+				);
+			}
+
+			const { market: closed, didClose } = await closeMarketTrading(market.id);
+			if (!closed) {
+				throw new Error("Market not found.");
+			}
+
+			await clearMarketJobs(closed.id);
+			await scheduleMarketGrace(closed);
+			await refreshMarketMessage(client, closed.id);
+			if (didClose) {
+				await announceMarketUpdate(
+					client,
+					closed,
+					"Trading Paused",
+					`Trading on **${closed.title}** was paused by <@${interaction.user.id}>.`,
+					0xf59e0b,
+				);
+			}
+
+			await interaction.editReply({
+				embeds: [
+					buildMarketStatusEmbed(
+						didClose ? "Trading Paused" : "Trading Already Closed",
+						didClose
+							? `Paused trading on **${closed.title}**.`
+							: `Trading is already closed on **${closed.title}**.`,
+						didClose ? 0xf59e0b : 0x60a5fa,
+					),
+				],
+			});
+			return;
+		}
+
 		case "cancel": {
 			await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 			const market = await getMarketByQuery(
@@ -524,14 +609,15 @@ export const handleMarketCommand = async (
 				reason: interaction.options.getString("reason"),
 				permissions: interaction.memberPermissions,
 			});
-			await clearMarketLifecycle(cancelled.id);
-			await refreshMarketMessage(client, cancelled.id);
+			await clearMarketLifecycle(cancelled.market.id);
+			await refreshMarketMessage(client, cancelled.market.id);
+			await notifyMarketCancelled(client, cancelled.market, cancelled.refunds);
 			await announceMarketUpdate(
 				client,
-				cancelled,
+				cancelled.market,
 				"Market Cancelled",
 				[
-					`**${cancelled.title}** was cancelled by <@${interaction.user.id}>.`,
+					`**${cancelled.market.title}** was cancelled by <@${interaction.user.id}>.`,
 					interaction.options.getString("reason")
 						? `Reason: ${interaction.options.getString("reason", true)}`
 						: null,
@@ -544,7 +630,7 @@ export const handleMarketCommand = async (
 				embeds: [
 					buildMarketStatusEmbed(
 						"Market Cancelled",
-						`Cancelled **${cancelled.title}** and refunded open positions.`,
+						`Cancelled **${cancelled.market.title}** and refunded open positions.`,
 						0xf59e0b,
 					),
 				],

--- a/src/features/markets/handlers/interactions/commands.ts
+++ b/src/features/markets/handlers/interactions/commands.ts
@@ -1,582 +1,745 @@
-import type { InteractionReplyOptions } from 'discord.js';
-import { MessageFlags, type ChatInputCommandInteraction, type Client } from 'discord.js';
+import type { InteractionReplyOptions } from "discord.js";
+import {
+	MessageFlags,
+	type ChatInputCommandInteraction,
+	type Client,
+} from "discord.js";
 
-import { logger } from '../../../../app/logger.js';
+import { logger } from "../../../../app/logger.js";
 import {
-  buildLeaderboardEmbed,
-  buildMarketForecastLeaderboardEmbed,
-  buildMarketForecastProfileEmbeds,
-  buildMarketListEmbed,
-  buildMarketTradersEmbeds,
-} from '../../ui/render/analytics.js';
-import { buildMarketForecastProfileDiagram } from '../../ui/profile-visualize.js';
-import { buildMarketStatusEmbed } from '../../ui/render/market.js';
-import { buildPortfolioMessage } from '../../ui/render/portfolio.js';
-import { getMarketConfig } from '../../services/config.js';
+	buildLeaderboardEmbed,
+	buildMarketForecastLeaderboardEmbed,
+	buildMarketForecastProfileEmbeds,
+	buildMarketListEmbed,
+	buildMarketTradersEmbeds,
+} from "../../ui/render/analytics.js";
+import { buildMarketForecastProfileDiagram } from "../../ui/profile-visualize.js";
+import { buildMarketStatusEmbed } from "../../ui/render/market.js";
+import { buildPortfolioMessage } from "../../ui/render/portfolio.js";
+import { getMarketConfig } from "../../services/config.js";
 import {
-  announceMarketUpdate,
-  buildMarketViewResponse,
-  clearMarketLifecycle,
-  hydrateMarketMessage,
-  notifyMarketResolved,
-  refreshMarketMessage,
-} from '../../services/lifecycle.js';
+	announceMarketUpdate,
+	buildMarketViewResponse,
+	clearMarketLifecycle,
+	hydrateMarketMessage,
+	notifyMarketResolved,
+	refreshMarketMessage,
+} from "../../services/lifecycle.js";
 import {
-  getMarketAccountSummary,
-  getMarketLeaderboard,
-  grantMarketBankroll,
-} from '../../services/account.js';
+	getMarketAccountSummary,
+	getMarketLeaderboard,
+	grantMarketBankroll,
+} from "../../services/account.js";
 import {
-  getMarketForecastLeaderboard,
-  getMarketForecastProfileDetails,
-} from '../../services/forecast/queries.js';
+	getMarketForecastLeaderboard,
+	getMarketForecastProfileDetails,
+} from "../../services/forecast/queries.js";
 import {
-  appendMarketOutcomes,
-  createMarketRecord,
-  deleteMarketRecord,
-  editMarketRecord,
-  getMarketByQuery,
-  listMarkets,
-  summarizeMarketTraders,
-} from '../../services/records.js';
+	appendMarketOutcomes,
+	createMarketRecord,
+	deleteMarketRecord,
+	editMarketRecord,
+	getMarketByQuery,
+	listMarkets,
+	summarizeMarketTraders,
+} from "../../services/records.js";
 import {
-  clearMarketJobs,
-  scheduleMarketClose,
-  scheduleMarketLiquidity,
-  scheduleMarketRefresh,
-} from '../../services/scheduler.js';
-import { cancelMarket } from '../../services/trading/cancel.js';
-import { executeMarketTrade } from '../../services/trading/execution.js';
+	clearMarketJobs,
+	scheduleMarketClose,
+	scheduleMarketLiquidity,
+	scheduleMarketRefresh,
+} from "../../services/scheduler.js";
+import { cancelMarket } from "../../services/trading/cancel.js";
+import { executeMarketTrade } from "../../services/trading/execution.js";
 import {
-  resolveMarket,
-  resolveMarketOutcome,
-} from '../../services/trading/resolution.js';
+	resolveMarket,
+	resolveMarketOutcome,
+} from "../../services/trading/resolution.js";
 import {
-  parseAdditionalMarketOutcomes,
-  parseMarketOutcomes,
-  parseMarketTags,
-  parseOutcomeSelection,
-  sanitizeMarketDescription,
-  sanitizeMarketTitle,
-} from '../../parsing/market.js';
-import { parseMarketCloseAt } from '../../parsing/close.js';
-import { createTradeQuotePreview } from './quotes.js';
+	parseAdditionalMarketOutcomes,
+	parseMarketOutcomes,
+	parseMarketTags,
+	parseOutcomeSelection,
+	sanitizeMarketDescription,
+	sanitizeMarketTitle,
+} from "../../parsing/market.js";
+import { parseMarketCloseAt } from "../../parsing/close.js";
+import { createTradeQuotePreview } from "./quotes.js";
 import {
-  assertCanGrantMarketFunds,
-  buildTradeExecutionDescription,
-  getTradeFeedback,
-  parseTradeInputAmount,
-  type TradeAction,
-  validateEvidenceUrl,
-} from './shared.js';
-import { handleMarketConfigCommand } from './config.js';
-import type { MarketWithRelations } from '../../core/types.js';
+	assertCanGrantMarketFunds,
+	buildTradeExecutionDescription,
+	getTradeFeedback,
+	parseTradeInputAmount,
+	type TradeAction,
+	validateEvidenceUrl,
+} from "./shared.js";
+import { handleMarketConfigCommand } from "./config.js";
+import type { MarketWithRelations } from "../../core/types.js";
 
-const describeMarketEditChanges = (previous: MarketWithRelations, updated: MarketWithRelations): string[] => {
-  const changes: string[] = [];
-  if (previous.title !== updated.title) {
-    changes.push(`Title: **${previous.title}** -> **${updated.title}**`);
-  }
+const describeMarketEditChanges = (
+	previous: MarketWithRelations,
+	updated: MarketWithRelations,
+): string[] => {
+	const changes: string[] = [];
+	if (previous.title !== updated.title) {
+		changes.push(`Title: **${previous.title}** -> **${updated.title}**`);
+	}
 
-  if ((previous.description ?? '') !== (updated.description ?? '')) {
-    changes.push(`Description: ${updated.description ? 'updated' : 'cleared'}`);
-  }
+	if ((previous.description ?? "") !== (updated.description ?? "")) {
+		changes.push(`Description: ${updated.description ? "updated" : "cleared"}`);
+	}
 
-  if (previous.closeAt.getTime() !== updated.closeAt.getTime()) {
-    changes.push(`Close time: <t:${Math.floor(updated.closeAt.getTime() / 1000)}:F>`);
-  }
+	if (previous.closeAt.getTime() !== updated.closeAt.getTime()) {
+		changes.push(
+			`Close time: <t:${Math.floor(updated.closeAt.getTime() / 1000)}:F>`,
+		);
+	}
 
-  if (previous.buttonStyle !== updated.buttonStyle) {
-    changes.push(`Button style: **${previous.buttonStyle}** -> **${updated.buttonStyle}**`);
-  }
+	if (previous.buttonStyle !== updated.buttonStyle) {
+		changes.push(
+			`Button style: **${previous.buttonStyle}** -> **${updated.buttonStyle}**`,
+		);
+	}
 
-  if (previous.tags.join(',') !== updated.tags.join(',')) {
-    changes.push(`Tags: ${updated.tags.length > 0 ? updated.tags.map((tag) => `\`${tag}\``).join(' ') : 'none'}`);
-  }
+	if (previous.tags.join(",") !== updated.tags.join(",")) {
+		changes.push(
+			`Tags: ${updated.tags.length > 0 ? updated.tags.map((tag) => `\`${tag}\``).join(" ") : "none"}`,
+		);
+	}
 
-  if (previous.outcomes.map((outcome) => outcome.label).join('|') !== updated.outcomes.map((outcome) => outcome.label).join('|')) {
-    changes.push(`Outcomes: ${updated.outcomes.map((outcome) => `**${outcome.label}**`).join(', ')}`);
-  }
+	if (
+		previous.outcomes.map((outcome) => outcome.label).join("|") !==
+		updated.outcomes.map((outcome) => outcome.label).join("|")
+	) {
+		changes.push(
+			`Outcomes: ${updated.outcomes.map((outcome) => `**${outcome.label}**`).join(", ")}`,
+		);
+	}
 
-  return changes;
+	return changes;
 };
 
 export const handleMarketCommand = async (
-  client: Client,
-  interaction: ChatInputCommandInteraction,
+	client: Client,
+	interaction: ChatInputCommandInteraction,
 ): Promise<void> => {
-  if (!interaction.inGuild()) {
-    throw new Error('Prediction markets can only be used inside a server.');
-  }
+	if (!interaction.inGuild()) {
+		throw new Error("Prediction markets can only be used inside a server.");
+	}
 
-  const subcommandGroup = interaction.options.getSubcommandGroup(false);
-  const subcommand = interaction.options.getSubcommand();
+	const subcommandGroup = interaction.options.getSubcommandGroup(false);
+	const subcommand = interaction.options.getSubcommand();
 
-  if (subcommandGroup === 'config' && await handleMarketConfigCommand(interaction)) {
-    return;
-  }
+	if (
+		subcommandGroup === "config" &&
+		(await handleMarketConfigCommand(interaction))
+	) {
+		return;
+	}
 
-  switch (subcommand) {
-    case 'create': {
-      await interaction.deferReply();
-      const config = await getMarketConfig(interaction.guildId);
-      if (!config.enabled || !config.channelId) {
-        throw new Error('Prediction markets are not configured yet. Ask a server manager to run /market config set.');
-      }
+	switch (subcommand) {
+		case "create": {
+			await interaction.deferReply();
+			const config = await getMarketConfig(interaction.guildId);
+			if (!config.enabled || !config.channelId) {
+				throw new Error(
+					"Prediction markets are not configured yet. Ask a server manager to run /market config set.",
+				);
+			}
 
-      const market = await createMarketRecord({
-        guildId: interaction.guildId,
-        creatorId: interaction.user.id,
-        originChannelId: interaction.channelId,
-        marketChannelId: config.channelId,
-        title: sanitizeMarketTitle(interaction.options.getString('title', true)),
-        description: sanitizeMarketDescription(interaction.options.getString('description')),
-        buttonStyle: (interaction.options.getString('button_style') as MarketWithRelations['buttonStyle'] | null) ?? 'primary',
-        outcomes: parseMarketOutcomes(interaction.options.getString('outcomes', true)),
-        tags: parseMarketTags(interaction.options.getString('tags')),
-        closeAt: parseMarketCloseAt(interaction.options.getString('close', true)),
-      });
-      let published: Awaited<ReturnType<typeof hydrateMarketMessage>>;
-      try {
-        published = await hydrateMarketMessage(client, market);
-      } catch (error) {
-        await deleteMarketRecord(market.id).catch(() => undefined);
-        throw error;
-      }
-      await interaction.editReply({
-        embeds: [
-          buildMarketStatusEmbed(
-            'Market Created',
-            [
-              `<@${interaction.user.id}> created **${market.title}** in forum <#${market.marketChannelId}>.`,
-              `[Open forum post](${published.url})`,
-              published.threadUrl
-                ? `[Open discussion](${published.threadUrl})`
-                : 'Forum discussion is available on the market post.',
-              `Market ID: \`${market.id}\``,
-            ].join('\n'),
-            0x57f287,
-          ),
-        ],
-        allowedMentions: {
-          parse: [],
-          users: [interaction.user.id],
-        },
-      });
-      return;
-    }
-    case 'edit': {
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-      const market = await getMarketByQuery(interaction.options.getString('query', true), interaction.guildId);
-      if (!market) {
-        throw new Error('Market not found.');
-      }
+			const market = await createMarketRecord({
+				guildId: interaction.guildId,
+				creatorId: interaction.user.id,
+				originChannelId: interaction.channelId,
+				marketChannelId: config.channelId,
+				title: sanitizeMarketTitle(
+					interaction.options.getString("title", true),
+				),
+				description: sanitizeMarketDescription(
+					interaction.options.getString("description"),
+				),
+				buttonStyle:
+					(interaction.options.getString("button_style") as
+						| MarketWithRelations["buttonStyle"]
+						| null) ?? "primary",
+				contractMode:
+					(interaction.options.getString("contract_mode") as
+						| MarketWithRelations["contractMode"]
+						| null) ?? "categorical_single_winner",
+				outcomes: parseMarketOutcomes(
+					interaction.options.getString("outcomes", true),
+				),
+				tags: parseMarketTags(interaction.options.getString("tags")),
+				closeAt: parseMarketCloseAt(
+					interaction.options.getString("close", true),
+				),
+			});
+			let published: Awaited<ReturnType<typeof hydrateMarketMessage>>;
+			try {
+				published = await hydrateMarketMessage(client, market);
+			} catch (error) {
+				await deleteMarketRecord(market.id).catch(() => undefined);
+				throw error;
+			}
+			await interaction.editReply({
+				embeds: [
+					buildMarketStatusEmbed(
+						"Market Created",
+						[
+							`<@${interaction.user.id}> created **${market.title}** in forum <#${market.marketChannelId}>.`,
+							`[Open forum post](${published.url})`,
+							published.threadUrl
+								? `[Open discussion](${published.threadUrl})`
+								: "Forum discussion is available on the market post.",
+							`Market ID: \`${market.id}\``,
+						].join("\n"),
+						0x57f287,
+					),
+				],
+				allowedMentions: {
+					parse: [],
+					users: [interaction.user.id],
+				},
+			});
+			return;
+		}
+		case "edit": {
+			await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+			const market = await getMarketByQuery(
+				interaction.options.getString("query", true),
+				interaction.guildId,
+			);
+			if (!market) {
+				throw new Error("Market not found.");
+			}
 
-      const updated = await editMarketRecord(market.id, interaction.user.id, {
-        ...(interaction.options.getString('title') !== null ? { title: sanitizeMarketTitle(interaction.options.getString('title', true)) } : {}),
-        ...(interaction.options.getString('description') !== null ? { description: sanitizeMarketDescription(interaction.options.getString('description')) } : {}),
-        ...(interaction.options.getString('button_style') !== null ? { buttonStyle: interaction.options.getString('button_style', true) as MarketWithRelations['buttonStyle'] } : {}),
-        ...(interaction.options.getString('tags') !== null ? { tags: parseMarketTags(interaction.options.getString('tags')) } : {}),
-        ...(interaction.options.getString('close') !== null ? { closeAt: parseMarketCloseAt(interaction.options.getString('close', true)) } : {}),
-        ...(interaction.options.getString('outcomes') !== null ? { outcomes: parseMarketOutcomes(interaction.options.getString('outcomes', true)) } : {}),
-      });
-      await clearMarketJobs(updated.id);
-      await Promise.all([
-        scheduleMarketClose(updated),
-        scheduleMarketLiquidity(updated),
-      ]);
-      await refreshMarketMessage(client, updated.id);
-      const changes = describeMarketEditChanges(market, updated);
-      if (changes.length > 0) {
-        await announceMarketUpdate(
-          client,
-          updated,
-          'Market Updated',
-          [
-            `**${updated.title}** was updated by <@${interaction.user.id}>.`,
-            ...changes,
-          ].join('\n'),
-        );
-      }
-      await interaction.editReply({
-        embeds: [buildMarketStatusEmbed('Market Updated', `Updated **${updated.title}**.`)],
-      });
-      return;
-    }
-    case 'view': {
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-      const market = await getMarketByQuery(interaction.options.getString('query', true), interaction.guildId);
-      if (!market) {
-        throw new Error('Market not found.');
-      }
+			const updated = await editMarketRecord(market.id, interaction.user.id, {
+				...(interaction.options.getString("title") !== null
+					? {
+							title: sanitizeMarketTitle(
+								interaction.options.getString("title", true),
+							),
+						}
+					: {}),
+				...(interaction.options.getString("description") !== null
+					? {
+							description: sanitizeMarketDescription(
+								interaction.options.getString("description"),
+							),
+						}
+					: {}),
+				...(interaction.options.getString("button_style") !== null
+					? {
+							buttonStyle: interaction.options.getString(
+								"button_style",
+								true,
+							) as MarketWithRelations["buttonStyle"],
+						}
+					: {}),
+				...(interaction.options.getString("tags") !== null
+					? { tags: parseMarketTags(interaction.options.getString("tags")) }
+					: {}),
+				...(interaction.options.getString("close") !== null
+					? {
+							closeAt: parseMarketCloseAt(
+								interaction.options.getString("close", true),
+							),
+						}
+					: {}),
+				...(interaction.options.getString("outcomes") !== null
+					? {
+							outcomes: parseMarketOutcomes(
+								interaction.options.getString("outcomes", true),
+							),
+						}
+					: {}),
+			});
+			await clearMarketJobs(updated.id);
+			await Promise.all([
+				scheduleMarketClose(updated),
+				scheduleMarketLiquidity(updated),
+			]);
+			await refreshMarketMessage(client, updated.id);
+			const changes = describeMarketEditChanges(market, updated);
+			if (changes.length > 0) {
+				await announceMarketUpdate(
+					client,
+					updated,
+					"Market Updated",
+					[
+						`**${updated.title}** was updated by <@${interaction.user.id}>.`,
+						...changes,
+					].join("\n"),
+				);
+			}
+			await interaction.editReply({
+				embeds: [
+					buildMarketStatusEmbed(
+						"Market Updated",
+						`Updated **${updated.title}**.`,
+					),
+				],
+			});
+			return;
+		}
+		case "view": {
+			await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+			const market = await getMarketByQuery(
+				interaction.options.getString("query", true),
+				interaction.guildId,
+			);
+			if (!market) {
+				throw new Error("Market not found.");
+			}
 
-      await interaction.editReply({
-        ...(await buildMarketViewResponse(market)),
-        allowedMentions: {
-          parse: [],
-        },
-      });
-      return;
-    }
-    case 'add-outcomes': {
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-      const market = await getMarketByQuery(interaction.options.getString('query', true), interaction.guildId);
-      if (!market) {
-        throw new Error('Market not found.');
-      }
+			await interaction.editReply({
+				...(await buildMarketViewResponse(market)),
+				allowedMentions: {
+					parse: [],
+				},
+			});
+			return;
+		}
+		case "add-outcomes": {
+			await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+			const market = await getMarketByQuery(
+				interaction.options.getString("query", true),
+				interaction.guildId,
+			);
+			if (!market) {
+				throw new Error("Market not found.");
+			}
 
-      const updated = await appendMarketOutcomes(
-        market.id,
-        interaction.user.id,
-        parseAdditionalMarketOutcomes(interaction.options.getString('outcomes', true)),
-      );
-      await refreshMarketMessage(client, updated.id);
-      await announceMarketUpdate(
-        client,
-        updated,
-        'Outcomes Added',
-        [
-          `**${updated.title}** has ${updated.outcomes.length - market.outcomes.length} new outcome${updated.outcomes.length - market.outcomes.length === 1 ? '' : 's'}.`,
-          ...updated.outcomes
-            .slice(market.outcomes.length)
-            .map((outcome) => `• ${outcome.label}`),
-        ].join('\n'),
-        0x57f287,
-      );
-      await interaction.editReply({
-        embeds: [
-          buildMarketStatusEmbed(
-            'Outcomes Added',
-            `Added ${updated.outcomes.length - market.outcomes.length} outcome${updated.outcomes.length - market.outcomes.length === 1 ? '' : 's'} to **${updated.title}**.`,
-            0x57f287,
-          ),
-        ],
-      });
-      return;
-    }
-    case 'list': {
-      const status = interaction.options.getString('status') as 'open' | 'closed' | 'resolved' | 'cancelled' | null;
-      const creatorId = interaction.options.getUser('creator')?.id;
-      const tag = interaction.options.getString('tag')?.trim().toLowerCase();
-      const markets = await listMarkets({
-        guildId: interaction.guildId,
-        ...(status ? { status } : {}),
-        ...(creatorId ? { creatorId } : {}),
-        ...(tag ? { tag } : {}),
-      });
-      await interaction.reply({
-        flags: MessageFlags.Ephemeral,
-        embeds: [buildMarketListEmbed('Markets', markets)],
-        allowedMentions: {
-          parse: [],
-        },
-      });
-      return;
-    }
-    case 'trade': {
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-      const market = await getMarketByQuery(interaction.options.getString('query', true), interaction.guildId);
-      if (!market) {
-        throw new Error('Market not found.');
-      }
+			const updated = await appendMarketOutcomes(
+				market.id,
+				interaction.user.id,
+				parseAdditionalMarketOutcomes(
+					interaction.options.getString("outcomes", true),
+				),
+			);
+			await refreshMarketMessage(client, updated.id);
+			await announceMarketUpdate(
+				client,
+				updated,
+				"Outcomes Added",
+				[
+					`**${updated.title}** has ${updated.outcomes.length - market.outcomes.length} new outcome${updated.outcomes.length - market.outcomes.length === 1 ? "" : "s"}.`,
+					...updated.outcomes
+						.slice(market.outcomes.length)
+						.map((outcome) => `• ${outcome.label}`),
+				].join("\n"),
+				0x57f287,
+			);
+			await interaction.editReply({
+				embeds: [
+					buildMarketStatusEmbed(
+						"Outcomes Added",
+						`Added ${updated.outcomes.length - market.outcomes.length} outcome${updated.outcomes.length - market.outcomes.length === 1 ? "" : "s"} to **${updated.title}**.`,
+						0x57f287,
+					),
+				],
+			});
+			return;
+		}
+		case "list": {
+			const status = interaction.options.getString("status") as
+				| "open"
+				| "closed"
+				| "resolved"
+				| "cancelled"
+				| null;
+			const creatorId = interaction.options.getUser("creator")?.id;
+			const tag = interaction.options.getString("tag")?.trim().toLowerCase();
+			const markets = await listMarkets({
+				guildId: interaction.guildId,
+				...(status ? { status } : {}),
+				...(creatorId ? { creatorId } : {}),
+				...(tag ? { tag } : {}),
+			});
+			await interaction.reply({
+				flags: MessageFlags.Ephemeral,
+				embeds: [buildMarketListEmbed("Markets", markets)],
+				allowedMentions: {
+					parse: [],
+				},
+			});
+			return;
+		}
+		case "trade": {
+			await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+			const market = await getMarketByQuery(
+				interaction.options.getString("query", true),
+				interaction.guildId,
+			);
+			if (!market) {
+				throw new Error("Market not found.");
+			}
 
-      const action = interaction.options.getString('action', true) as TradeAction;
-      const rawAmount = interaction.options.getString('amount', true);
-      const outcome = parseOutcomeSelection(interaction.options.getString('outcome', true), market.outcomes);
-      if (action === 'buy' || action === 'short') {
-        await interaction.editReply({
-          ...await createTradeQuotePreview({
-            marketId: market.id,
-            userId: interaction.user.id,
-            outcomeId: outcome.id,
-            action,
-            rawAmount,
-          }),
-          allowedMentions: {
-            parse: [],
-          },
-        });
-        return;
-      }
+			const action = interaction.options.getString(
+				"action",
+				true,
+			) as TradeAction;
+			const rawAmount = interaction.options.getString("amount", true);
+			const outcome = parseOutcomeSelection(
+				interaction.options.getString("outcome", true),
+				market.outcomes,
+			);
+			if (action === "buy" || action === "short") {
+				await interaction.editReply({
+					...(await createTradeQuotePreview({
+						marketId: market.id,
+						userId: interaction.user.id,
+						outcomeId: outcome.id,
+						action,
+						rawAmount,
+					})),
+					allowedMentions: {
+						parse: [],
+					},
+				});
+				return;
+			}
 
-      const parsedAmount = parseTradeInputAmount(action, rawAmount);
-      const result = await executeMarketTrade({
-        marketId: market.id,
-        userId: interaction.user.id,
-        outcomeId: outcome.id,
-        action,
-        amount: parsedAmount.amount,
-        amountMode: parsedAmount.amountMode,
-      });
-      const feedback = getTradeFeedback(action);
-      await scheduleMarketRefresh(market.id);
-      await interaction.editReply({
-        embeds: [
-          buildMarketStatusEmbed(
-            feedback.title,
-            buildTradeExecutionDescription(action, outcome.label, result),
-            feedback.color,
-          ),
-        ],
-      });
-      return;
-    }
-    case 'resolve': {
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-      const market = await getMarketByQuery(interaction.options.getString('query', true), interaction.guildId);
-      if (!market) {
-        throw new Error('Market not found.');
-      }
+			const parsedAmount = parseTradeInputAmount(action, rawAmount);
+			const result = await executeMarketTrade({
+				marketId: market.id,
+				userId: interaction.user.id,
+				outcomeId: outcome.id,
+				action,
+				amount: parsedAmount.amount,
+				amountMode: parsedAmount.amountMode,
+			});
+			const feedback = getTradeFeedback(action);
+			await scheduleMarketRefresh(market.id);
+			await interaction.editReply({
+				embeds: [
+					buildMarketStatusEmbed(
+						feedback.title,
+						buildTradeExecutionDescription(action, outcome.label, result),
+						feedback.color,
+					),
+				],
+			});
+			return;
+		}
+		case "resolve": {
+			await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+			const market = await getMarketByQuery(
+				interaction.options.getString("query", true),
+				interaction.guildId,
+			);
+			if (!market) {
+				throw new Error("Market not found.");
+			}
 
-      const outcome = parseOutcomeSelection(interaction.options.getString('winning_outcome', true), market.outcomes);
-      const resolved = await resolveMarket({
-        marketId: market.id,
-        actorId: interaction.user.id,
-        winningOutcomeId: outcome.id,
-        note: interaction.options.getString('note'),
-        evidenceUrl: validateEvidenceUrl(interaction.options.getString('evidence_url')),
-        permissions: interaction.memberPermissions,
-      });
-      await clearMarketLifecycle(market.id);
-      await refreshMarketMessage(client, market.id);
-      await notifyMarketResolved(client, resolved);
-      await interaction.editReply({
-        embeds: [
-          buildMarketStatusEmbed(
-            'Market Resolved',
-            `Resolved **${resolved.market.title}** in favor of **${outcome.label}**.`,
-            0x57f287,
-          ),
-        ],
-      });
-      return;
-    }
-    case 'resolve-outcome': {
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-      const market = await getMarketByQuery(interaction.options.getString('query', true), interaction.guildId);
-      if (!market) {
-        throw new Error('Market not found.');
-      }
+			const outcome = parseOutcomeSelection(
+				interaction.options.getString("winning_outcome", true),
+				market.outcomes,
+			);
+			const resolved = await resolveMarket({
+				marketId: market.id,
+				actorId: interaction.user.id,
+				winningOutcomeId: outcome.id,
+				note: interaction.options.getString("note"),
+				evidenceUrl: validateEvidenceUrl(
+					interaction.options.getString("evidence_url"),
+				),
+				permissions: interaction.memberPermissions,
+			});
+			await clearMarketLifecycle(market.id);
+			await refreshMarketMessage(client, market.id);
+			await notifyMarketResolved(client, resolved);
+			await interaction.editReply({
+				embeds: [
+					buildMarketStatusEmbed(
+						"Market Resolved",
+						`Resolved **${resolved.market.title}** in favor of **${outcome.label}**.`,
+						0x57f287,
+					),
+				],
+			});
+			return;
+		}
+		case "resolve-outcome": {
+			await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+			const market = await getMarketByQuery(
+				interaction.options.getString("query", true),
+				interaction.guildId,
+			);
+			if (!market) {
+				throw new Error("Market not found.");
+			}
 
-      const outcome = parseOutcomeSelection(interaction.options.getString('outcome', true), market.outcomes);
-      const resolved = await resolveMarketOutcome({
-        marketId: market.id,
-        actorId: interaction.user.id,
-        outcomeId: outcome.id,
-        note: interaction.options.getString('note'),
-        evidenceUrl: validateEvidenceUrl(interaction.options.getString('evidence_url')),
-        permissions: interaction.memberPermissions,
-      });
-      await refreshMarketMessage(client, market.id);
-      await announceMarketUpdate(
-        client,
-        resolved.market,
-        'Outcome Resolved',
-        `**${outcome.label}** was eliminated in **${resolved.market.title}** by <@${interaction.user.id}>. Trading remains open on the remaining outcomes.`,
-        0xf59e0b,
-      );
-      await interaction.editReply({
-        embeds: [
-          buildMarketStatusEmbed(
-            'Outcome Resolved',
-            `Resolved **${outcome.label}** as eliminated in **${resolved.market.title}**. Trading remains open on the remaining outcomes.`,
-            0xf59e0b,
-          ),
-        ],
-      });
-      return;
-    }
-    case 'cancel': {
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-      const market = await getMarketByQuery(interaction.options.getString('query', true), interaction.guildId);
-      if (!market) {
-        throw new Error('Market not found.');
-      }
+			const outcome = parseOutcomeSelection(
+				interaction.options.getString("outcome", true),
+				market.outcomes,
+			);
+			const resolved = await resolveMarketOutcome({
+				marketId: market.id,
+				actorId: interaction.user.id,
+				outcomeId: outcome.id,
+				...(interaction.options.getNumber("value") !== null
+					? { settlementValue: interaction.options.getNumber("value", true) }
+					: {}),
+				note: interaction.options.getString("note"),
+				evidenceUrl: validateEvidenceUrl(
+					interaction.options.getString("evidence_url"),
+				),
+				permissions: interaction.memberPermissions,
+			});
+			await refreshMarketMessage(client, market.id);
+			const settledValue = resolved.outcome.settlementValue ?? 0;
+			const settledPercent = `${(settledValue * 100).toFixed(1)}%`;
+			await announceMarketUpdate(
+				client,
+				resolved.market,
+				"Outcome Resolved",
+				`**${outcome.label}** was resolved to **${settledPercent}** in **${resolved.market.title}** by <@${interaction.user.id}>. Trading remains open on the remaining outcomes.`,
+				0xf59e0b,
+			);
+			await interaction.editReply({
+				embeds: [
+					buildMarketStatusEmbed(
+						"Outcome Resolved",
+						`Resolved **${outcome.label}** to **${settledPercent}** in **${resolved.market.title}**. Trading remains open on the remaining outcomes.`,
+						0xf59e0b,
+					),
+				],
+			});
+			return;
+		}
+		case "cancel": {
+			await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+			const market = await getMarketByQuery(
+				interaction.options.getString("query", true),
+				interaction.guildId,
+			);
+			if (!market) {
+				throw new Error("Market not found.");
+			}
 
-      const cancelled = await cancelMarket({
-        marketId: market.id,
-        actorId: interaction.user.id,
-        reason: interaction.options.getString('reason'),
-        permissions: interaction.memberPermissions,
-      });
-      await clearMarketLifecycle(cancelled.id);
-      await refreshMarketMessage(client, cancelled.id);
-      await announceMarketUpdate(
-        client,
-        cancelled,
-        'Market Cancelled',
-        [
-          `**${cancelled.title}** was cancelled by <@${interaction.user.id}>.`,
-          interaction.options.getString('reason') ? `Reason: ${interaction.options.getString('reason', true)}` : null,
-        ].filter(Boolean).join('\n'),
-        0xf59e0b,
-      );
-      await interaction.editReply({
-        embeds: [
-          buildMarketStatusEmbed(
-            'Market Cancelled',
-            `Cancelled **${cancelled.title}** and refunded open positions.`,
-            0xf59e0b,
-          ),
-        ],
-      });
-      return;
-    }
-    case 'portfolio': {
-      const user = interaction.options.getUser('user') ?? interaction.user;
-      const portfolio = await getMarketAccountSummary(interaction.guildId, user.id);
-      await interaction.reply({
-        flags: MessageFlags.Ephemeral,
-        ...buildPortfolioMessage(user.id, portfolio, user.id === interaction.user.id),
-        allowedMentions: {
-          parse: [],
-        },
-      });
-      return;
-    }
-    case 'traders': {
-      const market = await getMarketByQuery(interaction.options.getString('query', true), interaction.guildId);
-      if (!market) {
-        throw new Error('Market not found.');
-      }
+			const cancelled = await cancelMarket({
+				marketId: market.id,
+				actorId: interaction.user.id,
+				reason: interaction.options.getString("reason"),
+				permissions: interaction.memberPermissions,
+			});
+			await clearMarketLifecycle(cancelled.id);
+			await refreshMarketMessage(client, cancelled.id);
+			await announceMarketUpdate(
+				client,
+				cancelled,
+				"Market Cancelled",
+				[
+					`**${cancelled.title}** was cancelled by <@${interaction.user.id}>.`,
+					interaction.options.getString("reason")
+						? `Reason: ${interaction.options.getString("reason", true)}`
+						: null,
+				]
+					.filter(Boolean)
+					.join("\n"),
+				0xf59e0b,
+			);
+			await interaction.editReply({
+				embeds: [
+					buildMarketStatusEmbed(
+						"Market Cancelled",
+						`Cancelled **${cancelled.title}** and refunded open positions.`,
+						0xf59e0b,
+					),
+				],
+			});
+			return;
+		}
+		case "portfolio": {
+			const user = interaction.options.getUser("user") ?? interaction.user;
+			const portfolio = await getMarketAccountSummary(
+				interaction.guildId,
+				user.id,
+			);
+			await interaction.reply({
+				flags: MessageFlags.Ephemeral,
+				...buildPortfolioMessage(
+					user.id,
+					portfolio,
+					user.id === interaction.user.id,
+				),
+				allowedMentions: {
+					parse: [],
+				},
+			});
+			return;
+		}
+		case "traders": {
+			const market = await getMarketByQuery(
+				interaction.options.getString("query", true),
+				interaction.guildId,
+			);
+			if (!market) {
+				throw new Error("Market not found.");
+			}
 
-      await interaction.reply({
-        flags: MessageFlags.Ephemeral,
-        embeds: buildMarketTradersEmbeds(summarizeMarketTraders(market)),
-        allowedMentions: {
-          parse: [],
-        },
-      });
-      return;
-    }
-    case 'profile': {
-      const user = interaction.options.getUser('user') ?? interaction.user;
-      const profile = await getMarketForecastProfileDetails(interaction.guildId, user.id);
-      const embeds = buildMarketForecastProfileEmbeds(profile);
-      const response: InteractionReplyOptions = {
-        embeds,
-        allowedMentions: {
-          parse: [],
-        },
-      };
+			await interaction.reply({
+				flags: MessageFlags.Ephemeral,
+				embeds: buildMarketTradersEmbeds(summarizeMarketTraders(market)),
+				allowedMentions: {
+					parse: [],
+				},
+			});
+			return;
+		}
+		case "profile": {
+			const user = interaction.options.getUser("user") ?? interaction.user;
+			const profile = await getMarketForecastProfileDetails(
+				interaction.guildId,
+				user.id,
+			);
+			const embeds = buildMarketForecastProfileEmbeds(profile);
+			const response: InteractionReplyOptions = {
+				embeds,
+				allowedMentions: {
+					parse: [],
+				},
+			};
 
-      if (profile.allTimeSampleCount > 0) {
-        try {
-          const chart = await buildMarketForecastProfileDiagram(profile, {
-            displayName: user.displayName ?? user.globalName ?? user.username,
-            avatarUrl: user.displayAvatarURL({
-              extension: 'png',
-              forceStatic: true,
-              size: 256,
-            }),
-          });
-          embeds[0]?.setImage(`attachment://${chart.fileName}`);
-          response.files = [chart.attachment];
-        } catch (error) {
-          logger.warn({ err: error, userId: user.id, guildId: interaction.guildId }, 'Could not build market forecast profile diagram');
-        }
-      }
+			if (profile.allTimeSampleCount > 0) {
+				try {
+					const chart = await buildMarketForecastProfileDiagram(profile, {
+						displayName: user.displayName ?? user.globalName ?? user.username,
+						avatarUrl: user.displayAvatarURL({
+							extension: "png",
+							forceStatic: true,
+							size: 256,
+						}),
+					});
+					embeds[0]?.setImage(`attachment://${chart.fileName}`);
+					response.files = [chart.attachment];
+				} catch (error) {
+					logger.warn(
+						{ err: error, userId: user.id, guildId: interaction.guildId },
+						"Could not build market forecast profile diagram",
+					);
+				}
+			}
 
-      await interaction.reply({
-        ...response,
-      });
-      return;
-    }
-    case 'grant': {
-      assertCanGrantMarketFunds(interaction.user.id);
-      const user = interaction.options.getUser('user', true);
-      const amount = interaction.options.getNumber('amount', true);
-      const reason = interaction.options.getString('reason', true).trim();
-      if (reason.length === 0) {
-        throw new Error('Grant reason must contain at least one non-space character.');
-      }
+			await interaction.reply({
+				...response,
+			});
+			return;
+		}
+		case "grant": {
+			assertCanGrantMarketFunds(interaction.user.id);
+			const user = interaction.options.getUser("user", true);
+			const amount = interaction.options.getNumber("amount", true);
+			const reason = interaction.options.getString("reason", true).trim();
+			if (reason.length === 0) {
+				throw new Error(
+					"Grant reason must contain at least one non-space character.",
+				);
+			}
 
-      const account = await grantMarketBankroll({
-        guildId: interaction.guildId,
-        userId: user.id,
-        amount,
-      });
+			const account = await grantMarketBankroll({
+				guildId: interaction.guildId,
+				userId: user.id,
+				amount,
+			});
 
-      let dmDelivered = true;
-      await user.send({
-        embeds: [
-          buildMarketStatusEmbed(
-            'Market Currency Granted',
-            [
-              `You received **${amount.toFixed(2)} pts** in market currency.`,
-              `Reason: ${reason}`,
-              `New bankroll: **${account.bankroll.toFixed(2)} pts**`,
-            ].join('\n'),
-            0x57f287,
-          ),
-        ],
-        allowedMentions: {
-          parse: [],
-        },
-      }).catch((error) => {
-        dmDelivered = false;
-        logger.warn(
-          { err: error, guildId: interaction.guildId, adminUserId: interaction.user.id, recipientUserId: user.id },
-          'Could not DM market grant recipient',
-        );
-      });
+			let dmDelivered = true;
+			await user
+				.send({
+					embeds: [
+						buildMarketStatusEmbed(
+							"Market Currency Granted",
+							[
+								`You received **${amount.toFixed(2)} pts** in market currency.`,
+								`Reason: ${reason}`,
+								`New bankroll: **${account.bankroll.toFixed(2)} pts**`,
+							].join("\n"),
+							0x57f287,
+						),
+					],
+					allowedMentions: {
+						parse: [],
+					},
+				})
+				.catch((error) => {
+					dmDelivered = false;
+					logger.warn(
+						{
+							err: error,
+							guildId: interaction.guildId,
+							adminUserId: interaction.user.id,
+							recipientUserId: user.id,
+						},
+						"Could not DM market grant recipient",
+					);
+				});
 
-      await interaction.reply({
-        flags: MessageFlags.Ephemeral,
-        embeds: [
-          buildMarketStatusEmbed(
-            'Market Currency Granted',
-            [
-              `Granted **${amount.toFixed(2)} pts** to <@${user.id}>.`,
-              `Reason: ${reason}`,
-              `New bankroll: **${account.bankroll.toFixed(2)} pts**`,
-              dmDelivered ? 'Recipient DM sent.' : 'Recipient DM could not be delivered.',
-            ].join('\n'),
-            0x57f287,
-          ),
-        ],
-        allowedMentions: {
-          parse: [],
-          users: [user.id],
-        },
-      });
-      return;
-    }
-    case 'leaderboard': {
-      const board = interaction.options.getString('board') ?? 'bankroll';
-      if (board === 'forecast') {
-        const window = (interaction.options.getString('window') as 'all_time' | '30d' | null) ?? 'all_time';
-        const tag = interaction.options.getString('tag')?.trim().toLowerCase() ?? null;
-        const entries = await getMarketForecastLeaderboard({
-          guildId: interaction.guildId,
-          window,
-          ...(tag ? { tag } : {}),
-        });
-        await interaction.reply({
-          flags: MessageFlags.Ephemeral,
-          embeds: buildMarketForecastLeaderboardEmbed(entries, window, tag),
-          allowedMentions: {
-            parse: [],
-          },
-        });
-        return;
-      }
+			await interaction.reply({
+				flags: MessageFlags.Ephemeral,
+				embeds: [
+					buildMarketStatusEmbed(
+						"Market Currency Granted",
+						[
+							`Granted **${amount.toFixed(2)} pts** to <@${user.id}>.`,
+							`Reason: ${reason}`,
+							`New bankroll: **${account.bankroll.toFixed(2)} pts**`,
+							dmDelivered
+								? "Recipient DM sent."
+								: "Recipient DM could not be delivered.",
+						].join("\n"),
+						0x57f287,
+					),
+				],
+				allowedMentions: {
+					parse: [],
+					users: [user.id],
+				},
+			});
+			return;
+		}
+		case "leaderboard": {
+			const board = interaction.options.getString("board") ?? "bankroll";
+			if (board === "forecast") {
+				const window =
+					(interaction.options.getString("window") as
+						| "all_time"
+						| "30d"
+						| null) ?? "all_time";
+				const tag =
+					interaction.options.getString("tag")?.trim().toLowerCase() ?? null;
+				const entries = await getMarketForecastLeaderboard({
+					guildId: interaction.guildId,
+					window,
+					...(tag ? { tag } : {}),
+				});
+				await interaction.reply({
+					flags: MessageFlags.Ephemeral,
+					embeds: buildMarketForecastLeaderboardEmbed(entries, window, tag),
+					allowedMentions: {
+						parse: [],
+					},
+				});
+				return;
+			}
 
-      const entries = await getMarketLeaderboard(interaction.guildId);
-      await interaction.reply({
-        flags: MessageFlags.Ephemeral,
-        embeds: buildLeaderboardEmbed(entries.map((entry) => ({
-          userId: entry.userId,
-          bankroll: entry.bankroll,
-          realizedProfit: entry.realizedProfit,
-        }))),
-        allowedMentions: {
-          parse: [],
-        },
-      });
-      return;
-    }
-    default:
-      throw new Error('Unknown market subcommand.');
-  }
+			const entries = await getMarketLeaderboard(interaction.guildId);
+			await interaction.reply({
+				flags: MessageFlags.Ephemeral,
+				embeds: buildLeaderboardEmbed(
+					entries.map((entry) => ({
+						userId: entry.userId,
+						bankroll: entry.bankroll,
+						realizedProfit: entry.realizedProfit,
+					})),
+				),
+				allowedMentions: {
+					parse: [],
+				},
+			});
+			return;
+		}
+		default:
+			throw new Error("Unknown market subcommand.");
+	}
 };

--- a/src/features/markets/handlers/interactions/modals.ts
+++ b/src/features/markets/handlers/interactions/modals.ts
@@ -8,6 +8,7 @@ import { buildMarketStatusEmbed } from "../../ui/render/market.js";
 import {
 	announceMarketUpdate,
 	clearMarketLifecycle,
+	notifyMarketCancelled,
 	notifyMarketResolved,
 	refreshMarketMessage,
 } from "../../services/lifecycle.js";
@@ -149,12 +150,13 @@ export const handleMarketModal = async (
 		});
 		await clearMarketLifecycle(market.id);
 		await refreshMarketMessage(client, market.id);
+		await notifyMarketCancelled(client, cancelled.market, cancelled.refunds);
 		await announceMarketUpdate(
 			client,
-			cancelled,
+			cancelled.market,
 			"Market Cancelled",
 			[
-				`**${cancelled.title}** was cancelled by <@${interaction.user.id}>.`,
+				`**${cancelled.market.title}** was cancelled by <@${interaction.user.id}>.`,
 				reason ? `Reason: ${reason}` : null,
 			]
 				.filter(Boolean)

--- a/src/features/markets/handlers/interactions/quotes.ts
+++ b/src/features/markets/handlers/interactions/quotes.ts
@@ -5,6 +5,7 @@ import {
 	saveMarketTradeQuoteSession,
 } from "../../state/quote-session-store.js";
 import { calculateMarketTradeQuote } from "../../services/trading/quotes.js";
+import { getMarketById } from "../../services/records.js";
 import { parseTradeInputAmount } from "./shared.js";
 
 export const createTradeQuotePreview = async (input: {
@@ -14,7 +15,24 @@ export const createTradeQuotePreview = async (input: {
 	action: "buy" | "sell" | "short" | "cover";
 	rawAmount: string;
 }): Promise<ReturnType<typeof buildMarketTradeQuoteMessage>> => {
-	const parsedAmount = parseTradeInputAmount(input.action, input.rawAmount);
+	const market =
+		input.action === "sell" || input.action === "cover"
+			? await getMarketById(input.marketId)
+			: null;
+	const positionShares =
+		input.action === "sell" || input.action === "cover"
+			? market?.positions.find(
+					(entry) =>
+						entry.userId === input.userId &&
+						entry.outcomeId === input.outcomeId &&
+						entry.side === (input.action === "sell" ? "long" : "short"),
+				)?.shares
+			: undefined;
+	const parsedAmount = parseTradeInputAmount(
+		input.action,
+		input.rawAmount,
+		positionShares === undefined ? undefined : { positionShares },
+	);
 	const quote =
 		input.action === "buy"
 			? await calculateMarketTradeQuote({

--- a/src/features/markets/handlers/interactions/quotes.ts
+++ b/src/features/markets/handlers/interactions/quotes.ts
@@ -60,6 +60,7 @@ export const createTradeQuotePreview = async (input: {
 		kind: "trade",
 		sessionId,
 		action: quote.action,
+		...(quote.contractMode ? { contractMode: quote.contractMode } : {}),
 		guildId: quote.guildId,
 		marketId: quote.marketId,
 		marketTitle: quote.marketTitle,

--- a/src/features/markets/handlers/interactions/session.ts
+++ b/src/features/markets/handlers/interactions/session.ts
@@ -200,9 +200,21 @@ export const refreshRootMarketInteractionSessionPreview = async (
 		return saveRootMarketInteractionSession(nextSession);
 	}
 
+	const positionShares =
+		nextSession.selectedAction === "sell" ||
+		nextSession.selectedAction === "cover"
+			? (await getMarketById(nextSession.marketId))?.positions.find(
+					(position) =>
+						position.userId === nextSession.userId &&
+						position.outcomeId === nextSession.selectedOutcomeId &&
+						position.side ===
+							(nextSession.selectedAction === "sell" ? "long" : "short"),
+				)?.shares
+			: undefined;
 	const parsedAmount = parseTradeInputAmount(
 		nextSession.selectedAction,
 		nextSession.amountInput,
+		positionShares === undefined ? undefined : { positionShares },
 	);
 	const quote =
 		nextSession.selectedAction === "buy"

--- a/src/features/markets/handlers/interactions/shared.ts
+++ b/src/features/markets/handlers/interactions/shared.ts
@@ -210,6 +210,29 @@ export const parseMarketSessionQuickAmountCustomId = (
 	};
 };
 
+export const parseMarketSessionQuickSellCustomId = (
+	customId: string,
+): { sessionId: string; value: "all" | 25 | 50 | 75 } | null => {
+	const match = /^market:session-quick-sell:([^:]+):(all|25|50|75)$/.exec(
+		customId,
+	);
+	if (!match?.[1] || !match[2]) {
+		return null;
+	}
+
+	if (match[2] === "all") {
+		return {
+			sessionId: match[1],
+			value: "all",
+		};
+	}
+
+	return {
+		sessionId: match[1],
+		value: Number(match[2]) as 25 | 50 | 75,
+	};
+};
+
 export const parseMarketSessionCoverageCustomId = (
 	customId: string,
 ): { sessionId: string; targetCoverage: number } | null => {
@@ -324,6 +347,7 @@ export const buildTradeExecutionDescription = (
 export const parseTradeInputAmount = (
 	action: TradeAction,
 	rawAmount: string,
+	options?: { positionShares?: number },
 ): { amount: number; amountMode: "points" | "shares" } =>
 	action === "buy"
 		? {
@@ -331,6 +355,50 @@ export const parseTradeInputAmount = (
 				amountMode: "points",
 			}
 		: (() => {
+				const trimmed = rawAmount.trim();
+				if (action === "sell" || action === "cover") {
+					if (/^all$/i.test(trimmed)) {
+						const positionShares = options?.positionShares ?? 0;
+						if (!Number.isFinite(positionShares) || positionShares <= 1e-6) {
+							throw new Error(
+								`You do not have an open ${action === "sell" ? "long" : "short"} position to ${action}.`,
+							);
+						}
+
+						return {
+							amount: positionShares,
+							amountMode: "shares",
+						};
+					}
+
+					const percentMatch = /^(?<value>\d+(?:\.\d+)?)\s*%$/.exec(trimmed);
+					if (percentMatch?.groups?.value) {
+						const percent = Number(percentMatch.groups.value);
+						if (!Number.isFinite(percent) || percent <= 0 || percent > 100) {
+							throw new Error(
+								"Percentage amount must be greater than 0% and at most 100%.",
+							);
+						}
+
+						const positionShares = options?.positionShares ?? 0;
+						if (!Number.isFinite(positionShares) || positionShares <= 1e-6) {
+							throw new Error(
+								`You do not have an open ${action === "sell" ? "long" : "short"} position to ${action}.`,
+							);
+						}
+
+						const shares = (positionShares * percent) / 100;
+						if (shares <= 1e-6) {
+							throw new Error("That percentage resolves to zero shares.");
+						}
+
+						return {
+							amount: shares,
+							amountMode: "shares",
+						};
+					}
+				}
+
 				const parsed = parseFlexibleTradeAmount(rawAmount);
 				return {
 					amount: parsed.amount,

--- a/src/features/markets/services/forecast/queries.ts
+++ b/src/features/markets/services/forecast/queries.ts
@@ -1,255 +1,366 @@
 import type {
-  MarketForecastLeaderboardEntry,
-  MarketForecastProfileDetails,
-  MarketForecastProfile,
-  MarketForecastProfileRecentRecord,
-  MarketForecastProfileTrendPoint,
-} from '../../core/types.js';
-import { roundProbability } from '../../core/shared.js';
-import { prisma } from '../../../../lib/prisma.js';
+	MarketForecastLeaderboardEntry,
+	MarketForecastProfileDetails,
+	MarketForecastProfile,
+	MarketForecastProfileRecentRecord,
+	MarketForecastProfileTrendPoint,
+} from "../../core/types.js";
+import { roundProbability } from "../../core/shared.js";
+import { prisma } from "../../../../lib/prisma.js";
 import {
-  buildCalibrationBucketLabel,
-  computeBestStreak,
-  computeCurrentStreak,
-  getPredictedOutcomeProbability,
-  thirtyDayWindowMs,
-  type HydratedForecastRecord,
-} from './shared.js';
-import { getForecastRecordsForGuild } from './records.js';
+	buildCalibrationBucketLabel,
+	computeBestStreak,
+	computeCurrentStreak,
+	getPredictedOutcomeProbability,
+	thirtyDayWindowMs,
+	type HydratedForecastRecord,
+} from "./shared.js";
+import { getForecastRecordsForGuild } from "./records.js";
 
 const filterForecastRecords = (
-  records: HydratedForecastRecord[],
-  input: {
-    userId?: string;
-    window?: 'all_time' | '30d';
-    tag?: string;
-  } = {},
+	records: HydratedForecastRecord[],
+	input: {
+		userId?: string;
+		window?: "all_time" | "30d";
+		tag?: string;
+	} = {},
 ) => {
-  const thirtyDayCutoff = Date.now() - thirtyDayWindowMs;
-  return records.filter((record) => {
-    if (input.userId && record.userId !== input.userId) {
-      return false;
-    }
+	const thirtyDayCutoff = Date.now() - thirtyDayWindowMs;
+	return records.filter((record) => {
+		if (input.userId && record.userId !== input.userId) {
+			return false;
+		}
 
-    if (input.window === '30d' && record.resolvedAt.getTime() < thirtyDayCutoff) {
-      return false;
-    }
+		if (
+			input.window === "30d" &&
+			record.resolvedAt.getTime() < thirtyDayCutoff
+		) {
+			return false;
+		}
 
-    if (input.tag && !record.marketTagSnapshot.includes(input.tag)) {
-      return false;
-    }
+		if (input.tag && !record.marketTagSnapshot.includes(input.tag)) {
+			return false;
+		}
 
-    return true;
-  });
+		return true;
+	});
 };
 
 const getMeanBrier = (records: HydratedForecastRecord[]): number | null => {
-  if (records.length === 0) {
-    return null;
-  }
+	if (records.length === 0) {
+		return null;
+	}
 
-  return roundProbability(records.reduce((sum, record) => sum + record.brierScore, 0) / records.length);
+	return roundProbability(
+		records.reduce((sum, record) => sum + record.brierScore, 0) /
+			records.length,
+	);
 };
 
 const buildMarketForecastProfile = (
-  allGuildRecords: HydratedForecastRecord[],
-  userId: string,
+	allGuildRecords: HydratedForecastRecord[],
+	userId: string,
 ): {
-  profile: MarketForecastProfile;
-  userRecords: HydratedForecastRecord[];
+	profile: MarketForecastProfile;
+	userRecords: HydratedForecastRecord[];
 } => {
-  const userRecords = filterForecastRecords(allGuildRecords, { userId });
-  const thirtyDayRecords = filterForecastRecords(allGuildRecords, { userId, window: '30d' });
-  const recordsByUser = allGuildRecords.reduce<Map<string, HydratedForecastRecord[]>>((map, record) => {
-    const existing = map.get(record.userId) ?? [];
-    existing.push(record);
-    map.set(record.userId, existing);
-    return map;
-  }, new Map());
+	const userRecords = filterForecastRecords(allGuildRecords, { userId });
+	const thirtyDayRecords = filterForecastRecords(allGuildRecords, {
+		userId,
+		window: "30d",
+	});
+	const recordsByUser = allGuildRecords.reduce<
+		Map<string, HydratedForecastRecord[]>
+	>((map, record) => {
+		const existing = map.get(record.userId) ?? [];
+		existing.push(record);
+		map.set(record.userId, existing);
+		return map;
+	}, new Map());
 
-  const rankedUsers = [...recordsByUser.entries()]
-    .map(([candidateUserId, records]) => ({
-      userId: candidateUserId,
-      sampleCount: records.length,
-      meanBrier: getMeanBrier(records),
-    }))
-    .filter((entry): entry is { userId: string; sampleCount: number; meanBrier: number } =>
-      entry.sampleCount >= 5 && entry.meanBrier !== null)
-    .sort((left, right) => left.meanBrier - right.meanBrier || right.sampleCount - left.sampleCount || left.userId.localeCompare(right.userId));
+	const rankedUsers = [...recordsByUser.entries()]
+		.map(([candidateUserId, records]) => ({
+			userId: candidateUserId,
+			sampleCount: records.length,
+			meanBrier: getMeanBrier(records),
+		}))
+		.filter(
+			(
+				entry,
+			): entry is { userId: string; sampleCount: number; meanBrier: number } =>
+				entry.sampleCount >= 5 && entry.meanBrier !== null,
+		)
+		.sort(
+			(left, right) =>
+				left.meanBrier - right.meanBrier ||
+				right.sampleCount - left.sampleCount ||
+				left.userId.localeCompare(right.userId),
+		);
 
-  const userRankIndex = rankedUsers.findIndex((entry) => entry.userId === userId);
-  const rank = userRankIndex >= 0 ? userRankIndex + 1 : null;
-  const rankedUserCount = rankedUsers.length;
-  const percentileRank = rank === null
-    ? null
-    : rankedUserCount <= 1
-      ? 100
-      : Math.round(((rankedUserCount - rank) / (rankedUserCount - 1)) * 100);
+	const userRankIndex = rankedUsers.findIndex(
+		(entry) => entry.userId === userId,
+	);
+	const rank = userRankIndex >= 0 ? userRankIndex + 1 : null;
+	const rankedUserCount = rankedUsers.length;
+	const percentileRank =
+		rank === null
+			? null
+			: rankedUserCount <= 1
+				? 100
+				: Math.round(((rankedUserCount - rank) / (rankedUserCount - 1)) * 100);
 
-  const calibrationBuckets = [...userRecords.reduce<Map<number, { confidenceSum: number; successCount: number; sampleCount: number }>>((map, record) => {
-    const predictedProbability = getPredictedOutcomeProbability(record.forecastVector, record.predictedOutcomeId);
-    const bucketIndex = Math.min(9, Math.max(0, Math.floor(predictedProbability * 10)));
-    const existing = map.get(bucketIndex) ?? { confidenceSum: 0, successCount: 0, sampleCount: 0 };
-    existing.confidenceSum += predictedProbability;
-    existing.successCount += record.wasCorrect ? 1 : 0;
-    existing.sampleCount += 1;
-    map.set(bucketIndex, existing);
-    return map;
-  }, new Map()).entries()]
-    .sort((left, right) => left[0] - right[0])
-    .map(([bucketIndex, value]) => ({
-      label: buildCalibrationBucketLabel(bucketIndex),
-      sampleCount: value.sampleCount,
-      averageConfidence: roundProbability(value.confidenceSum / value.sampleCount),
-      actualRate: roundProbability(value.successCount / value.sampleCount),
-    }));
+	const calibrationBuckets = [
+		...userRecords
+			.reduce<
+				Map<
+					number,
+					{ confidenceSum: number; successCount: number; sampleCount: number }
+				>
+			>((map, record) => {
+				const predictedProbability = getPredictedOutcomeProbability(
+					record.forecastVector,
+					record.predictedOutcomeId,
+				);
+				const bucketIndex = Math.min(
+					9,
+					Math.max(0, Math.floor(predictedProbability * 10)),
+				);
+				const existing = map.get(bucketIndex) ?? {
+					confidenceSum: 0,
+					successCount: 0,
+					sampleCount: 0,
+				};
+				existing.confidenceSum += predictedProbability;
+				existing.successCount += record.wasCorrect ? 1 : 0;
+				existing.sampleCount += 1;
+				map.set(bucketIndex, existing);
+				return map;
+			}, new Map())
+			.entries(),
+	]
+		.sort((left, right) => left[0] - right[0])
+		.map(([bucketIndex, value]) => ({
+			label: buildCalibrationBucketLabel(bucketIndex),
+			sampleCount: value.sampleCount,
+			averageConfidence: roundProbability(
+				value.confidenceSum / value.sampleCount,
+			),
+			actualRate: roundProbability(value.successCount / value.sampleCount),
+		}));
 
-  const topTags = [...userRecords.reduce<Map<string, { brierSum: number; sampleCount: number; latestResolvedAt: number }>>((map, record) => {
-    for (const tag of record.marketTagSnapshot) {
-      const existing = map.get(tag) ?? { brierSum: 0, sampleCount: 0, latestResolvedAt: 0 };
-      existing.brierSum += record.brierScore;
-      existing.sampleCount += 1;
-      existing.latestResolvedAt = Math.max(existing.latestResolvedAt, record.resolvedAt.getTime());
-      map.set(tag, existing);
-    }
-    return map;
-  }, new Map()).entries()]
-    .map(([tag, value]) => ({
-      tag,
-      meanBrier: roundProbability(value.brierSum / value.sampleCount),
-      sampleCount: value.sampleCount,
-      latestResolvedAt: value.latestResolvedAt,
-    }))
-    .filter((entry) => entry.sampleCount >= 5)
-    .sort((left, right) => left.meanBrier - right.meanBrier || right.sampleCount - left.sampleCount || right.latestResolvedAt - left.latestResolvedAt)
-    .slice(0, 3)
-    .map(({ latestResolvedAt: _latestResolvedAt, ...entry }) => entry);
+	const topTags = [
+		...userRecords
+			.reduce<
+				Map<
+					string,
+					{ brierSum: number; sampleCount: number; latestResolvedAt: number }
+				>
+			>((map, record) => {
+				for (const tag of record.marketTagSnapshot) {
+					const existing = map.get(tag) ?? {
+						brierSum: 0,
+						sampleCount: 0,
+						latestResolvedAt: 0,
+					};
+					existing.brierSum += record.brierScore;
+					existing.sampleCount += 1;
+					existing.latestResolvedAt = Math.max(
+						existing.latestResolvedAt,
+						record.resolvedAt.getTime(),
+					);
+					map.set(tag, existing);
+				}
+				return map;
+			}, new Map())
+			.entries(),
+	]
+		.map(([tag, value]) => ({
+			tag,
+			meanBrier: roundProbability(value.brierSum / value.sampleCount),
+			sampleCount: value.sampleCount,
+			latestResolvedAt: value.latestResolvedAt,
+		}))
+		.filter((entry) => entry.sampleCount >= 5)
+		.sort(
+			(left, right) =>
+				left.meanBrier - right.meanBrier ||
+				right.sampleCount - left.sampleCount ||
+				right.latestResolvedAt - left.latestResolvedAt,
+		)
+		.slice(0, 3)
+		.map(({ latestResolvedAt: _latestResolvedAt, ...entry }) => entry);
 
-  return {
-    profile: {
-      userId,
-      allTimeMeanBrier: getMeanBrier(userRecords),
-      thirtyDayMeanBrier: getMeanBrier(thirtyDayRecords),
-      allTimeSampleCount: userRecords.length,
-      thirtyDaySampleCount: thirtyDayRecords.length,
-      percentileRank,
-      rank,
-      rankedUserCount,
-      currentCorrectPickStreak: computeCurrentStreak(userRecords, (record) => record.wasCorrect),
-      bestCorrectPickStreak: computeBestStreak(userRecords, (record) => record.wasCorrect),
-      currentProfitableMarketStreak: computeCurrentStreak(userRecords, (record) => record.realizedProfit > 0),
-      bestProfitableMarketStreak: computeBestStreak(userRecords, (record) => record.realizedProfit > 0),
-      calibrationBuckets,
-      topTags,
-    },
-    userRecords,
-  };
+	return {
+		profile: {
+			userId,
+			allTimeMeanBrier: getMeanBrier(userRecords),
+			thirtyDayMeanBrier: getMeanBrier(thirtyDayRecords),
+			allTimeSampleCount: userRecords.length,
+			thirtyDaySampleCount: thirtyDayRecords.length,
+			percentileRank,
+			rank,
+			rankedUserCount,
+			currentCorrectPickStreak: computeCurrentStreak(
+				userRecords,
+				(record) => record.wasCorrect,
+			),
+			bestCorrectPickStreak: computeBestStreak(
+				userRecords,
+				(record) => record.wasCorrect,
+			),
+			currentProfitableMarketStreak: computeCurrentStreak(
+				userRecords,
+				(record) => record.realizedProfit > 0,
+			),
+			bestProfitableMarketStreak: computeBestStreak(
+				userRecords,
+				(record) => record.realizedProfit > 0,
+			),
+			calibrationBuckets,
+			topTags,
+		},
+		userRecords,
+	};
 };
 
 const buildProfileTrend = (
-  records: HydratedForecastRecord[],
+	records: HydratedForecastRecord[],
 ): MarketForecastProfileTrendPoint[] => {
-  let cumulativeProfit = 0;
-  return records.map((record) => {
-    cumulativeProfit += record.realizedProfit;
-    return {
-      time: record.resolvedAt.getTime(),
-      brierScore: record.brierScore,
-      realizedProfit: record.realizedProfit,
-      cumulativeProfit: roundProbability(cumulativeProfit),
-    };
-  });
+	let cumulativeProfit = 0;
+	return records.map((record) => {
+		cumulativeProfit += record.realizedProfit;
+		return {
+			time: record.resolvedAt.getTime(),
+			brierScore: record.brierScore,
+			realizedProfit: record.realizedProfit,
+			cumulativeProfit: roundProbability(cumulativeProfit),
+		};
+	});
 };
 
 const buildRecentRecords = (
-  records: HydratedForecastRecord[],
-  titleByMarketId: Map<string, string>,
+	records: HydratedForecastRecord[],
+	titleByMarketId: Map<string, string>,
 ): MarketForecastProfileRecentRecord[] =>
-  [...records]
-    .sort((left, right) => right.resolvedAt.getTime() - left.resolvedAt.getTime())
-    .slice(0, 6)
-    .map((record) => ({
-      marketId: record.marketId,
-      marketTitle: titleByMarketId.get(record.marketId) ?? record.marketId,
-      resolvedAt: record.resolvedAt,
-      brierScore: record.brierScore,
-      realizedProfit: record.realizedProfit,
-      wasCorrect: record.wasCorrect,
-      predictedOutcomeId: record.predictedOutcomeId,
-      winningOutcomeId: record.winningOutcomeId,
-      winningOutcomeProbability: record.winningOutcomeProbability,
-      tradeCount: record.tradeCount,
-      stakeWeight: record.stakeWeight,
-      tags: [...record.marketTagSnapshot],
-    }));
+	[...records]
+		.sort(
+			(left, right) => right.resolvedAt.getTime() - left.resolvedAt.getTime(),
+		)
+		.slice(0, 6)
+		.map((record) => ({
+			marketId: record.marketId,
+			marketTitle: titleByMarketId.get(record.marketId) ?? record.marketId,
+			resolvedAt: record.resolvedAt,
+			brierScore: record.brierScore,
+			realizedProfit: record.realizedProfit,
+			wasCorrect: record.wasCorrect,
+			predictedOutcomeId: record.predictedOutcomeId,
+			resolutionVector: [...record.resolutionVector],
+			winningOutcomeId: record.winningOutcomeId,
+			winningOutcomeProbability: record.winningOutcomeProbability,
+			tradeCount: record.tradeCount,
+			stakeWeight: record.stakeWeight,
+			tags: [...record.marketTagSnapshot],
+		}));
 
 export const getMarketForecastProfile = async (
-  guildId: string,
-  userId: string,
+	guildId: string,
+	userId: string,
 ): Promise<MarketForecastProfile> => {
-  const { profile } = buildMarketForecastProfile(await getForecastRecordsForGuild(guildId), userId);
-  return profile;
+	const { profile } = buildMarketForecastProfile(
+		await getForecastRecordsForGuild(guildId),
+		userId,
+	);
+	return profile;
 };
 
 export const getMarketForecastProfileDetails = async (
-  guildId: string,
-  userId: string,
+	guildId: string,
+	userId: string,
 ): Promise<MarketForecastProfileDetails> => {
-  const { profile, userRecords } = buildMarketForecastProfile(await getForecastRecordsForGuild(guildId), userId);
-  const userMarketIds = [...new Set(userRecords.map((record) => record.marketId))];
-  const markets = userMarketIds.length === 0
-    ? []
-    : await prisma.market.findMany({
-        where: {
-          guildId,
-          id: {
-            in: userMarketIds,
-          },
-        },
-        select: {
-          id: true,
-          title: true,
-        },
-      });
-  const titleByMarketId = new Map(markets.map((market) => [market.id, market.title]));
+	const { profile, userRecords } = buildMarketForecastProfile(
+		await getForecastRecordsForGuild(guildId),
+		userId,
+	);
+	const userMarketIds = [
+		...new Set(userRecords.map((record) => record.marketId)),
+	];
+	const markets =
+		userMarketIds.length === 0
+			? []
+			: await prisma.market.findMany({
+					where: {
+						guildId,
+						id: {
+							in: userMarketIds,
+						},
+					},
+					select: {
+						id: true,
+						title: true,
+					},
+				});
+	const titleByMarketId = new Map(
+		markets.map((market) => [market.id, market.title]),
+	);
 
-  return {
-    ...profile,
-    recentRecords: buildRecentRecords(userRecords, titleByMarketId),
-    brierTrend: buildProfileTrend(userRecords),
-    profitTrend: buildProfileTrend(userRecords),
-  };
+	return {
+		...profile,
+		recentRecords: buildRecentRecords(userRecords, titleByMarketId),
+		brierTrend: buildProfileTrend(userRecords),
+		profitTrend: buildProfileTrend(userRecords),
+	};
 };
 
 export const getMarketForecastLeaderboard = async (input: {
-  guildId: string;
-  window?: 'all_time' | '30d';
-  tag?: string;
-  limit?: number;
+	guildId: string;
+	window?: "all_time" | "30d";
+	tag?: string;
+	limit?: number;
 }): Promise<MarketForecastLeaderboardEntry[]> => {
-  const filteredRecords = filterForecastRecords(await getForecastRecordsForGuild(input.guildId), {
-    window: input.window ?? 'all_time',
-    ...(input.tag ? { tag: input.tag } : {}),
-  });
-  const minimumSampleCount = (input.window ?? 'all_time') === '30d' ? 3 : 5;
-  const recordsByUser = filteredRecords.reduce<Map<string, HydratedForecastRecord[]>>((map, record) => {
-    const existing = map.get(record.userId) ?? [];
-    existing.push(record);
-    map.set(record.userId, existing);
-    return map;
-  }, new Map());
+	const filteredRecords = filterForecastRecords(
+		await getForecastRecordsForGuild(input.guildId),
+		{
+			window: input.window ?? "all_time",
+			...(input.tag ? { tag: input.tag } : {}),
+		},
+	);
+	const minimumSampleCount = (input.window ?? "all_time") === "30d" ? 3 : 5;
+	const recordsByUser = filteredRecords.reduce<
+		Map<string, HydratedForecastRecord[]>
+	>((map, record) => {
+		const existing = map.get(record.userId) ?? [];
+		existing.push(record);
+		map.set(record.userId, existing);
+		return map;
+	}, new Map());
 
-  return [...recordsByUser.entries()]
-    .map(([userId, records]) => ({
-      userId,
-      meanBrier: getMeanBrier(records),
-      sampleCount: records.length,
-      correctPickRate: records.length === 0
-        ? 0
-        : roundProbability(records.filter((record) => record.wasCorrect).length / records.length),
-      currentCorrectPickStreak: computeCurrentStreak(records, (record) => record.wasCorrect),
-    }))
-    .filter((entry): entry is MarketForecastLeaderboardEntry => entry.meanBrier !== null && entry.sampleCount >= minimumSampleCount)
-    .sort((left, right) => left.meanBrier - right.meanBrier || right.sampleCount - left.sampleCount || left.userId.localeCompare(right.userId))
-    .slice(0, input.limit ?? 10);
+	return [...recordsByUser.entries()]
+		.map(([userId, records]) => ({
+			userId,
+			meanBrier: getMeanBrier(records),
+			sampleCount: records.length,
+			correctPickRate:
+				records.length === 0
+					? 0
+					: roundProbability(
+							records.filter((record) => record.wasCorrect).length /
+								records.length,
+						),
+			currentCorrectPickStreak: computeCurrentStreak(
+				records,
+				(record) => record.wasCorrect,
+			),
+		}))
+		.filter(
+			(entry): entry is MarketForecastLeaderboardEntry =>
+				entry.meanBrier !== null && entry.sampleCount >= minimumSampleCount,
+		)
+		.sort(
+			(left, right) =>
+				left.meanBrier - right.meanBrier ||
+				right.sampleCount - left.sampleCount ||
+				left.userId.localeCompare(right.userId),
+		)
+		.slice(0, input.limit ?? 10);
 };

--- a/src/features/markets/services/forecast/records.ts
+++ b/src/features/markets/services/forecast/records.ts
@@ -1,149 +1,161 @@
-import { Prisma } from '@prisma/client';
+import { Prisma } from "@prisma/client";
 
-import { logger } from '../../../../app/logger.js';
-import { prisma } from '../../../../lib/prisma.js';
+import { logger } from "../../../../app/logger.js";
+import { prisma } from "../../../../lib/prisma.js";
+import { getMarketForUpdate, marketInclude } from "../../core/shared.js";
+import type { MarketWithRelations } from "../../core/types.js";
 import {
-  getMarketForUpdate,
-  marketInclude,
-} from '../../core/shared.js';
-import type { MarketWithRelations } from '../../core/types.js';
-import {
-  buildForecastRecordsForMarket,
-  hydrateForecastRecord,
-  type HydratedForecastRecord,
-} from './shared.js';
+	buildForecastRecordsForMarket,
+	hydrateForecastRecord,
+	type HydratedForecastRecord,
+} from "./shared.js";
 
 const forecastBackfillCooldownMs = 5 * 60 * 1_000;
-const forecastBackfillState = new Map<string, { lastStartedAt: number; promise: Promise<number> | null }>();
+const forecastBackfillState = new Map<
+	string,
+	{ lastStartedAt: number; promise: Promise<number> | null }
+>();
 
 export const persistForecastRecordsTx = async (
-  tx: Prisma.TransactionClient,
-  market: MarketWithRelations,
+	tx: Prisma.TransactionClient,
+	market: MarketWithRelations,
 ): Promise<number> => {
-  const records = buildForecastRecordsForMarket(market);
-  await Promise.all(records.map((record) =>
-    tx.marketForecastRecord.upsert({
-      where: {
-        guildId_marketId_userId: {
-          guildId: market.guildId,
-          marketId: market.id,
-          userId: record.userId,
-        },
-      },
-      create: {
-        guildId: market.guildId,
-        marketId: market.id,
-        userId: record.userId,
-        resolvedAt: record.resolvedAt,
-        marketTagSnapshot: record.marketTagSnapshot,
-        forecastVector: record.forecastVector,
-        winningOutcomeId: record.winningOutcomeId,
-        winningOutcomeProbability: record.winningOutcomeProbability,
-        predictedOutcomeId: record.predictedOutcomeId,
-        brierScore: record.brierScore,
-        wasCorrect: record.wasCorrect,
-        realizedProfit: record.realizedProfit,
-        tradeCount: record.tradeCount,
-        stakeWeight: record.stakeWeight,
-      },
-      update: {
-        resolvedAt: record.resolvedAt,
-        marketTagSnapshot: record.marketTagSnapshot,
-        forecastVector: record.forecastVector,
-        winningOutcomeId: record.winningOutcomeId,
-        winningOutcomeProbability: record.winningOutcomeProbability,
-        predictedOutcomeId: record.predictedOutcomeId,
-        brierScore: record.brierScore,
-        wasCorrect: record.wasCorrect,
-        realizedProfit: record.realizedProfit,
-        tradeCount: record.tradeCount,
-        stakeWeight: record.stakeWeight,
-      },
-    })));
+	const records = buildForecastRecordsForMarket(market);
+	await Promise.all(
+		records.map((record) =>
+			tx.marketForecastRecord.upsert({
+				where: {
+					guildId_marketId_userId: {
+						guildId: market.guildId,
+						marketId: market.id,
+						userId: record.userId,
+					},
+				},
+				create: {
+					guildId: market.guildId,
+					marketId: market.id,
+					userId: record.userId,
+					resolvedAt: record.resolvedAt,
+					marketTagSnapshot: record.marketTagSnapshot,
+					forecastVector: record.forecastVector,
+					resolutionVector: record.resolutionVector,
+					winningOutcomeId: record.winningOutcomeId,
+					winningOutcomeProbability: record.winningOutcomeProbability,
+					predictedOutcomeId: record.predictedOutcomeId,
+					brierScore: record.brierScore,
+					wasCorrect: record.wasCorrect,
+					realizedProfit: record.realizedProfit,
+					tradeCount: record.tradeCount,
+					stakeWeight: record.stakeWeight,
+				},
+				update: {
+					resolvedAt: record.resolvedAt,
+					marketTagSnapshot: record.marketTagSnapshot,
+					forecastVector: record.forecastVector,
+					resolutionVector: record.resolutionVector,
+					winningOutcomeId: record.winningOutcomeId,
+					winningOutcomeProbability: record.winningOutcomeProbability,
+					predictedOutcomeId: record.predictedOutcomeId,
+					brierScore: record.brierScore,
+					wasCorrect: record.wasCorrect,
+					realizedProfit: record.realizedProfit,
+					tradeCount: record.tradeCount,
+					stakeWeight: record.stakeWeight,
+				},
+			}),
+		),
+	);
 
-  return records.length;
+	return records.length;
 };
 
-export const backfillMarketForecastRecords = async (guildId?: string): Promise<number> => {
-  const markets = await prisma.market.findMany({
-    where: {
-      ...(guildId ? { guildId } : {}),
-      cancelledAt: null,
-      resolvedAt: {
-        not: null,
-      },
-      trades: {
-        some: {},
-      },
-      forecastRecords: {
-        none: {},
-      },
-    },
-    include: marketInclude,
-    orderBy: {
-      resolvedAt: 'asc',
-    },
-  });
+export const backfillMarketForecastRecords = async (
+	guildId?: string,
+): Promise<number> => {
+	const markets = await prisma.market.findMany({
+		where: {
+			...(guildId ? { guildId } : {}),
+			cancelledAt: null,
+			resolvedAt: {
+				not: null,
+			},
+			trades: {
+				some: {},
+			},
+			forecastRecords: {
+				none: {},
+			},
+		},
+		include: marketInclude,
+		orderBy: {
+			resolvedAt: "asc",
+		},
+	});
 
-  let recordCount = 0;
-  for (const market of markets) {
-    recordCount += await prisma.$transaction(async (tx) => {
-      const freshMarket = await getMarketForUpdate(tx, market.id);
-      if (!freshMarket || !freshMarket.resolvedAt || freshMarket.cancelledAt) {
-        return 0;
-      }
+	let recordCount = 0;
+	for (const market of markets) {
+		recordCount += await prisma.$transaction(async (tx) => {
+			const freshMarket = await getMarketForUpdate(tx, market.id);
+			if (!freshMarket || !freshMarket.resolvedAt || freshMarket.cancelledAt) {
+				return 0;
+			}
 
-      return persistForecastRecordsTx(tx, freshMarket);
-    });
-  }
+			return persistForecastRecordsTx(tx, freshMarket);
+		});
+	}
 
-  return recordCount;
+	return recordCount;
 };
 
 const scheduleForecastBackfill = (guildId: string): void => {
-  const now = Date.now();
-  const existing = forecastBackfillState.get(guildId);
-  if (existing?.promise) {
-    return;
-  }
+	const now = Date.now();
+	const existing = forecastBackfillState.get(guildId);
+	if (existing?.promise) {
+		return;
+	}
 
-  if (existing && (now - existing.lastStartedAt) < forecastBackfillCooldownMs) {
-    return;
-  }
+	if (existing && now - existing.lastStartedAt < forecastBackfillCooldownMs) {
+		return;
+	}
 
-  const promise = backfillMarketForecastRecords(guildId)
-    .catch((error) => {
-      logger.warn({ err: error, guildId }, 'Could not backfill market forecast records');
-      return 0;
-    })
-    .finally(() => {
-      const current = forecastBackfillState.get(guildId);
-      if (!current || current.promise !== promise) {
-        return;
-      }
+	const promise = backfillMarketForecastRecords(guildId)
+		.catch((error) => {
+			logger.warn(
+				{ err: error, guildId },
+				"Could not backfill market forecast records",
+			);
+			return 0;
+		})
+		.finally(() => {
+			const current = forecastBackfillState.get(guildId);
+			if (!current || current.promise !== promise) {
+				return;
+			}
 
-      forecastBackfillState.set(guildId, {
-        lastStartedAt: current.lastStartedAt,
-        promise: null,
-      });
-    });
+			forecastBackfillState.set(guildId, {
+				lastStartedAt: current.lastStartedAt,
+				promise: null,
+			});
+		});
 
-  forecastBackfillState.set(guildId, {
-    lastStartedAt: now,
-    promise,
-  });
+	forecastBackfillState.set(guildId, {
+		lastStartedAt: now,
+		promise,
+	});
 };
 
-export const getForecastRecordsForGuild = async (guildId: string): Promise<HydratedForecastRecord[]> => {
-  scheduleForecastBackfill(guildId);
-  const records = await prisma.marketForecastRecord.findMany({
-    where: {
-      guildId,
-    },
-    orderBy: {
-      resolvedAt: 'asc',
-    },
-  });
+export const getForecastRecordsForGuild = async (
+	guildId: string,
+): Promise<HydratedForecastRecord[]> => {
+	scheduleForecastBackfill(guildId);
+	const records = await prisma.marketForecastRecord.findMany({
+		where: {
+			guildId,
+		},
+		orderBy: {
+			resolvedAt: "asc",
+		},
+	});
 
-  return records.map(hydrateForecastRecord);
+	return records.map(hydrateForecastRecord);
 };

--- a/src/features/markets/services/forecast/shared.ts
+++ b/src/features/markets/services/forecast/shared.ts
@@ -1,449 +1,583 @@
-import type { Market, MarketLiquidityEvent, MarketOutcome, MarketTrade, Prisma } from '@prisma/client';
+import type {
+	Market,
+	MarketLiquidityEvent,
+	MarketOutcome,
+	MarketTrade,
+	Prisma,
+} from "@prisma/client";
 
 import {
-  clampSmall,
-  compareMarketHistoryEvents,
-  computeSupplementaryBonusDistribution,
-  getMarketProbabilities,
-  roundCurrency,
-  roundProbability,
-} from '../../core/shared.js';
+	clampSmall,
+	compareMarketHistoryEvents,
+	computeSupplementaryBonusDistribution,
+	getMarketResolutionVector,
+	getMarketProbabilities,
+	roundCurrency,
+	roundProbability,
+} from "../../core/shared.js";
 import type {
-  MarketForecastVectorEntry,
-  MarketWithRelations,
-} from '../../core/types.js';
+	MarketForecastVectorEntry,
+	MarketWithRelations,
+} from "../../core/types.js";
 
 export const thirtyDayWindowMs = 30 * 24 * 60 * 60 * 1_000;
 export const minimumForecastTradeCount = 2;
 export const minimumForecastStakeWeight = 25;
 
 type RunningLongPosition = {
-  shares: number;
-  costBasis: number;
+	shares: number;
+	costBasis: number;
 };
 
 type RunningShortPosition = {
-  shares: number;
-  proceeds: number;
-  collateralLocked: number;
+	shares: number;
+	proceeds: number;
+	collateralLocked: number;
 };
 
 type RunningForecastState = {
-  tradeCount: number;
-  stakeWeight: number;
-  weightedProbabilities: Map<string, { weightedSum: number; weight: number }>;
+	tradeCount: number;
+	stakeWeight: number;
+	weightedProbabilities: Map<string, { weightedSum: number; weight: number }>;
 };
 
 type RunningProfitState = {
-  realizedProfit: number;
-  longPositions: Map<string, RunningLongPosition>;
-  shortPositions: Map<string, RunningShortPosition>;
+	realizedProfit: number;
+	longPositions: Map<string, RunningLongPosition>;
+	shortPositions: Map<string, RunningShortPosition>;
 };
 
 type MarketHistoryEvent =
-  | {
-      kind: 'trade';
-      createdAt: Date;
-      trade: MarketTrade;
-    }
-  | {
-      kind: 'liquidity';
-      createdAt: Date;
-      liquidityEvent: MarketLiquidityEvent;
-    };
+	| {
+			kind: "trade";
+			createdAt: Date;
+			trade: MarketTrade;
+	  }
+	| {
+			kind: "liquidity";
+			createdAt: Date;
+			liquidityEvent: MarketLiquidityEvent;
+	  };
 
 export type HydratedForecastRecord = {
-  id: string;
-  guildId: string;
-  marketId: string;
-  userId: string;
-  resolvedAt: Date;
-  marketTagSnapshot: string[];
-  forecastVector: MarketForecastVectorEntry[];
-  winningOutcomeId: string;
-  winningOutcomeProbability: number;
-  predictedOutcomeId: string;
-  brierScore: number;
-  wasCorrect: boolean;
-  realizedProfit: number;
-  tradeCount: number;
-  stakeWeight: number;
+	id: string;
+	guildId: string;
+	marketId: string;
+	userId: string;
+	resolvedAt: Date;
+	marketTagSnapshot: string[];
+	forecastVector: MarketForecastVectorEntry[];
+	resolutionVector: number[];
+	winningOutcomeId: string;
+	winningOutcomeProbability: number;
+	predictedOutcomeId: string;
+	brierScore: number;
+	wasCorrect: boolean;
+	realizedProfit: number;
+	tradeCount: number;
+	stakeWeight: number;
 };
 
+const inferResolutionVectorFromWinningOutcome = (
+	forecastVector: MarketForecastVectorEntry[],
+	winningOutcomeId: string,
+): number[] =>
+	forecastVector.map((entry) => (entry.outcomeId === winningOutcomeId ? 1 : 0));
+
 const normalizeForecastVector = (
-  market: Pick<Market, 'winningOutcomeId'> & {
-    outcomes: Array<Pick<MarketOutcome, 'id'>>;
-  },
-  weightedProbabilities: Map<string, { weightedSum: number; weight: number }>,
+	market: Pick<Market, "winningOutcomeId"> & {
+		contractMode?: Market["contractMode"] | null;
+		outcomes: Array<Pick<MarketOutcome, "id">>;
+	},
+	weightedProbabilities: Map<string, { weightedSum: number; weight: number }>,
 ): MarketForecastVectorEntry[] | null => {
-  const values = market.outcomes.map((outcome) => {
-    const aggregate = weightedProbabilities.get(outcome.id);
-    return aggregate && aggregate.weight > 0
-      ? clampSmall(Math.min(1, Math.max(0, aggregate.weightedSum / aggregate.weight)))
-      : null;
-  });
+	const values = market.outcomes.map((outcome) => {
+		const aggregate = weightedProbabilities.get(outcome.id);
+		return aggregate && aggregate.weight > 0
+			? clampSmall(
+					Math.min(1, Math.max(0, aggregate.weightedSum / aggregate.weight)),
+				)
+			: null;
+	});
 
-  const knownValues = values.filter((value): value is number => value !== null);
-  if (knownValues.length === 0) {
-    return null;
-  }
+	const knownValues = values.filter((value): value is number => value !== null);
+	if (knownValues.length === 0) {
+		return null;
+	}
 
-  const missingCount = values.filter((value) => value === null).length;
-  const knownSum = knownValues.reduce((sum, value) => sum + value, 0);
-  const filledValues = values.map((value) => value ?? 0);
+	const missingCount = values.filter((value) => value === null).length;
+	const knownSum = knownValues.reduce((sum, value) => sum + value, 0);
+	const filledValues = values.map((value) => value ?? 0);
 
-  if (missingCount > 0 && knownSum < 1) {
-    const filler = (1 - knownSum) / missingCount;
-    for (let index = 0; index < filledValues.length; index += 1) {
-      if (values[index] === null) {
-        filledValues[index] = filler;
-      }
-    }
-  }
+	if (missingCount > 0) {
+		if (market.contractMode === "independent_binary_set") {
+			for (let index = 0; index < filledValues.length; index += 1) {
+				if (values[index] === null) {
+					filledValues[index] = 0.5;
+				}
+			}
+		} else if (knownSum < 1) {
+			const filler = (1 - knownSum) / missingCount;
+			for (let index = 0; index < filledValues.length; index += 1) {
+				if (values[index] === null) {
+					filledValues[index] = filler;
+				}
+			}
+		}
+	}
 
-  const total = filledValues.reduce((sum, value) => sum + value, 0);
-  if (total <= 0) {
-    return null;
-  }
+	if (market.contractMode === "independent_binary_set") {
+		return market.outcomes.map((outcome, index) => ({
+			outcomeId: outcome.id,
+			probability: roundProbability(
+				Math.min(1, Math.max(0, filledValues[index] ?? 0)),
+			),
+		}));
+	}
 
-  return market.outcomes.map((outcome, index) => ({
-    outcomeId: outcome.id,
-    probability: roundProbability((filledValues[index] ?? 0) / total),
-  }));
+	const total = filledValues.reduce((sum, value) => sum + value, 0);
+	if (total <= 0) {
+		return null;
+	}
+
+	return market.outcomes.map((outcome, index) => ({
+		outcomeId: outcome.id,
+		probability: roundProbability((filledValues[index] ?? 0) / total),
+	}));
 };
 
 export const buildCalibrationBucketLabel = (bucketIndex: number): string => {
-  const lower = bucketIndex * 10;
-  const upper = bucketIndex === 9 ? 100 : (bucketIndex * 10) + 9;
-  return `${lower}-${upper}%`;
+	const lower = bucketIndex * 10;
+	const upper = bucketIndex === 9 ? 100 : bucketIndex * 10 + 9;
+	return `${lower}-${upper}%`;
 };
 
-export const computeCurrentStreak = <T>(entries: T[], predicate: (entry: T) => boolean): number => {
-  let streak = 0;
-  for (let index = entries.length - 1; index >= 0; index -= 1) {
-    if (!predicate(entries[index] as T)) {
-      break;
-    }
+export const computeCurrentStreak = <T>(
+	entries: T[],
+	predicate: (entry: T) => boolean,
+): number => {
+	let streak = 0;
+	for (let index = entries.length - 1; index >= 0; index -= 1) {
+		if (!predicate(entries[index] as T)) {
+			break;
+		}
 
-    streak += 1;
-  }
+		streak += 1;
+	}
 
-  return streak;
+	return streak;
 };
 
-export const computeBestStreak = <T>(entries: T[], predicate: (entry: T) => boolean): number => {
-  let best = 0;
-  let current = 0;
+export const computeBestStreak = <T>(
+	entries: T[],
+	predicate: (entry: T) => boolean,
+): number => {
+	let best = 0;
+	let current = 0;
 
-  for (const entry of entries) {
-    if (predicate(entry)) {
-      current += 1;
-      best = Math.max(best, current);
-    } else {
-      current = 0;
-    }
-  }
+	for (const entry of entries) {
+		if (predicate(entry)) {
+			current += 1;
+			best = Math.max(best, current);
+		} else {
+			current = 0;
+		}
+	}
 
-  return best;
+	return best;
 };
 
 export const getPredictedOutcomeProbability = (
-  forecastVector: MarketForecastVectorEntry[],
-  predictedOutcomeId: string,
+	forecastVector: MarketForecastVectorEntry[],
+	predictedOutcomeId: string,
 ): number =>
-  forecastVector.find((entry) => entry.outcomeId === predictedOutcomeId)?.probability ?? 0;
+	forecastVector.find((entry) => entry.outcomeId === predictedOutcomeId)
+		?.probability ?? 0;
 
 export const hydrateForecastRecord = (
-  record: Prisma.MarketForecastRecordGetPayload<Record<string, never>>,
-): HydratedForecastRecord => ({
-  ...record,
-  marketTagSnapshot: [...record.marketTagSnapshot],
-  forecastVector: Array.isArray(record.forecastVector)
-    ? (record.forecastVector as MarketForecastVectorEntry[])
-    : [],
-});
+	record: Prisma.MarketForecastRecordGetPayload<Record<string, never>>,
+): HydratedForecastRecord => {
+	const forecastVector = Array.isArray(record.forecastVector)
+		? (record.forecastVector as MarketForecastVectorEntry[])
+		: [];
+	const resolutionVector = Array.isArray(record.resolutionVector)
+		? (record.resolutionVector as number[])
+		: inferResolutionVectorFromWinningOutcome(
+				forecastVector,
+				record.winningOutcomeId,
+			);
+
+	return {
+		...record,
+		marketTagSnapshot: [...record.marketTagSnapshot],
+		forecastVector,
+		resolutionVector,
+	};
+};
 
 const buildHistoricalProbabilityVector = (
-  market: Pick<Market, 'winningOutcomeId'> & {
-    outcomes: Array<Pick<MarketOutcome, 'id' | 'resolvedAt' | 'settlementValue'>>;
-  },
-  pricingSharesByOutcomeId: Map<string, number>,
-  liquidityParameter: number,
-  snapshotAt: Date,
+	market: Pick<Market, "winningOutcomeId"> & {
+		contractMode?: Market["contractMode"] | null;
+		outcomes: Array<
+			Pick<MarketOutcome, "id" | "resolvedAt" | "settlementValue">
+		>;
+	},
+	pricingSharesByOutcomeId: Map<string, number>,
+	liquidityParameter: number,
+	snapshotAt: Date,
 ): MarketForecastVectorEntry[] => {
-  const probabilities = getMarketProbabilities({
-    liquidityParameter,
-    resolvedAt: null,
-    winningOutcomeId: market.winningOutcomeId,
-    outcomes: market.outcomes.map((outcome) => ({
-      id: outcome.id,
-      pricingShares: pricingSharesByOutcomeId.get(outcome.id) ?? 0,
-      settlementValue: outcome.resolvedAt && outcome.resolvedAt.getTime() <= snapshotAt.getTime()
-        ? outcome.settlementValue
-        : null,
-    })),
-  });
+	const probabilities = getMarketProbabilities({
+		...(market.contractMode !== undefined
+			? { contractMode: market.contractMode }
+			: {}),
+		liquidityParameter,
+		resolvedAt: null,
+		winningOutcomeId: market.winningOutcomeId,
+		outcomes: market.outcomes.map((outcome) => ({
+			id: outcome.id,
+			pricingShares: pricingSharesByOutcomeId.get(outcome.id) ?? 0,
+			settlementValue:
+				outcome.resolvedAt &&
+				outcome.resolvedAt.getTime() <= snapshotAt.getTime()
+					? outcome.settlementValue
+					: null,
+		})),
+	});
 
-  return market.outcomes.map((outcome, index) => ({
-    outcomeId: outcome.id,
-    probability: roundProbability(probabilities[index] ?? 0),
-  }));
+	return market.outcomes.map((outcome, index) => ({
+		outcomeId: outcome.id,
+		probability: roundProbability(probabilities[index] ?? 0),
+	}));
 };
 
 const reconstructMarketProfitByUser = (
-  market: Pick<Market, 'winningOutcomeId'> & {
-    trades: MarketTrade[];
-    outcomes: Array<Pick<MarketOutcome, 'id'>>;
-  },
+	market: Pick<Market, "winningOutcomeId"> & {
+		contractMode?: Market["contractMode"] | null;
+		trades: MarketTrade[];
+		outcomes: Array<Pick<MarketOutcome, "id" | "settlementValue">>;
+	},
 ): Map<string, number> => {
-  const userStates = new Map<string, RunningProfitState>();
+	const userStates = new Map<string, RunningProfitState>();
 
-  const getUserState = (userId: string): RunningProfitState => {
-    let state = userStates.get(userId);
-    if (!state) {
-      state = {
-        realizedProfit: 0,
-        longPositions: new Map(),
-        shortPositions: new Map(),
-      };
-      userStates.set(userId, state);
-    }
+	const getUserState = (userId: string): RunningProfitState => {
+		let state = userStates.get(userId);
+		if (!state) {
+			state = {
+				realizedProfit: 0,
+				longPositions: new Map(),
+				shortPositions: new Map(),
+			};
+			userStates.set(userId, state);
+		}
 
-    return state;
-  };
+		return state;
+	};
 
-  for (const trade of market.trades) {
-    const state = getUserState(trade.userId);
+	for (const trade of market.trades) {
+		const state = getUserState(trade.userId);
 
-    switch (trade.side) {
-      case 'buy': {
-        const position = state.longPositions.get(trade.outcomeId) ?? { shares: 0, costBasis: 0 };
-        position.shares += trade.shareDelta;
-        position.costBasis += -trade.cashDelta;
-        state.longPositions.set(trade.outcomeId, position);
-        break;
-      }
-      case 'sell': {
-        const position = state.longPositions.get(trade.outcomeId);
-        if (!position || position.shares <= 1e-6) {
-          break;
-        }
+		switch (trade.side) {
+			case "buy": {
+				const position = state.longPositions.get(trade.outcomeId) ?? {
+					shares: 0,
+					costBasis: 0,
+				};
+				position.shares += trade.shareDelta;
+				position.costBasis += -trade.cashDelta;
+				state.longPositions.set(trade.outcomeId, position);
+				break;
+			}
+			case "sell": {
+				const position = state.longPositions.get(trade.outcomeId);
+				if (!position || position.shares <= 1e-6) {
+					break;
+				}
 
-        const sharesSold = Math.abs(trade.shareDelta);
-        const averageCostBasis = position.costBasis / position.shares;
-        const releasedCostBasis = averageCostBasis * sharesSold;
-        position.shares = clampSmall(position.shares - sharesSold);
-        position.costBasis = clampSmall(position.costBasis - releasedCostBasis);
-        state.realizedProfit += trade.cashDelta - releasedCostBasis;
-        if (position.shares <= 1e-6) {
-          state.longPositions.delete(trade.outcomeId);
-        } else {
-          state.longPositions.set(trade.outcomeId, position);
-        }
-        break;
-      }
-      case 'short': {
-        const position = state.shortPositions.get(trade.outcomeId) ?? { shares: 0, proceeds: 0, collateralLocked: 0 };
-        const sharesShorted = Math.abs(trade.shareDelta);
-        position.shares += sharesShorted;
-        position.proceeds += trade.cashDelta;
-        position.collateralLocked += sharesShorted;
-        state.shortPositions.set(trade.outcomeId, position);
-        break;
-      }
-      case 'cover': {
-        const position = state.shortPositions.get(trade.outcomeId);
-        if (!position || position.shares <= 1e-6) {
-          break;
-        }
+				const sharesSold = Math.abs(trade.shareDelta);
+				const averageCostBasis = position.costBasis / position.shares;
+				const releasedCostBasis = averageCostBasis * sharesSold;
+				position.shares = clampSmall(position.shares - sharesSold);
+				position.costBasis = clampSmall(position.costBasis - releasedCostBasis);
+				state.realizedProfit += trade.cashDelta - releasedCostBasis;
+				if (position.shares <= 1e-6) {
+					state.longPositions.delete(trade.outcomeId);
+				} else {
+					state.longPositions.set(trade.outcomeId, position);
+				}
+				break;
+			}
+			case "short": {
+				const position = state.shortPositions.get(trade.outcomeId) ?? {
+					shares: 0,
+					proceeds: 0,
+					collateralLocked: 0,
+				};
+				const sharesShorted = Math.abs(trade.shareDelta);
+				position.shares += sharesShorted;
+				position.proceeds += trade.cashDelta;
+				position.collateralLocked += sharesShorted;
+				state.shortPositions.set(trade.outcomeId, position);
+				break;
+			}
+			case "cover": {
+				const position = state.shortPositions.get(trade.outcomeId);
+				if (!position || position.shares <= 1e-6) {
+					break;
+				}
 
-        const sharesCovered = trade.shareDelta;
-        const averageProceeds = position.proceeds / position.shares;
-        const averageCollateral = position.collateralLocked / position.shares;
-        const releasedProceeds = averageProceeds * sharesCovered;
-        const releasedCollateral = averageCollateral * sharesCovered;
-        const coverCost = -trade.cashDelta;
-        position.shares = clampSmall(position.shares - sharesCovered);
-        position.proceeds = clampSmall(position.proceeds - releasedProceeds);
-        position.collateralLocked = clampSmall(position.collateralLocked - releasedCollateral);
-        state.realizedProfit += releasedProceeds - coverCost;
-        if (position.shares <= 1e-6) {
-          state.shortPositions.delete(trade.outcomeId);
-        } else {
-          state.shortPositions.set(trade.outcomeId, position);
-        }
-        break;
-      }
-    }
-  }
+				const sharesCovered = trade.shareDelta;
+				const averageProceeds = position.proceeds / position.shares;
+				const averageCollateral = position.collateralLocked / position.shares;
+				const releasedProceeds = averageProceeds * sharesCovered;
+				const releasedCollateral = averageCollateral * sharesCovered;
+				const coverCost = -trade.cashDelta;
+				position.shares = clampSmall(position.shares - sharesCovered);
+				position.proceeds = clampSmall(position.proceeds - releasedProceeds);
+				position.collateralLocked = clampSmall(
+					position.collateralLocked - releasedCollateral,
+				);
+				state.realizedProfit += releasedProceeds - coverCost;
+				if (position.shares <= 1e-6) {
+					state.shortPositions.delete(trade.outcomeId);
+				} else {
+					state.shortPositions.set(trade.outcomeId, position);
+				}
+				break;
+			}
+		}
+	}
 
-  const profits = new Map<string, number>();
-  for (const [userId, state] of userStates) {
-    let totalProfit = state.realizedProfit;
+	const profits = new Map<string, number>();
+	const resolutionVector = getMarketResolutionVector({
+		...(market.contractMode !== undefined
+			? { contractMode: market.contractMode }
+			: {}),
+		winningOutcomeId: market.winningOutcomeId,
+		outcomes: market.outcomes,
+	});
+	const payoutByOutcomeId = new Map<string, number>(
+		market.outcomes.map((outcome, index) => [
+			outcome.id,
+			resolutionVector[index] ?? 0,
+		]),
+	);
+	for (const [userId, state] of userStates) {
+		let totalProfit = state.realizedProfit;
 
-    for (const [outcomeId, position] of state.longPositions) {
-      totalProfit += (outcomeId === market.winningOutcomeId ? position.shares : 0) - position.costBasis;
-    }
+		for (const [outcomeId, position] of state.longPositions) {
+			totalProfit +=
+				(payoutByOutcomeId.get(outcomeId) ?? 0) * position.shares -
+				position.costBasis;
+		}
 
-    for (const [outcomeId, position] of state.shortPositions) {
-      totalProfit += position.proceeds - (outcomeId === market.winningOutcomeId ? position.collateralLocked : 0);
-    }
+		for (const [outcomeId, position] of state.shortPositions) {
+			totalProfit +=
+				position.proceeds -
+				(payoutByOutcomeId.get(outcomeId) ?? 0) * position.collateralLocked;
+		}
 
-    profits.set(userId, roundCurrency(totalProfit));
-  }
+		profits.set(userId, roundCurrency(totalProfit));
+	}
 
-  return profits;
+	return profits;
 };
 
 const buildMarketHistory = (
-  market: Pick<Market, 'createdAt'> & {
-    trades: MarketTrade[];
-    liquidityEvents: MarketLiquidityEvent[];
-  },
+	market: Pick<Market, "createdAt"> & {
+		trades: MarketTrade[];
+		liquidityEvents: MarketLiquidityEvent[];
+	},
 ): MarketHistoryEvent[] =>
-  [
-    ...market.trades.map((trade) => ({
-      kind: 'trade' as const,
-      createdAt: trade.createdAt,
-      trade,
-    })),
-    ...market.liquidityEvents.map((liquidityEvent) => ({
-      kind: 'liquidity' as const,
-      createdAt: liquidityEvent.createdAt,
-      liquidityEvent,
-    })),
-  ].sort(compareMarketHistoryEvents);
+	[
+		...market.trades.map((trade) => ({
+			kind: "trade" as const,
+			createdAt: trade.createdAt,
+			trade,
+		})),
+		...market.liquidityEvents.map((liquidityEvent) => ({
+			kind: "liquidity" as const,
+			createdAt: liquidityEvent.createdAt,
+			liquidityEvent,
+		})),
+	].sort(compareMarketHistoryEvents);
 
 export const buildForecastRecordsForMarket = (
-  market: MarketWithRelations,
+	market: MarketWithRelations,
 ): Array<{
-  userId: string;
-  resolvedAt: Date;
-  marketTagSnapshot: string[];
-  forecastVector: MarketForecastVectorEntry[];
-  winningOutcomeId: string;
-  winningOutcomeProbability: number;
-  predictedOutcomeId: string;
-  brierScore: number;
-  wasCorrect: boolean;
-  realizedProfit: number;
-  tradeCount: number;
-  stakeWeight: number;
+	userId: string;
+	resolvedAt: Date;
+	marketTagSnapshot: string[];
+	forecastVector: MarketForecastVectorEntry[];
+	resolutionVector: number[];
+	winningOutcomeId: string;
+	winningOutcomeProbability: number;
+	predictedOutcomeId: string;
+	brierScore: number;
+	wasCorrect: boolean;
+	realizedProfit: number;
+	tradeCount: number;
+	stakeWeight: number;
 }> => {
-  if (!market.resolvedAt || market.cancelledAt || !market.winningOutcomeId) {
-    return [];
-  }
+	if (!market.resolvedAt || market.cancelledAt) {
+		return [];
+	}
 
-  const resolvedAt = market.resolvedAt;
-  const winningOutcomeId = market.winningOutcomeId;
-  const tradeCutoff = market.tradingClosedAt ?? market.closeAt;
-  const tradesByUser = new Map<string, RunningForecastState>();
-  const pricingSharesByOutcomeId = new Map<string, number>(
-    market.outcomes.map((outcome) => [outcome.id, 0]),
-  );
-  let liquidityParameter = market.baseLiquidityParameter;
+	const resolvedAt = market.resolvedAt;
+	const winningOutcomeId =
+		market.winningOutcomeId ?? market.outcomes[0]?.id ?? "unknown";
+	const tradeCutoff = market.tradingClosedAt ?? market.closeAt;
+	const tradesByUser = new Map<string, RunningForecastState>();
+	const pricingSharesByOutcomeId = new Map<string, number>(
+		market.outcomes.map((outcome) => [outcome.id, 0]),
+	);
+	let liquidityParameter = market.baseLiquidityParameter;
 
-  for (const event of buildMarketHistory(market)) {
-    if (event.createdAt.getTime() > tradeCutoff.getTime()) {
-      continue;
-    }
+	for (const event of buildMarketHistory(market)) {
+		if (event.createdAt.getTime() > tradeCutoff.getTime()) {
+			continue;
+		}
 
-    if (event.kind === 'liquidity') {
-      liquidityParameter = event.liquidityEvent.nextLiquidityParameter;
-      for (const outcome of market.outcomes) {
-        if (outcome.resolvedAt && outcome.resolvedAt.getTime() <= event.createdAt.getTime()) {
-          continue;
-        }
+		if (event.kind === "liquidity") {
+			liquidityParameter = event.liquidityEvent.nextLiquidityParameter;
+			for (const outcome of market.outcomes) {
+				if (
+					outcome.resolvedAt &&
+					outcome.resolvedAt.getTime() <= event.createdAt.getTime()
+				) {
+					continue;
+				}
 
-        pricingSharesByOutcomeId.set(
-          outcome.id,
-          clampSmall((pricingSharesByOutcomeId.get(outcome.id) ?? 0) * event.liquidityEvent.scaleFactor),
-        );
-      }
+				pricingSharesByOutcomeId.set(
+					outcome.id,
+					clampSmall(
+						(pricingSharesByOutcomeId.get(outcome.id) ?? 0) *
+							event.liquidityEvent.scaleFactor,
+					),
+				);
+			}
 
-      continue;
-    }
+			continue;
+		}
 
-    const { trade } = event;
-    const weight = Math.abs(trade.cashDelta);
-    let state = tradesByUser.get(trade.userId);
-    if (!state) {
-      state = {
-        tradeCount: 0,
-        stakeWeight: 0,
-        weightedProbabilities: new Map(),
-      };
-      tradesByUser.set(trade.userId, state);
-    }
+		const { trade } = event;
+		const weight = Math.abs(trade.cashDelta);
+		let state = tradesByUser.get(trade.userId);
+		if (!state) {
+			state = {
+				tradeCount: 0,
+				stakeWeight: 0,
+				weightedProbabilities: new Map(),
+			};
+			tradesByUser.set(trade.userId, state);
+		}
 
-    pricingSharesByOutcomeId.set(
-      trade.outcomeId,
-      clampSmall((pricingSharesByOutcomeId.get(trade.outcomeId) ?? 0) + trade.shareDelta),
-    );
-    const probabilityVector = buildHistoricalProbabilityVector(
-      market,
-      pricingSharesByOutcomeId,
-      liquidityParameter,
-      trade.createdAt,
-    );
-    state.tradeCount += 1;
-    state.stakeWeight += weight;
-    for (const probabilityEntry of probabilityVector) {
-      const existing = state.weightedProbabilities.get(probabilityEntry.outcomeId) ?? { weightedSum: 0, weight: 0 };
-      existing.weightedSum += probabilityEntry.probability * weight;
-      existing.weight += weight;
-      state.weightedProbabilities.set(probabilityEntry.outcomeId, existing);
-    }
-  }
+		pricingSharesByOutcomeId.set(
+			trade.outcomeId,
+			clampSmall(
+				(pricingSharesByOutcomeId.get(trade.outcomeId) ?? 0) + trade.shareDelta,
+			),
+		);
+		const probabilityVector = buildHistoricalProbabilityVector(
+			market,
+			pricingSharesByOutcomeId,
+			liquidityParameter,
+			trade.createdAt,
+		);
+		state.tradeCount += 1;
+		state.stakeWeight += weight;
+		for (const probabilityEntry of probabilityVector) {
+			const existing = state.weightedProbabilities.get(
+				probabilityEntry.outcomeId,
+			) ?? { weightedSum: 0, weight: 0 };
+			existing.weightedSum += probabilityEntry.probability * weight;
+			existing.weight += weight;
+			state.weightedProbabilities.set(probabilityEntry.outcomeId, existing);
+		}
+	}
 
-  const profits = reconstructMarketProfitByUser(market);
-  if (market.supplementaryBonusDistributedAt && market.supplementaryBonusPool > 1e-6) {
-    const bonuses = computeSupplementaryBonusDistribution(profits, market.supplementaryBonusPool);
-    for (const [userId, bonus] of bonuses) {
-      profits.set(userId, roundCurrency((profits.get(userId) ?? 0) + bonus));
-    }
-  }
-  const actualVector = market.outcomes.map((outcome) => outcome.id === winningOutcomeId ? 1 : 0);
+	const profits = reconstructMarketProfitByUser(market);
+	if (
+		market.supplementaryBonusDistributedAt &&
+		market.supplementaryBonusPool > 1e-6
+	) {
+		const bonuses = computeSupplementaryBonusDistribution(
+			profits,
+			market.supplementaryBonusPool,
+		);
+		for (const [userId, bonus] of bonuses) {
+			profits.set(userId, roundCurrency((profits.get(userId) ?? 0) + bonus));
+		}
+	}
+	const actualVector = getMarketResolutionVector(market);
+	const bestResolutionValue = actualVector.reduce(
+		(max, value) => Math.max(max, value),
+		0,
+	);
 
-  return [...tradesByUser.entries()].flatMap(([userId, state]) => {
-    if (state.tradeCount < minimumForecastTradeCount || state.stakeWeight < minimumForecastStakeWeight) {
-      return [];
-    }
+	return [...tradesByUser.entries()].flatMap(([userId, state]) => {
+		if (
+			state.tradeCount < minimumForecastTradeCount ||
+			state.stakeWeight < minimumForecastStakeWeight
+		) {
+			return [];
+		}
 
-    const forecastVector = normalizeForecastVector(market, state.weightedProbabilities);
-    if (!forecastVector) {
-      return [];
-    }
+		const forecastVector = normalizeForecastVector(
+			market,
+			state.weightedProbabilities,
+		);
+		if (!forecastVector) {
+			return [];
+		}
 
-    let predictedOutcomeId = market.outcomes[0]?.id ?? winningOutcomeId;
-    let highestProbability = -1;
-    for (const outcome of market.outcomes) {
-      const probability = forecastVector.find((entry) => entry.outcomeId === outcome.id)?.probability ?? 0;
-      if (probability > highestProbability) {
-        highestProbability = probability;
-        predictedOutcomeId = outcome.id;
-      }
-    }
+		let predictedOutcomeId = market.outcomes[0]?.id ?? winningOutcomeId;
+		let highestProbability = -1;
+		for (const outcome of market.outcomes) {
+			const probability =
+				forecastVector.find((entry) => entry.outcomeId === outcome.id)
+					?.probability ?? 0;
+			if (probability > highestProbability) {
+				highestProbability = probability;
+				predictedOutcomeId = outcome.id;
+			}
+		}
 
-    const brierScore = roundProbability(forecastVector.reduce((sum, entry, index) => {
-      const actual = actualVector[index] ?? 0;
-      return sum + ((entry.probability - actual) ** 2);
-    }, 0) / market.outcomes.length);
-    const winningOutcomeProbability = forecastVector.find((entry) => entry.outcomeId === winningOutcomeId)?.probability ?? 0;
+		const brierScore = roundProbability(
+			forecastVector.reduce((sum, entry, index) => {
+				const actual = actualVector[index] ?? 0;
+				return sum + (entry.probability - actual) ** 2;
+			}, 0) / market.outcomes.length,
+		);
+		const winningOutcomeProbability =
+			forecastVector.find((entry) => entry.outcomeId === winningOutcomeId)
+				?.probability ?? 0;
 
-    return [{
-      userId,
-      resolvedAt,
-      marketTagSnapshot: [...market.tags],
-      forecastVector,
-      winningOutcomeId,
-      winningOutcomeProbability: roundProbability(winningOutcomeProbability),
-      predictedOutcomeId,
-      brierScore,
-      wasCorrect: predictedOutcomeId === winningOutcomeId,
-      realizedProfit: profits.get(userId) ?? 0,
-      tradeCount: state.tradeCount,
-      stakeWeight: roundCurrency(state.stakeWeight),
-    }];
-  });
+		const wasCorrect =
+			bestResolutionValue <= 1e-6
+				? false
+				: (actualVector[
+						market.outcomes.findIndex(
+							(outcome) => outcome.id === predictedOutcomeId,
+						)
+					] ?? 0) >=
+					bestResolutionValue - 1e-6;
+
+		return [
+			{
+				userId,
+				resolvedAt,
+				marketTagSnapshot: [...market.tags],
+				forecastVector,
+				resolutionVector: [...actualVector],
+				winningOutcomeId,
+				winningOutcomeProbability: roundProbability(winningOutcomeProbability),
+				predictedOutcomeId,
+				brierScore,
+				wasCorrect,
+				realizedProfit: profits.get(userId) ?? 0,
+				tradeCount: state.tradeCount,
+				stakeWeight: roundCurrency(state.stakeWeight),
+			},
+		];
+	});
 };

--- a/src/features/markets/services/lifecycle.ts
+++ b/src/features/markets/services/lifecycle.ts
@@ -370,7 +370,7 @@ export const notifyMarketCancelled = async (
 						buildMarketStatusEmbed(
 							"Market Cancelled",
 							[
-								`**${market.title}** was cancelled and your open position${refund.positionCount === 1 ? "" : "s"} were refunded.`,
+								`**${market.title}** was cancelled and your open position${refund.positionCount === 1 ? "" : "s"} ${refund.positionCount === 1 ? "was" : "were"} refunded.`,
 								`Refund amount: **${refund.refundAmount.toFixed(2)} pts**`,
 								refund.protectionRefund > 0
 									? `Includes protection premium refund: **${refund.protectionRefund.toFixed(2)} pts**`

--- a/src/features/markets/services/lifecycle.ts
+++ b/src/features/markets/services/lifecycle.ts
@@ -1,431 +1,568 @@
-import { ChannelType, type Client, type ForumChannel, type Message } from 'discord.js';
+import {
+	ChannelType,
+	type Client,
+	type ForumChannel,
+	type Message,
+} from "discord.js";
 
-import { logger } from '../../../app/logger.js';
-import { prisma } from '../../../lib/prisma.js';
+import { logger } from "../../../app/logger.js";
+import { prisma } from "../../../lib/prisma.js";
 import {
-  buildMarketDetailsEmbed,
-  buildMarketEmbed,
-  buildMarketMessage,
-  buildMarketResolvePrompt,
-  buildMarketStatusEmbed,
-} from '../ui/render/market.js';
+	buildMarketDetailsEmbed,
+	buildMarketEmbed,
+	buildMarketMessage,
+	buildMarketResolvePrompt,
+	buildMarketStatusEmbed,
+} from "../ui/render/market.js";
+import { attachMarketPublication, getMarketById } from "./records.js";
 import {
-  attachMarketPublication,
-  getMarketById,
-} from './records.js';
-import {
-  clearMarketJobs,
-  scheduleMarketClose,
-  scheduleMarketGrace,
-  scheduleMarketLiquidity,
-} from './scheduler.js';
-import { injectMarketLiquidity } from './liquidity.js';
-import { closeMarketTrading } from './trading/close.js';
-import type { MarketWithRelations } from '../core/types.js';
-import type { MarketResolutionResult } from '../core/types.js';
-import { buildMarketDiagram } from '../ui/visualize.js';
+	clearMarketJobs,
+	scheduleMarketClose,
+	scheduleMarketGrace,
+	scheduleMarketLiquidity,
+} from "./scheduler.js";
+import { injectMarketLiquidity } from "./liquidity.js";
+import { closeMarketTrading } from "./trading/close.js";
+import type { MarketWithRelations } from "../core/types.js";
+import type { MarketResolutionResult } from "../core/types.js";
+import type { MarketCancellationRefund } from "../core/types.js";
+import { buildMarketDiagram } from "../ui/visualize.js";
 
 const buildMarketMessagePayload = async (
-  market: MarketWithRelations,
-  options?: {
-    replaceAttachments?: boolean;
-  },
+	market: MarketWithRelations,
+	options?: {
+		replaceAttachments?: boolean;
+	},
 ) => {
-  const payload = buildMarketMessage(market);
-  try {
-    const chart = await buildMarketDiagram(market);
-    payload.embeds[0].setImage(`attachment://${chart.fileName}`);
-    return {
-      ...payload,
-      files: [chart.attachment],
-      ...(options?.replaceAttachments ? { attachments: [] } : {}),
-    };
-  } catch (error) {
-    logger.warn({ err: error, marketId: market.id }, 'Could not generate market diagram');
-    return {
-      ...payload,
-      ...(options?.replaceAttachments ? { attachments: [] } : {}),
-    };
-  }
+	const payload = buildMarketMessage(market);
+	try {
+		const chart = await buildMarketDiagram(market);
+		payload.embeds[0].setImage(`attachment://${chart.fileName}`);
+		return {
+			...payload,
+			files: [chart.attachment],
+			...(options?.replaceAttachments ? { attachments: [] } : {}),
+		};
+	} catch (error) {
+		logger.warn(
+			{ err: error, marketId: market.id },
+			"Could not generate market diagram",
+		);
+		return {
+			...payload,
+			...(options?.replaceAttachments ? { attachments: [] } : {}),
+		};
+	}
 };
 
 const getMarketForumChannel = async (
-  client: Client,
-  channelId: string,
+	client: Client,
+	channelId: string,
 ): Promise<ForumChannel> => {
-  const channel = await client.channels.fetch(channelId).catch(() => null);
-  if (!channel || channel.type !== ChannelType.GuildForum) {
-    throw new Error('Configured market channel is not a forum channel.');
-  }
+	const channel = await client.channels.fetch(channelId).catch(() => null);
+	if (!channel || channel.type !== ChannelType.GuildForum) {
+		throw new Error("Configured market channel is not a forum channel.");
+	}
 
-  return channel;
+	return channel;
 };
 
 export const createMarketForumPost = async (
-  client: Client,
-  market: MarketWithRelations,
+	client: Client,
+	market: MarketWithRelations,
 ): Promise<{
-  messageId: string;
-  starterMessage: Message<true>;
-  threadId: string;
-  threadUrl: string;
-  url: string;
+	messageId: string;
+	starterMessage: Message<true>;
+	threadId: string;
+	threadUrl: string;
+	url: string;
 }> => {
-  const forumChannel = await getMarketForumChannel(client, market.marketChannelId);
-  const thread = await forumChannel.threads.create({
-    name: resolveMarketThreadName(market.title),
-    message: {
-      ...(await buildMarketMessagePayload(market)),
-      allowedMentions: {
-        parse: [],
-      },
-    },
-  });
-  const starterMessage = await thread.fetchStarterMessage().catch(() => null);
-  if (!starterMessage) {
-    await thread.delete().catch((error) => {
-      logger.warn({ err: error, marketId: market.id, threadId: thread.id }, 'Could not delete partially published market forum post');
-    });
-    throw new Error('Could not fetch the forum post starter message.');
-  }
+	const forumChannel = await getMarketForumChannel(
+		client,
+		market.marketChannelId,
+	);
+	const thread = await forumChannel.threads.create({
+		name: resolveMarketThreadName(market.title),
+		message: {
+			...(await buildMarketMessagePayload(market)),
+			allowedMentions: {
+				parse: [],
+			},
+		},
+	});
+	const starterMessage = await thread.fetchStarterMessage().catch(() => null);
+	if (!starterMessage) {
+		await thread.delete().catch((error) => {
+			logger.warn(
+				{ err: error, marketId: market.id, threadId: thread.id },
+				"Could not delete partially published market forum post",
+			);
+		});
+		throw new Error("Could not fetch the forum post starter message.");
+	}
 
-  return {
-    messageId: starterMessage.id,
-    starterMessage,
-    threadId: thread.id,
-    threadUrl: thread.url,
-    url: thread.url,
-  };
+	return {
+		messageId: starterMessage.id,
+		starterMessage,
+		threadId: thread.id,
+		threadUrl: thread.url,
+		url: thread.url,
+	};
 };
 
 export const hydrateMarketMessage = async (
-  client: Client,
-  market: MarketWithRelations,
-): Promise<{ messageId: string; url: string; threadCreated: boolean; threadId: string | null; threadUrl: string | null }> => {
-  let published:
-    | Awaited<ReturnType<typeof createMarketForumPost>>
-    | null = null;
-  try {
-    published = await createMarketForumPost(client, market);
-    await attachMarketPublication(market.id, {
-      marketChannelId: market.marketChannelId,
-      messageId: published.messageId,
-      threadId: published.threadId,
-    });
-    await scheduleMarketClose(market);
-    await scheduleMarketLiquidity(market);
-    return {
-      messageId: published.messageId,
-      url: published.url,
-      threadCreated: true,
-      threadId: published.threadId,
-      threadUrl: published.threadUrl,
-    };
-  } catch (error) {
-    if (published) {
-      const forumThread = await client.channels.fetch(published.threadId).catch(() => null);
-      if (forumThread?.isThread()) {
-        await forumThread.delete().catch((deleteError) => {
-          logger.warn({ err: deleteError, marketId: market.id, threadId: published?.threadId }, 'Could not delete partially published market forum post');
-        });
-      }
-    }
-    throw error;
-  }
+	client: Client,
+	market: MarketWithRelations,
+): Promise<{
+	messageId: string;
+	url: string;
+	threadCreated: boolean;
+	threadId: string | null;
+	threadUrl: string | null;
+}> => {
+	let published: Awaited<ReturnType<typeof createMarketForumPost>> | null =
+		null;
+	try {
+		published = await createMarketForumPost(client, market);
+		await attachMarketPublication(market.id, {
+			marketChannelId: market.marketChannelId,
+			messageId: published.messageId,
+			threadId: published.threadId,
+		});
+		await scheduleMarketClose(market);
+		await scheduleMarketLiquidity(market);
+		return {
+			messageId: published.messageId,
+			url: published.url,
+			threadCreated: true,
+			threadId: published.threadId,
+			threadUrl: published.threadUrl,
+		};
+	} catch (error) {
+		if (published) {
+			const forumThread = await client.channels
+				.fetch(published.threadId)
+				.catch(() => null);
+			if (forumThread?.isThread()) {
+				await forumThread.delete().catch((deleteError) => {
+					logger.warn(
+						{
+							err: deleteError,
+							marketId: market.id,
+							threadId: published?.threadId,
+						},
+						"Could not delete partially published market forum post",
+					);
+				});
+			}
+		}
+		throw error;
+	}
 };
 
 const resolveMarketThreadName = (title: string): string => {
-  const normalized = title.trim().replace(/\s+/g, ' ') || 'Market discussion';
-  return normalized.length > 100 ? normalized.slice(0, 100) : normalized;
+	const normalized = title.trim().replace(/\s+/g, " ") || "Market discussion";
+	return normalized.length > 100 ? normalized.slice(0, 100) : normalized;
 };
 
 const getMarketStarterMessage = async (
-  client: Client,
-  market: Pick<MarketWithRelations, 'marketChannelId' | 'messageId' | 'threadId'>,
+	client: Client,
+	market: Pick<
+		MarketWithRelations,
+		"marketChannelId" | "messageId" | "threadId"
+	>,
 ): Promise<Message<boolean> | null> => {
-  if (market.threadId) {
-    const thread = await client.channels.fetch(market.threadId).catch(() => null);
-    if (thread?.isThread()) {
-      const starterMessage = await thread.fetchStarterMessage().catch(() => null);
-      if (starterMessage) {
-        return starterMessage;
-      }
-    }
-  }
+	if (market.threadId) {
+		const thread = await client.channels
+			.fetch(market.threadId)
+			.catch(() => null);
+		if (thread?.isThread()) {
+			const starterMessage = await thread
+				.fetchStarterMessage()
+				.catch(() => null);
+			if (starterMessage) {
+				return starterMessage;
+			}
+		}
+	}
 
-  if (!market.messageId) {
-    return null;
-  }
+	if (!market.messageId) {
+		return null;
+	}
 
-  const channel = await client.channels.fetch(market.marketChannelId).catch(() => null);
-  if (!channel?.isTextBased() || !('messages' in channel)) {
-    return null;
-  }
+	const channel = await client.channels
+		.fetch(market.marketChannelId)
+		.catch(() => null);
+	if (!channel?.isTextBased() || !("messages" in channel)) {
+		return null;
+	}
 
-  return channel.messages.fetch(market.messageId).catch(() => null);
+	return channel.messages.fetch(market.messageId).catch(() => null);
 };
 
-export const refreshMarketMessage = async (client: Client, marketId: string): Promise<void> => {
-  const market = await getMarketById(marketId);
-  if (!market) {
-    return;
-  }
+export const refreshMarketMessage = async (
+	client: Client,
+	marketId: string,
+): Promise<void> => {
+	const market = await getMarketById(marketId);
+	if (!market) {
+		return;
+	}
 
-  const message = await getMarketStarterMessage(client, market);
-  if (!message) {
-    return;
-  }
+	const message = await getMarketStarterMessage(client, market);
+	if (!message) {
+		return;
+	}
 
-  await message.edit({
-    ...(await buildMarketMessagePayload(market, {
-      replaceAttachments: true,
-    })),
-    allowedMentions: {
-      parse: [],
-    },
-  });
+	await message.edit({
+		...(await buildMarketMessagePayload(market, {
+			replaceAttachments: true,
+		})),
+		allowedMentions: {
+			parse: [],
+		},
+	});
 };
 
 const getMarketAnnouncementChannel = async (
-  client: Client,
-  market: Pick<MarketWithRelations, 'threadId' | 'marketChannelId'>,
+	client: Client,
+	market: Pick<MarketWithRelations, "threadId" | "marketChannelId">,
 ) => {
-  if (market.threadId) {
-    const thread = await client.channels.fetch(market.threadId).catch(() => null);
-    if (thread?.isTextBased() && 'send' in thread) {
-      return thread;
-    }
-  }
+	if (market.threadId) {
+		const thread = await client.channels
+			.fetch(market.threadId)
+			.catch(() => null);
+		if (thread?.isTextBased() && "send" in thread) {
+			return thread;
+		}
+	}
 
-  const channel = await client.channels.fetch(market.marketChannelId).catch(() => null);
-  if (channel?.isTextBased() && 'send' in channel) {
-    return channel;
-  }
+	const channel = await client.channels
+		.fetch(market.marketChannelId)
+		.catch(() => null);
+	if (channel?.isTextBased() && "send" in channel) {
+		return channel;
+	}
 
-  return null;
+	return null;
 };
 
 export const announceMarketUpdate = async (
-  client: Client,
-  market: MarketWithRelations,
-  title: string,
-  description: string,
-  color = 0x60a5fa,
+	client: Client,
+	market: MarketWithRelations,
+	title: string,
+	description: string,
+	color = 0x60a5fa,
 ): Promise<void> => {
-  const channel = await getMarketAnnouncementChannel(client, market);
-  if (!channel) {
-    return;
-  }
+	const channel = await getMarketAnnouncementChannel(client, market);
+	if (!channel) {
+		return;
+	}
 
-  await channel.send({
-    embeds: [buildMarketStatusEmbed(title, description, color)],
-    allowedMentions: {
-      parse: [],
-    },
-  }).catch((error) => {
-    logger.warn({ err: error, marketId: market.id }, 'Could not announce market update');
-  });
+	await channel
+		.send({
+			embeds: [buildMarketStatusEmbed(title, description, color)],
+			allowedMentions: {
+				parse: [],
+			},
+		})
+		.catch((error) => {
+			logger.warn(
+				{ err: error, marketId: market.id },
+				"Could not announce market update",
+			);
+		});
 };
 
 export const notifyMarketResolved = async (
-  client: Client,
-  resolved: MarketResolutionResult,
+	client: Client,
+	resolved: MarketResolutionResult,
 ): Promise<void> => {
-  await announceMarketUpdate(
-    client,
-    resolved.market,
-    'Market Resolved',
-    [
-      `**${resolved.market.title}** resolved in favor of **${resolved.market.winningOutcome?.label ?? 'Unknown'}**.`,
-      resolved.market.resolutionNote ? `Note: ${resolved.market.resolutionNote}` : null,
-      resolved.market.resolutionEvidenceUrl ? `Evidence: ${resolved.market.resolutionEvidenceUrl}` : null,
-      `Resolved ${resolved.payouts.length} portfolio${resolved.payouts.length === 1 ? '' : 's'}.`,
-    ].filter(Boolean).join('\n'),
-    0x57f287,
-  );
+	await announceMarketUpdate(
+		client,
+		resolved.market,
+		"Market Resolved",
+		[
+			`**${resolved.market.title}** resolved in favor of **${resolved.market.winningOutcome?.label ?? "Unknown"}**.`,
+			resolved.market.resolutionNote
+				? `Note: ${resolved.market.resolutionNote}`
+				: null,
+			resolved.market.resolutionEvidenceUrl
+				? `Evidence: ${resolved.market.resolutionEvidenceUrl}`
+				: null,
+			`Resolved ${resolved.payouts.length} portfolio${resolved.payouts.length === 1 ? "" : "s"}.`,
+		]
+			.filter(Boolean)
+			.join("\n"),
+		0x57f287,
+	);
 
-  await Promise.all(resolved.payouts.map(async (payout) => {
-    const user = await client.users.fetch(payout.userId).catch(() => null);
-    if (!user) {
-      return;
-    }
+	await Promise.all(
+		resolved.payouts.map(async (payout) => {
+			const user = await client.users.fetch(payout.userId).catch(() => null);
+			if (!user) {
+				return;
+			}
 
-    const positionLines = payout.positions.length === 0
-      ? 'You had no open positions left in this market.'
-      : payout.positions.map((position) =>
-        position.side === 'long'
-          ? `• LONG ${position.outcomeLabel}: ${position.shares.toFixed(2)} shares (${position.costBasis.toFixed(2)} pts basis)`
-          : `• SHORT ${position.outcomeLabel}: ${position.shares.toFixed(2)} shares (${position.proceeds.toFixed(2)} pts proceeds, ${position.collateralLocked.toFixed(2)} pts locked)`,
-      ).join('\n');
+			const positionLines =
+				payout.positions.length === 0
+					? "You had no open positions left in this market."
+					: payout.positions
+							.map((position) =>
+								position.side === "long"
+									? `• LONG ${position.outcomeLabel}: ${position.shares.toFixed(2)} shares (${position.costBasis.toFixed(2)} pts basis)`
+									: `• SHORT ${position.outcomeLabel}: ${position.shares.toFixed(2)} shares (${position.proceeds.toFixed(2)} pts proceeds, ${position.collateralLocked.toFixed(2)} pts locked)`,
+							)
+							.join("\n");
 
-    await user.send({
-      embeds: [
-        buildMarketStatusEmbed(
-          'Your Market Position Resolved',
-          [
-            `**${resolved.market.title}** resolved in favor of **${resolved.market.winningOutcome?.label ?? 'Unknown'}**.`,
-            '',
-            'Your positions in this market:',
-            positionLines,
-            '',
-            `Payout: **${payout.payout.toFixed(2)} pts**`,
-            `Realized profit: **${payout.profit.toFixed(2)} pts**`,
-            payout.bonus > 0 ? `Bonus: **${payout.bonus.toFixed(2)} pts**` : null,
-            `Market ID: \`${resolved.market.id}\``,
-          ].filter(Boolean).join('\n'),
-          0x57f287,
-        ),
-      ],
-      allowedMentions: {
-        parse: [],
-      },
-    }).catch((error) => {
-      logger.warn({ err: error, marketId: resolved.market.id, userId: payout.userId }, 'Could not DM market resolution notice');
-    });
-  }));
+			await user
+				.send({
+					embeds: [
+						buildMarketStatusEmbed(
+							"Your Market Position Resolved",
+							[
+								`**${resolved.market.title}** resolved in favor of **${resolved.market.winningOutcome?.label ?? "Unknown"}**.`,
+								"",
+								"Your positions in this market:",
+								positionLines,
+								"",
+								`Payout: **${payout.payout.toFixed(2)} pts**`,
+								`Realized profit: **${payout.profit.toFixed(2)} pts**`,
+								payout.bonus > 0
+									? `Bonus: **${payout.bonus.toFixed(2)} pts**`
+									: null,
+								`Market ID: \`${resolved.market.id}\``,
+							]
+								.filter(Boolean)
+								.join("\n"),
+							0x57f287,
+						),
+					],
+					allowedMentions: {
+						parse: [],
+					},
+				})
+				.catch((error) => {
+					logger.warn(
+						{ err: error, marketId: resolved.market.id, userId: payout.userId },
+						"Could not DM market resolution notice",
+					);
+				});
+		}),
+	);
 };
 
-const sendCreatorClosePrompt = async (client: Client, market: MarketWithRelations): Promise<void> => {
-  const creator = await client.users.fetch(market.creatorId).catch(() => null);
-  if (!creator) {
-    return;
-  }
+export const notifyMarketCancelled = async (
+	client: Client,
+	market: MarketWithRelations,
+	refunds: MarketCancellationRefund[],
+): Promise<void> => {
+	await Promise.all(
+		refunds.map(async (refund) => {
+			const user = await client.users.fetch(refund.userId).catch(() => null);
+			if (!user) {
+				return;
+			}
 
-  await creator.send({
-    ...buildMarketResolvePrompt(market),
-    allowedMentions: {
-      parse: [],
-    },
-  }).catch((error) => {
-    logger.warn({ err: error, marketId: market.id }, 'Could not DM market creator');
-  });
+			await user
+				.send({
+					embeds: [
+						buildMarketStatusEmbed(
+							"Market Cancelled",
+							[
+								`**${market.title}** was cancelled and your open position${refund.positionCount === 1 ? "" : "s"} were refunded.`,
+								`Refund amount: **${refund.refundAmount.toFixed(2)} pts**`,
+								refund.protectionRefund > 0
+									? `Includes protection premium refund: **${refund.protectionRefund.toFixed(2)} pts**`
+									: null,
+								`Market ID: \`${market.id}\``,
+							]
+								.filter(Boolean)
+								.join("\n"),
+							0xf59e0b,
+						),
+					],
+					allowedMentions: {
+						parse: [],
+					},
+				})
+				.catch((error) => {
+					logger.warn(
+						{ err: error, marketId: market.id, userId: refund.userId },
+						"Could not DM market cancellation notice",
+					);
+				});
+		}),
+	);
+};
+
+const sendCreatorClosePrompt = async (
+	client: Client,
+	market: MarketWithRelations,
+): Promise<void> => {
+	const creator = await client.users.fetch(market.creatorId).catch(() => null);
+	if (!creator) {
+		return;
+	}
+
+	await creator
+		.send({
+			...buildMarketResolvePrompt(market),
+			allowedMentions: {
+				parse: [],
+			},
+		})
+		.catch((error) => {
+			logger.warn(
+				{ err: error, marketId: market.id },
+				"Could not DM market creator",
+			);
+		});
 };
 
 export const closeMarketAndNotify = async (
-  client: Client,
-  marketId: string,
+	client: Client,
+	marketId: string,
 ): Promise<void> => {
-  const { market, didClose } = await closeMarketTrading(marketId);
-  if (!market) {
-    return;
-  }
+	const { market, didClose } = await closeMarketTrading(marketId);
+	if (!market) {
+		return;
+	}
 
-  if (didClose) {
-    await scheduleMarketGrace(market);
-    await refreshMarketMessage(client, market.id);
-    await sendCreatorClosePrompt(client, market);
-  }
+	if (didClose) {
+		await scheduleMarketGrace(market);
+		await refreshMarketMessage(client, market.id);
+		await sendCreatorClosePrompt(client, market);
+	}
 };
 
 export const injectMarketLiquidityAndRefresh = async (
-  client: Client,
-  marketId: string,
+	client: Client,
+	marketId: string,
 ): Promise<void> => {
-  const { market, didInject } = await injectMarketLiquidity(marketId);
-  if (!market) {
-    return;
-  }
+	const { market, didInject } = await injectMarketLiquidity(marketId);
+	if (!market) {
+		return;
+	}
 
-  await scheduleMarketLiquidity(market);
-  if (didInject) {
-    await refreshMarketMessage(client, market.id);
-  }
+	await scheduleMarketLiquidity(market);
+	if (didInject) {
+		await refreshMarketMessage(client, market.id);
+	}
 };
 
 export const recoverExpiredMarkets = async (client: Client): Promise<void> => {
-  const markets = await prisma.market.findMany({
-    where: {
-      tradingClosedAt: null,
-      resolvedAt: null,
-      cancelledAt: null,
-      closeAt: {
-        lte: new Date(),
-      },
-    },
-    select: {
-      id: true,
-    },
-  });
+	const markets = await prisma.market.findMany({
+		where: {
+			tradingClosedAt: null,
+			resolvedAt: null,
+			cancelledAt: null,
+			closeAt: {
+				lte: new Date(),
+			},
+		},
+		select: {
+			id: true,
+		},
+	});
 
-  await Promise.all(markets.map((market) => closeMarketAndNotify(client, market.id)));
+	await Promise.all(
+		markets.map((market) => closeMarketAndNotify(client, market.id)),
+	);
 };
 
-export const sendMarketGraceNotice = async (client: Client, marketId: string): Promise<void> => {
-  const market = await getMarketById(marketId);
-  if (!market || market.resolvedAt || market.cancelledAt || !market.resolutionGraceEndsAt || market.graceNotifiedAt) {
-    return;
-  }
+export const sendMarketGraceNotice = async (
+	client: Client,
+	marketId: string,
+): Promise<void> => {
+	const market = await getMarketById(marketId);
+	if (
+		!market ||
+		market.resolvedAt ||
+		market.cancelledAt ||
+		!market.resolutionGraceEndsAt ||
+		market.graceNotifiedAt
+	) {
+		return;
+	}
 
-  const channel = await getMarketAnnouncementChannel(client, market);
-  if (!channel) {
-    return;
-  }
+	const channel = await getMarketAnnouncementChannel(client, market);
+	if (!channel) {
+		return;
+	}
 
-  try {
-    await channel.send({
-      embeds: [
-        buildMarketStatusEmbed(
-          'Market Needs Resolution',
-          `The creator has not resolved **${market.title}** within 24 hours. Moderators can now resolve or cancel it.\nMarket ID: \`${market.id}\``,
-          0xf59e0b,
-        ),
-      ],
-      allowedMentions: {
-        parse: [],
-      },
-    });
+	try {
+		await channel.send({
+			embeds: [
+				buildMarketStatusEmbed(
+					"Market Needs Resolution",
+					`The creator has not resolved **${market.title}** within 24 hours. Moderators can now resolve or cancel it.\nMarket ID: \`${market.id}\``,
+					0xf59e0b,
+				),
+			],
+			allowedMentions: {
+				parse: [],
+			},
+		});
 
-    await prisma.market.update({
-      where: {
-        id: market.id,
-      },
-      data: {
-        graceNotifiedAt: new Date(),
-      },
-    });
-  } catch (error) {
-    logger.warn({ err: error, marketId }, 'Could not send market grace notice');
-  }
+		await prisma.market.update({
+			where: {
+				id: market.id,
+			},
+			data: {
+				graceNotifiedAt: new Date(),
+			},
+		});
+	} catch (error) {
+		logger.warn({ err: error, marketId }, "Could not send market grace notice");
+	}
 };
 
-export const recoverExpiredMarketGraceNotices = async (client: Client): Promise<void> => {
-  const markets = await prisma.market.findMany({
-    where: {
-      resolvedAt: null,
-      cancelledAt: null,
-      tradingClosedAt: {
-        not: null,
-      },
-      resolutionGraceEndsAt: {
-        lte: new Date(),
-      },
-      graceNotifiedAt: null,
-    },
-    select: {
-      id: true,
-    },
-  });
+export const recoverExpiredMarketGraceNotices = async (
+	client: Client,
+): Promise<void> => {
+	const markets = await prisma.market.findMany({
+		where: {
+			resolvedAt: null,
+			cancelledAt: null,
+			tradingClosedAt: {
+				not: null,
+			},
+			resolutionGraceEndsAt: {
+				lte: new Date(),
+			},
+			graceNotifiedAt: null,
+		},
+		select: {
+			id: true,
+		},
+	});
 
-  await Promise.all(markets.map((market) => sendMarketGraceNotice(client, market.id)));
+	await Promise.all(
+		markets.map((market) => sendMarketGraceNotice(client, market.id)),
+	);
 };
 
 export const buildMarketViewResponse = async (market: MarketWithRelations) => {
-  const embed = buildMarketDetailsEmbed(market);
-  try {
-    const chart = await buildMarketDiagram(market);
-    embed.setImage(`attachment://${chart.fileName}`);
-    return {
-      embeds: [embed],
-      files: [chart.attachment],
-    };
-  } catch (error) {
-    logger.warn({ err: error, marketId: market.id }, 'Could not build market view response diagram');
-    return {
-      embeds: [embed],
-    };
-  }
+	const embed = buildMarketDetailsEmbed(market);
+	try {
+		const chart = await buildMarketDiagram(market);
+		embed.setImage(`attachment://${chart.fileName}`);
+		return {
+			embeds: [embed],
+			files: [chart.attachment],
+		};
+	} catch (error) {
+		logger.warn(
+			{ err: error, marketId: market.id },
+			"Could not build market view response diagram",
+		);
+		return {
+			embeds: [embed],
+		};
+	}
 };
 
 export const clearMarketLifecycle = async (marketId: string): Promise<void> => {
-  await clearMarketJobs(marketId);
+	await clearMarketJobs(marketId);
 };

--- a/src/features/markets/services/records.ts
+++ b/src/features/markets/services/records.ts
@@ -1,363 +1,390 @@
-import { prisma } from '../../../lib/prisma.js';
-import { parseMarketLookup } from '../parsing/market.js';
+import { prisma } from "../../../lib/prisma.js";
+import { parseMarketLookup } from "../parsing/market.js";
 import {
-  assertMarketCanAddOutcomes,
-  assertMarketEditable,
-  getMarketForUpdate,
-  liquidityParameter,
-  maxLiquidityParameter,
-  marketInclude,
-} from '../core/shared.js';
+	assertMarketCanAddOutcomes,
+	assertMarketEditable,
+	getMarketForUpdate,
+	liquidityParameter,
+	maxLiquidityParameter,
+	marketInclude,
+} from "../core/shared.js";
 import type {
-  MarketCreationInput,
-  MarketStatus,
-  MarketTraderSummary,
-  MarketWithRelations,
-} from '../core/types.js';
+	MarketCreationInput,
+	MarketStatus,
+	MarketTraderSummary,
+	MarketWithRelations,
+} from "../core/types.js";
 
-export const createMarketRecord = async (input: MarketCreationInput): Promise<MarketWithRelations> => {
-  const market = await prisma.market.create({
-    data: {
-      guildId: input.guildId,
-      creatorId: input.creatorId,
-      originChannelId: input.originChannelId,
-      marketChannelId: input.marketChannelId,
-      title: input.title,
-      description: input.description,
-      buttonStyle: input.buttonStyle,
-      tags: input.tags,
-      baseLiquidityParameter: liquidityParameter,
-      liquidityParameter,
-      maxLiquidityParameter,
-      closeAt: input.closeAt,
-      outcomes: {
-        create: input.outcomes.map((label, index) => ({
-          label,
-          sortOrder: index,
-          pricingShares: 0,
-        })),
-      },
-    },
-  });
+export const createMarketRecord = async (
+	input: MarketCreationInput,
+): Promise<MarketWithRelations> => {
+	const market = await prisma.market.create({
+		data: {
+			guildId: input.guildId,
+			creatorId: input.creatorId,
+			originChannelId: input.originChannelId,
+			marketChannelId: input.marketChannelId,
+			title: input.title,
+			description: input.description,
+			buttonStyle: input.buttonStyle,
+			contractMode: input.contractMode ?? "categorical_single_winner",
+			tags: input.tags,
+			baseLiquidityParameter: liquidityParameter,
+			liquidityParameter,
+			maxLiquidityParameter,
+			closeAt: input.closeAt,
+			outcomes: {
+				create: input.outcomes.map((label, index) => ({
+					label,
+					sortOrder: index,
+					pricingShares: 0,
+				})),
+			},
+		},
+	});
 
-  return prisma.market.findUniqueOrThrow({
-    where: {
-      id: market.id,
-    },
-    include: marketInclude,
-  });
+	return prisma.market.findUniqueOrThrow({
+		where: {
+			id: market.id,
+		},
+		include: marketInclude,
+	});
 };
 
 export const deleteMarketRecord = async (marketId: string): Promise<void> => {
-  await prisma.market.delete({
-    where: {
-      id: marketId,
-    },
-  });
+	await prisma.market.delete({
+		where: {
+			id: marketId,
+		},
+	});
 };
 
 export const attachMarketMessage = async (
-  marketId: string,
-  messageId: string,
+	marketId: string,
+	messageId: string,
 ): Promise<MarketWithRelations> => {
-  await prisma.market.update({
-    where: {
-      id: marketId,
-    },
-    data: {
-      messageId,
-    },
-  });
+	await prisma.market.update({
+		where: {
+			id: marketId,
+		},
+		data: {
+			messageId,
+		},
+	});
 
-  return prisma.market.findUniqueOrThrow({
-    where: {
-      id: marketId,
-    },
-    include: marketInclude,
-  });
+	return prisma.market.findUniqueOrThrow({
+		where: {
+			id: marketId,
+		},
+		include: marketInclude,
+	});
 };
 
 export const attachMarketThread = async (
-  marketId: string,
-  threadId: string,
+	marketId: string,
+	threadId: string,
 ): Promise<MarketWithRelations> => {
-  await prisma.market.update({
-    where: {
-      id: marketId,
-    },
-    data: {
-      threadId,
-    },
-  });
+	await prisma.market.update({
+		where: {
+			id: marketId,
+		},
+		data: {
+			threadId,
+		},
+	});
 
-  return prisma.market.findUniqueOrThrow({
-    where: {
-      id: marketId,
-    },
-    include: marketInclude,
-  });
+	return prisma.market.findUniqueOrThrow({
+		where: {
+			id: marketId,
+		},
+		include: marketInclude,
+	});
 };
 
 export const attachMarketPublication = async (
-  marketId: string,
-  input: {
-    marketChannelId: string;
-    messageId: string;
-    threadId: string;
-  },
+	marketId: string,
+	input: {
+		marketChannelId: string;
+		messageId: string;
+		threadId: string;
+	},
 ): Promise<MarketWithRelations> => {
-  await prisma.market.update({
-    where: {
-      id: marketId,
-    },
-    data: {
-      marketChannelId: input.marketChannelId,
-      messageId: input.messageId,
-      threadId: input.threadId,
-    },
-  });
+	await prisma.market.update({
+		where: {
+			id: marketId,
+		},
+		data: {
+			marketChannelId: input.marketChannelId,
+			messageId: input.messageId,
+			threadId: input.threadId,
+		},
+	});
 
-  return prisma.market.findUniqueOrThrow({
-    where: {
-      id: marketId,
-    },
-    include: marketInclude,
-  });
+	return prisma.market.findUniqueOrThrow({
+		where: {
+			id: marketId,
+		},
+		include: marketInclude,
+	});
 };
 
-export const getMarketById = async (marketId: string): Promise<MarketWithRelations | null> =>
-  prisma.market.findUnique({
-    where: {
-      id: marketId,
-    },
-    include: marketInclude,
-  });
+export const getMarketById = async (
+	marketId: string,
+): Promise<MarketWithRelations | null> =>
+	prisma.market.findUnique({
+		where: {
+			id: marketId,
+		},
+		include: marketInclude,
+	});
 
-export const getMarketByMessageId = async (messageId: string): Promise<MarketWithRelations | null> =>
-  prisma.market.findUnique({
-    where: {
-      messageId,
-    },
-    include: marketInclude,
-  });
+export const getMarketByMessageId = async (
+	messageId: string,
+): Promise<MarketWithRelations | null> =>
+	prisma.market.findUnique({
+		where: {
+			messageId,
+		},
+		include: marketInclude,
+	});
 
-export const getMarketByQuery = async (query: string, guildId?: string): Promise<MarketWithRelations | null> => {
-  const lookup = parseMarketLookup(query);
-  const market = lookup.kind === 'market-id'
-    ? await getMarketById(lookup.value)
-    : lookup.kind === 'message-id'
-      ? await getMarketByMessageId(lookup.value)
-      : await getMarketByMessageId(lookup.messageId);
+export const getMarketByQuery = async (
+	query: string,
+	guildId?: string,
+): Promise<MarketWithRelations | null> => {
+	const lookup = parseMarketLookup(query);
+	const market =
+		lookup.kind === "market-id"
+			? await getMarketById(lookup.value)
+			: lookup.kind === "message-id"
+				? await getMarketByMessageId(lookup.value)
+				: await getMarketByMessageId(lookup.messageId);
 
-  if (guildId && market && market.guildId !== guildId) {
-    throw new Error('That market belongs to a different server.');
-  }
+	if (guildId && market && market.guildId !== guildId) {
+		throw new Error("That market belongs to a different server.");
+	}
 
-  return market;
+	return market;
 };
 
 export const editMarketRecord = async (
-  marketId: string,
-  actorId: string,
-  input: {
-    title?: string;
-    description?: string | null;
-    buttonStyle?: MarketWithRelations['buttonStyle'];
-    tags?: string[];
-    closeAt?: Date;
-    outcomes?: string[];
-  },
+	marketId: string,
+	actorId: string,
+	input: {
+		title?: string;
+		description?: string | null;
+		buttonStyle?: MarketWithRelations["buttonStyle"];
+		tags?: string[];
+		closeAt?: Date;
+		outcomes?: string[];
+	},
 ): Promise<MarketWithRelations> =>
-  prisma.$transaction(async (tx) => {
-    const market = await getMarketForUpdate(tx, marketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+	prisma.$transaction(async (tx) => {
+		const market = await getMarketForUpdate(tx, marketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
 
-    assertMarketEditable(market, actorId);
+		assertMarketEditable(market, actorId);
 
-    const hasTrades = market.trades.length > 0;
-    const editsRequireNoTrades = input.title !== undefined
-      || input.description !== undefined
-      || input.tags !== undefined
-      || input.outcomes !== undefined;
-    if (hasTrades && editsRequireNoTrades) {
-      throw new Error('After the first trade, only close time and button style can be edited.');
-    }
+		const hasTrades = market.trades.length > 0;
+		const editsRequireNoTrades =
+			input.title !== undefined ||
+			input.description !== undefined ||
+			input.tags !== undefined ||
+			input.outcomes !== undefined;
+		if (hasTrades && editsRequireNoTrades) {
+			throw new Error(
+				"After the first trade, only close time and button style can be edited.",
+			);
+		}
 
-    await tx.market.update({
-      where: {
-        id: marketId,
-      },
-      data: {
-        ...(input.title !== undefined ? { title: input.title } : {}),
-        ...(input.description !== undefined ? { description: input.description } : {}),
-        ...(input.buttonStyle !== undefined ? { buttonStyle: input.buttonStyle } : {}),
-        ...(input.tags !== undefined ? { tags: input.tags } : {}),
-        ...(input.closeAt !== undefined ? { closeAt: input.closeAt } : {}),
-      },
-    });
+		await tx.market.update({
+			where: {
+				id: marketId,
+			},
+			data: {
+				...(input.title !== undefined ? { title: input.title } : {}),
+				...(input.description !== undefined
+					? { description: input.description }
+					: {}),
+				...(input.buttonStyle !== undefined
+					? { buttonStyle: input.buttonStyle }
+					: {}),
+				...(input.tags !== undefined ? { tags: input.tags } : {}),
+				...(input.closeAt !== undefined ? { closeAt: input.closeAt } : {}),
+			},
+		});
 
-    if (input.outcomes) {
-      await tx.marketOutcome.deleteMany({
-        where: {
-          marketId,
-        },
-      });
+		if (input.outcomes) {
+			await tx.marketOutcome.deleteMany({
+				where: {
+					marketId,
+				},
+			});
 
-      await tx.market.update({
-        where: {
-          id: marketId,
-        },
-        data: {
-          outcomes: {
-          create: input.outcomes.map((label, index) => ({
-            label,
-            sortOrder: index,
-            pricingShares: 0,
-          })),
-        },
-      },
-      });
-    }
+			await tx.market.update({
+				where: {
+					id: marketId,
+				},
+				data: {
+					outcomes: {
+						create: input.outcomes.map((label, index) => ({
+							label,
+							sortOrder: index,
+							pricingShares: 0,
+						})),
+					},
+				},
+			});
+		}
 
-    return tx.market.findUniqueOrThrow({
-      where: {
-        id: marketId,
-      },
-      include: marketInclude,
-    });
-  });
+		return tx.market.findUniqueOrThrow({
+			where: {
+				id: marketId,
+			},
+			include: marketInclude,
+		});
+	});
 
 export const appendMarketOutcomes = async (
-  marketId: string,
-  actorId: string,
-  outcomes: string[],
+	marketId: string,
+	actorId: string,
+	outcomes: string[],
 ): Promise<MarketWithRelations> =>
-  prisma.$transaction(async (tx) => {
-    const market = await getMarketForUpdate(tx, marketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+	prisma.$transaction(async (tx) => {
+		const market = await getMarketForUpdate(tx, marketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
 
-    assertMarketCanAddOutcomes(market, actorId);
+		assertMarketCanAddOutcomes(market, actorId);
 
-    const normalizedLabels = new Set<string>();
-    for (const outcome of market.outcomes) {
-      normalizedLabels.add(outcome.label.trim().toLowerCase());
-    }
+		const normalizedLabels = new Set<string>();
+		for (const outcome of market.outcomes) {
+			normalizedLabels.add(outcome.label.trim().toLowerCase());
+		}
 
-    const nextOutcomes: string[] = [];
-    for (const label of outcomes) {
-      const normalized = label.trim().toLowerCase();
-      if (normalizedLabels.has(normalized)) {
-        throw new Error(`Outcome "${label}" already exists in this market.`);
-      }
+		const nextOutcomes: string[] = [];
+		for (const label of outcomes) {
+			const normalized = label.trim().toLowerCase();
+			if (normalizedLabels.has(normalized)) {
+				throw new Error(`Outcome "${label}" already exists in this market.`);
+			}
 
-      normalizedLabels.add(normalized);
-      nextOutcomes.push(label);
-    }
+			normalizedLabels.add(normalized);
+			nextOutcomes.push(label);
+		}
 
-    if ((market.outcomes.length + nextOutcomes.length) > 5) {
-      throw new Error('Markets can have at most 5 outcomes.');
-    }
+		if (market.outcomes.length + nextOutcomes.length > 5) {
+			throw new Error("Markets can have at most 5 outcomes.");
+		}
 
-    await tx.market.update({
-      where: {
-        id: marketId,
-      },
-      data: {
-        outcomes: {
-          create: nextOutcomes.map((label, index) => ({
-            label,
-            sortOrder: market.outcomes.length + index,
-            pricingShares: 0,
-          })),
-        },
-      },
-    });
+		await tx.market.update({
+			where: {
+				id: marketId,
+			},
+			data: {
+				outcomes: {
+					create: nextOutcomes.map((label, index) => ({
+						label,
+						sortOrder: market.outcomes.length + index,
+						pricingShares: 0,
+					})),
+				},
+			},
+		});
 
-    return tx.market.findUniqueOrThrow({
-      where: {
-        id: marketId,
-      },
-      include: marketInclude,
-    });
-  });
+		return tx.market.findUniqueOrThrow({
+			where: {
+				id: marketId,
+			},
+			include: marketInclude,
+		});
+	});
 
 export const listMarkets = async (input: {
-  guildId: string;
-  status?: MarketStatus;
-  creatorId?: string;
-  tag?: string;
+	guildId: string;
+	status?: MarketStatus;
+	creatorId?: string;
+	tag?: string;
 }): Promise<MarketWithRelations[]> =>
-  prisma.market.findMany({
-    where: {
-      guildId: input.guildId,
-      ...(input.creatorId ? { creatorId: input.creatorId } : {}),
-      ...(input.tag ? { tags: { has: input.tag.toLowerCase() } } : {}),
-      ...(input.status === 'open'
-        ? { tradingClosedAt: null, resolvedAt: null, cancelledAt: null }
-        : input.status === 'closed'
-          ? { tradingClosedAt: { not: null }, resolvedAt: null, cancelledAt: null }
-          : input.status === 'resolved'
-            ? { resolvedAt: { not: null } }
-            : input.status === 'cancelled'
-              ? { cancelledAt: { not: null } }
-              : {}),
-    },
-    include: marketInclude,
-    orderBy: {
-      createdAt: 'desc',
-    },
-    take: 20,
-  });
+	prisma.market.findMany({
+		where: {
+			guildId: input.guildId,
+			...(input.creatorId ? { creatorId: input.creatorId } : {}),
+			...(input.tag ? { tags: { has: input.tag.toLowerCase() } } : {}),
+			...(input.status === "open"
+				? { tradingClosedAt: null, resolvedAt: null, cancelledAt: null }
+				: input.status === "closed"
+					? {
+							tradingClosedAt: { not: null },
+							resolvedAt: null,
+							cancelledAt: null,
+						}
+					: input.status === "resolved"
+						? { resolvedAt: { not: null } }
+						: input.status === "cancelled"
+							? { cancelledAt: { not: null } }
+							: {}),
+		},
+		include: marketInclude,
+		orderBy: {
+			createdAt: "desc",
+		},
+		take: 20,
+	});
 
-export const summarizeMarketTraders = (market: MarketWithRelations): MarketTraderSummary => {
-  const entriesByUserId = new Map<string, MarketTraderSummary['entries'][number]>();
+export const summarizeMarketTraders = (
+	market: MarketWithRelations,
+): MarketTraderSummary => {
+	const entriesByUserId = new Map<
+		string,
+		MarketTraderSummary["entries"][number]
+	>();
 
-  for (const trade of market.trades) {
-    const existing = entriesByUserId.get(trade.userId);
-    const amountSpent = trade.cashDelta < 0 ? -trade.cashDelta : 0;
+	for (const trade of market.trades) {
+		const existing = entriesByUserId.get(trade.userId);
+		const amountSpent = trade.cashDelta < 0 ? -trade.cashDelta : 0;
 
-    if (!existing) {
-      entriesByUserId.set(trade.userId, {
-        userId: trade.userId,
-        amountSpent,
-        tradeCount: 1,
-        lastTradedAt: trade.createdAt,
-      });
-      continue;
-    }
+		if (!existing) {
+			entriesByUserId.set(trade.userId, {
+				userId: trade.userId,
+				amountSpent,
+				tradeCount: 1,
+				lastTradedAt: trade.createdAt,
+			});
+			continue;
+		}
 
-    existing.amountSpent += amountSpent;
-    existing.tradeCount += 1;
-    if (trade.createdAt > existing.lastTradedAt) {
-      existing.lastTradedAt = trade.createdAt;
-    }
-  }
+		existing.amountSpent += amountSpent;
+		existing.tradeCount += 1;
+		if (trade.createdAt > existing.lastTradedAt) {
+			existing.lastTradedAt = trade.createdAt;
+		}
+	}
 
-  const entries = Array.from(entriesByUserId.values()).sort((left, right) => {
-    if (right.amountSpent !== left.amountSpent) {
-      return right.amountSpent - left.amountSpent;
-    }
+	const entries = Array.from(entriesByUserId.values()).sort((left, right) => {
+		if (right.amountSpent !== left.amountSpent) {
+			return right.amountSpent - left.amountSpent;
+		}
 
-    if (right.tradeCount !== left.tradeCount) {
-      return right.tradeCount - left.tradeCount;
-    }
+		if (right.tradeCount !== left.tradeCount) {
+			return right.tradeCount - left.tradeCount;
+		}
 
-    if (right.lastTradedAt.getTime() !== left.lastTradedAt.getTime()) {
-      return right.lastTradedAt.getTime() - left.lastTradedAt.getTime();
-    }
+		if (right.lastTradedAt.getTime() !== left.lastTradedAt.getTime()) {
+			return right.lastTradedAt.getTime() - left.lastTradedAt.getTime();
+		}
 
-    return left.userId.localeCompare(right.userId);
-  });
+		return left.userId.localeCompare(right.userId);
+	});
 
-  return {
-    marketId: market.id,
-    marketTitle: market.title,
-    traderCount: entries.length,
-    totalSpent: entries.reduce((sum, entry) => sum + entry.amountSpent, 0),
-    entries,
-  };
+	return {
+		marketId: market.id,
+		marketTitle: market.title,
+		traderCount: entries.length,
+		totalSpent: entries.reduce((sum, entry) => sum + entry.amountSpent, 0),
+		entries,
+	};
 };

--- a/src/features/markets/services/trading/cancel.ts
+++ b/src/features/markets/services/trading/cancel.ts
@@ -1,98 +1,133 @@
-import type { PermissionsBitField } from 'discord.js';
+import type { PermissionsBitField } from "discord.js";
 
-import { prisma } from '../../../../lib/prisma.js';
-import { ensureMarketAccountTx } from '../account.js';
+import { prisma } from "../../../../lib/prisma.js";
+import { ensureMarketAccountTx } from "../account.js";
 import {
-  assertCanCancelMarket,
-  getMarketForUpdate,
-  marketInclude,
-  roundCurrency,
-} from '../../core/shared.js';
-import type { MarketWithRelations } from '../../core/types.js';
-import { groupPositionsByUser } from './shared.js';
+	assertCanCancelMarket,
+	getMarketForUpdate,
+	marketInclude,
+	roundCurrency,
+} from "../../core/shared.js";
+import type {
+	MarketCancellationRefund,
+	MarketWithRelations,
+} from "../../core/types.js";
+import { groupPositionsByUser } from "./shared.js";
 
 export const cancelMarket = async (input: {
-  marketId: string;
-  actorId: string;
-  reason?: string | null;
-  permissions?: PermissionsBitField | Readonly<PermissionsBitField> | null;
-}): Promise<MarketWithRelations> =>
-  prisma.$transaction(async (tx) => {
-    const market = await getMarketForUpdate(tx, input.marketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+	marketId: string;
+	actorId: string;
+	reason?: string | null;
+	permissions?: PermissionsBitField | Readonly<PermissionsBitField> | null;
+}): Promise<{
+	market: MarketWithRelations;
+	refunds: MarketCancellationRefund[];
+}> =>
+	prisma.$transaction(async (tx) => {
+		const market = await getMarketForUpdate(tx, input.marketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
 
-    assertCanCancelMarket(market, input.actorId, input.permissions);
+		assertCanCancelMarket(market, input.actorId, input.permissions);
 
-    const positionsByUser = groupPositionsByUser(market.positions);
-    const protectionsByUser = new Map<string, number>();
-    for (const protection of market.lossProtections ?? []) {
-      protectionsByUser.set(
-        protection.userId,
-        roundCurrency((protectionsByUser.get(protection.userId) ?? 0) + protection.premiumPaid),
-      );
-    }
+		const positionsByUser = groupPositionsByUser(market.positions);
+		const protectionsByUser = new Map<string, number>();
+		for (const protection of market.lossProtections ?? []) {
+			protectionsByUser.set(
+				protection.userId,
+				roundCurrency(
+					(protectionsByUser.get(protection.userId) ?? 0) +
+						protection.premiumPaid,
+				),
+			);
+		}
 
-    const affectedUserIds = new Set<string>([
-      ...positionsByUser.keys(),
-      ...protectionsByUser.keys(),
-    ]);
+		const affectedUserIds = new Set<string>([
+			...positionsByUser.keys(),
+			...protectionsByUser.keys(),
+		]);
 
-    for (const userId of affectedUserIds) {
-      const positions = positionsByUser.get(userId) ?? [];
-      const protectionRefund = protectionsByUser.get(userId) ?? 0;
-      const refundDelta = roundCurrency(positions.reduce((sum, position) =>
-        sum + (position.side === 'long' ? position.costBasis : position.collateralLocked - position.proceeds), 0) + protectionRefund);
-      if (Math.abs(refundDelta) <= 1e-6) {
-        continue;
-      }
+		const refunds: MarketCancellationRefund[] = [];
 
-      const account = await ensureMarketAccountTx(tx, market.guildId, userId);
-      await tx.marketAccount.update({
-        where: {
-          id: account.id,
-        },
-        data: {
-          bankroll: roundCurrency(account.bankroll + refundDelta),
-          realizedProfit: roundCurrency(account.realizedProfit + protectionRefund),
-        },
-      });
-    }
+		for (const userId of affectedUserIds) {
+			const positions = positionsByUser.get(userId) ?? [];
+			const protectionRefund = protectionsByUser.get(userId) ?? 0;
+			const refundDelta = roundCurrency(
+				positions.reduce(
+					(sum, position) =>
+						sum +
+						(position.side === "long"
+							? position.costBasis
+							: position.collateralLocked - position.proceeds),
+					0,
+				) + protectionRefund,
+			);
+			refunds.push({
+				userId,
+				refundAmount: refundDelta,
+				positionCount: positions.length,
+				protectionRefund,
+			});
+			if (Math.abs(refundDelta) <= 1e-6) {
+				continue;
+			}
 
-    await tx.marketPosition.deleteMany({
-      where: {
-        marketId: market.id,
-      },
-    });
-    await tx.marketLossProtection.deleteMany({
-      where: {
-        marketId: market.id,
-      },
-    });
+			const account = await ensureMarketAccountTx(tx, market.guildId, userId);
+			await tx.marketAccount.update({
+				where: {
+					id: account.id,
+				},
+				data: {
+					bankroll: roundCurrency(account.bankroll + refundDelta),
+					realizedProfit: roundCurrency(
+						account.realizedProfit + protectionRefund,
+					),
+				},
+			});
+		}
 
-    await Promise.all(market.outcomes.map((outcome) =>
-      tx.marketOutcome.update({
-        where: {
-          id: outcome.id,
-        },
-        data: {
-          outstandingShares: 0,
-          pricingShares: 0,
-        },
-      })));
+		await tx.marketPosition.deleteMany({
+			where: {
+				marketId: market.id,
+			},
+		});
+		await tx.marketLossProtection.deleteMany({
+			where: {
+				marketId: market.id,
+			},
+		});
 
-    return tx.market.update({
-      where: {
-        id: market.id,
-      },
-      data: {
-        tradingClosedAt: market.tradingClosedAt ?? new Date(),
-        cancelledAt: new Date(),
-        resolutionNote: input.reason ?? null,
-        resolvedByUserId: input.actorId,
-        supplementaryBonusExpiredAt: new Date(),
-      },
-      include: marketInclude,
-    });
-  });
+		await Promise.all(
+			market.outcomes.map((outcome) =>
+				tx.marketOutcome.update({
+					where: {
+						id: outcome.id,
+					},
+					data: {
+						outstandingShares: 0,
+						pricingShares: 0,
+					},
+				}),
+			),
+		);
+
+		const cancelledMarket = await tx.market.update({
+			where: {
+				id: market.id,
+			},
+			data: {
+				tradingClosedAt: market.tradingClosedAt ?? new Date(),
+				cancelledAt: new Date(),
+				resolutionNote: input.reason ?? null,
+				resolvedByUserId: input.actorId,
+				supplementaryBonusExpiredAt: new Date(),
+			},
+			include: marketInclude,
+		});
+
+		return {
+			market: cancelledMarket,
+			refunds: refunds.filter((entry) => Math.abs(entry.refundAmount) > 1e-6),
+		};
+	});

--- a/src/features/markets/services/trading/execution.ts
+++ b/src/features/markets/services/trading/execution.ts
@@ -1,311 +1,740 @@
-import type { MarketPositionSide, MarketTradeSide } from '@prisma/client';
+import type { MarketPositionSide, MarketTradeSide } from "@prisma/client";
 
-import { runSerializableTransaction } from '../../../../lib/run-serializable-transaction.js';
-import { ensureMarketAccountTx } from '../account.js';
+import { runSerializableTransaction } from "../../../../lib/run-serializable-transaction.js";
+import { ensureMarketAccountTx } from "../account.js";
 import {
-  assertMarketOpen,
-  assertOutcomeTradable,
-  getMarketForUpdate,
-  getMarketProbabilities,
-  getLossProtection,
-  getLossProtectionMap,
-  getPosition,
-  getPositionMap,
-  getTradeLockReason,
-  getTradableOutcomeIndexes,
-  marketInclude,
-  replaceOutcomeState,
-  roundCurrency,
-  upsertPosition,
-} from '../../core/shared.js';
+	assertMarketOpen,
+	assertOutcomeTradable,
+	getMarketForUpdate,
+	getMarketProbabilities,
+	getLossProtection,
+	getLossProtectionMap,
+	getPosition,
+	getPositionMap,
+	getTradeLockReason,
+	getTradableOutcomeIndexes,
+	marketInclude,
+	replaceOutcomeState,
+	roundCurrency,
+	upsertPosition,
+} from "../../core/shared.js";
 import {
-  computeBuyCost,
-  computeLmsrProbabilities,
-  computeSellPayout,
-  solveBuySharesForAmount,
-  solveSellSharesForAmount,
-  solveShortSharesForAmount,
-} from '../../core/math.js';
-import type { MarketTradeResult } from '../../core/types.js';
-import { assertPositiveTradeAmount } from './shared.js';
-import { syncLossProtectionForSellTx } from './protection.js';
+	computeBinaryBuyCost,
+	computeBinaryLmsrProbability,
+	computeBinarySellPayout,
+	computeBuyCost,
+	computeLmsrProbabilities,
+	computeSellPayout,
+	solveBinaryBuySharesForAmount,
+	solveBinarySellSharesForAmount,
+	solveBinaryShortSharesForAmount,
+	solveBuySharesForAmount,
+	solveSellSharesForAmount,
+	solveShortSharesForAmount,
+} from "../../core/math.js";
+import type { MarketTradeResult } from "../../core/types.js";
+import { assertPositiveTradeAmount } from "./shared.js";
+import { syncLossProtectionForSellTx } from "./protection.js";
 
 export const executeMarketTrade = async (input: {
-  marketId: string;
-  userId: string;
-  outcomeId: string;
-  action: MarketTradeSide;
-  amount: number;
-  amountMode?: 'points' | 'shares';
+	marketId: string;
+	userId: string;
+	outcomeId: string;
+	action: MarketTradeSide;
+	amount: number;
+	amountMode?: "points" | "shares";
 }): Promise<MarketTradeResult> =>
-  runSerializableTransaction(async (tx) => {
-    assertPositiveTradeAmount(input.amount);
-    const market = await getMarketForUpdate(tx, input.marketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+	runSerializableTransaction(async (tx) => {
+		assertPositiveTradeAmount(input.amount);
+		const market = await getMarketForUpdate(tx, input.marketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
 
-    assertMarketOpen(market);
-    const outcomeIndex = market.outcomes.findIndex((outcome) => outcome.id === input.outcomeId);
-    const outcome = market.outcomes[outcomeIndex];
-    if (!outcome) {
-      throw new Error('Market outcome not found.');
-    }
+		assertMarketOpen(market);
+		const outcomeIndex = market.outcomes.findIndex(
+			(outcome) => outcome.id === input.outcomeId,
+		);
+		const outcome = market.outcomes[outcomeIndex];
+		if (!outcome) {
+			throw new Error("Market outcome not found.");
+		}
 
-    assertOutcomeTradable(market, outcome);
-    const tradeLockReason = getTradeLockReason(market, outcome.id, input.action);
-    if (tradeLockReason) {
-      throw new Error(tradeLockReason);
-    }
-    const tradableOutcomeIndexes = getTradableOutcomeIndexes(market);
-    const tradableIndex = tradableOutcomeIndexes.indexOf(outcomeIndex);
-    if (tradableIndex < 0) {
-      throw new Error('That outcome can no longer be traded.');
-    }
+		assertOutcomeTradable(market, outcome);
+		const tradeLockReason = getTradeLockReason(
+			market,
+			outcome.id,
+			input.action,
+		);
+		if (tradeLockReason) {
+			throw new Error(tradeLockReason);
+		}
+		const tradableOutcomeIndexes = getTradableOutcomeIndexes(market);
+		const tradableIndex = tradableOutcomeIndexes.indexOf(outcomeIndex);
+		if (tradableIndex < 0) {
+			throw new Error("That outcome can no longer be traded.");
+		}
 
-    const account = await ensureMarketAccountTx(tx, market.guildId, input.userId);
-    const pricingShares = tradableOutcomeIndexes.map((index) => market.outcomes[index]?.pricingShares ?? 0);
-    const outstandingShares = tradableOutcomeIndexes.map((index) => market.outcomes[index]?.outstandingShares ?? 0);
-    const positions = getPositionMap(market.positions.filter((position) => position.userId === input.userId));
-    const longPosition = getPosition(positions, outcome.id, 'long');
-    const shortPosition = getPosition(positions, outcome.id, 'short');
-    let shareDelta = 0;
-    const nextPricingShares = [...pricingShares];
-    const nextOutstandingShares = [...outstandingShares];
-    let nextLongShares = longPosition?.shares ?? 0;
-    let nextLongCostBasis = longPosition?.costBasis ?? 0;
-    let nextShortShares = shortPosition?.shares ?? 0;
-    let nextShortProceeds = shortPosition?.proceeds ?? 0;
-    let nextShortCollateral = shortPosition?.collateralLocked ?? 0;
-    let nextBankroll = account.bankroll;
-    let realizedProfitDelta = 0;
-    let cashAmount = input.amount;
-    let grossCashAmount = input.amount;
-    let netCashAmount = input.amount;
-    let feeCharged = 0;
-    let positionSide: MarketPositionSide = 'long';
-    const protection = getLossProtection(getLossProtectionMap(market.lossProtections ?? []), input.userId, outcome.id);
+		const account = await ensureMarketAccountTx(
+			tx,
+			market.guildId,
+			input.userId,
+		);
+		const positions = getPositionMap(
+			market.positions.filter((position) => position.userId === input.userId),
+		);
+		const longPosition = getPosition(positions, outcome.id, "long");
+		const shortPosition = getPosition(positions, outcome.id, "short");
+		const pricingShares = tradableOutcomeIndexes.map(
+			(index) => market.outcomes[index]?.pricingShares ?? 0,
+		);
+		const outstandingShares = tradableOutcomeIndexes.map(
+			(index) => market.outcomes[index]?.outstandingShares ?? 0,
+		);
+		let shareDelta = 0;
+		const nextPricingShares = [...pricingShares];
+		const nextOutstandingShares = [...outstandingShares];
+		let nextLongShares = longPosition?.shares ?? 0;
+		let nextLongCostBasis = longPosition?.costBasis ?? 0;
+		let nextShortShares = shortPosition?.shares ?? 0;
+		let nextShortProceeds = shortPosition?.proceeds ?? 0;
+		let nextShortCollateral = shortPosition?.collateralLocked ?? 0;
+		let nextBankroll = account.bankroll;
+		let realizedProfitDelta = 0;
+		let cashAmount = input.amount;
+		let grossCashAmount = input.amount;
+		let netCashAmount = input.amount;
+		let feeCharged = 0;
+		let positionSide: MarketPositionSide = "long";
+		const protection = getLossProtection(
+			getLossProtectionMap(market.lossProtections ?? []),
+			input.userId,
+			outcome.id,
+		);
 
-    switch (input.action) {
-      case 'buy': {
-        if (shortPosition && shortPosition.shares > 1e-6) {
-          throw new Error('You must cover your short position in that outcome before buying it.');
-        }
+		if (market.contractMode === "independent_binary_set") {
+			const pricingShare = market.outcomes[outcomeIndex]?.pricingShares ?? 0;
+			const nextPricingShare = pricingShare;
+			let nextSinglePricingShare = pricingShare;
+			const nextOutstandingShare =
+				market.outcomes[outcomeIndex]?.outstandingShares ?? 0;
+			let nextSingleOutstandingShare = nextOutstandingShare;
 
-        if (account.bankroll < input.amount - 1e-6) {
-          throw new Error('You do not have enough bankroll for that trade.');
-        }
+			switch (input.action) {
+				case "buy": {
+					if (shortPosition && shortPosition.shares > 1e-6) {
+						throw new Error(
+							"You must cover your short position in that outcome before buying it.",
+						);
+					}
 
-        shareDelta = solveBuySharesForAmount(pricingShares, tradableIndex, input.amount, market.liquidityParameter);
-        nextPricingShares[tradableIndex] = (nextPricingShares[tradableIndex] ?? 0) + shareDelta;
-        nextOutstandingShares[tradableIndex] = (nextOutstandingShares[tradableIndex] ?? 0) + shareDelta;
-        nextLongShares += shareDelta;
-        nextLongCostBasis += input.amount;
-        nextBankroll -= input.amount;
-        grossCashAmount = roundCurrency(input.amount);
-        netCashAmount = roundCurrency(input.amount);
-        positionSide = 'long';
-        break;
-      }
-      case 'sell': {
-        const ownedShares = longPosition?.shares ?? 0;
-        if (ownedShares <= 1e-6) {
-          throw new Error('You do not own a long position in that outcome yet.');
-        }
+					if (account.bankroll < input.amount - 1e-6) {
+						throw new Error("You do not have enough bankroll for that trade.");
+					}
 
-        const requestedSharesToSell = input.amountMode === 'shares'
-          ? input.amount
-          : solveSellSharesForAmount(pricingShares, tradableIndex, input.amount, ownedShares, market.liquidityParameter);
-        if (requestedSharesToSell > ownedShares + 1e-6) {
-          throw new Error('You do not have enough shares in that outcome to sell that much.');
-        }
+					shareDelta = solveBinaryBuySharesForAmount(
+						pricingShare,
+						input.amount,
+						market.liquidityParameter,
+					);
+					nextSinglePricingShare = nextPricingShare + shareDelta;
+					nextSingleOutstandingShare = nextOutstandingShare + shareDelta;
+					nextLongShares += shareDelta;
+					nextLongCostBasis += input.amount;
+					nextBankroll -= input.amount;
+					grossCashAmount = roundCurrency(input.amount);
+					netCashAmount = roundCurrency(input.amount);
+					positionSide = "long";
+					break;
+				}
+				case "sell": {
+					const ownedShares = longPosition?.shares ?? 0;
+					if (ownedShares <= 1e-6) {
+						throw new Error(
+							"You do not own a long position in that outcome yet.",
+						);
+					}
 
-        shareDelta = -requestedSharesToSell;
-        nextPricingShares[tradableIndex] = (nextPricingShares[tradableIndex] ?? 0) + shareDelta;
-        nextOutstandingShares[tradableIndex] = (nextOutstandingShares[tradableIndex] ?? 0) + shareDelta;
-        const sharesSold = Math.abs(shareDelta);
-        const averageCostBasis = (longPosition?.costBasis ?? 0) / ownedShares;
-        const releasedCostBasis = averageCostBasis * sharesSold;
-        nextLongShares -= sharesSold;
-        nextLongCostBasis -= releasedCostBasis;
-        cashAmount = input.amountMode === 'shares'
-          ? roundCurrency(computeSellPayout(pricingShares, tradableIndex, sharesSold, market.liquidityParameter))
-          : input.amount;
-        nextBankroll += cashAmount;
-        realizedProfitDelta = roundCurrency(cashAmount - releasedCostBasis);
-        grossCashAmount = roundCurrency(cashAmount);
-        netCashAmount = roundCurrency(cashAmount);
-        positionSide = 'long';
-        break;
-      }
-      case 'short': {
-        if (longPosition && longPosition.shares > 1e-6) {
-          throw new Error('You must sell your long position in that outcome before shorting it.');
-        }
+					const requestedSharesToSell =
+						input.amountMode === "shares"
+							? input.amount
+							: solveBinarySellSharesForAmount(
+									pricingShare,
+									input.amount,
+									ownedShares,
+									market.liquidityParameter,
+								);
+					if (requestedSharesToSell > ownedShares + 1e-6) {
+						throw new Error(
+							"You do not have enough shares in that outcome to sell that much.",
+						);
+					}
 
-        const sharesToShort = input.amountMode === 'shares'
-          ? input.amount
-          : solveShortSharesForAmount(pricingShares, tradableIndex, input.amount, market.liquidityParameter);
-        const proceedsReceived = input.amountMode === 'shares'
-          ? roundCurrency(computeSellPayout(pricingShares, tradableIndex, sharesToShort, market.liquidityParameter))
-          : input.amount;
-        const collateralToLock = roundCurrency(sharesToShort);
-        if ((account.bankroll + proceedsReceived - collateralToLock) < -1e-6) {
-          throw new Error('You do not have enough bankroll to collateralize that short.');
-        }
+					shareDelta = -requestedSharesToSell;
+					nextSinglePricingShare = nextPricingShare + shareDelta;
+					nextSingleOutstandingShare = nextOutstandingShare + shareDelta;
+					const sharesSold = Math.abs(shareDelta);
+					const averageCostBasis = (longPosition?.costBasis ?? 0) / ownedShares;
+					const releasedCostBasis = averageCostBasis * sharesSold;
+					nextLongShares -= sharesSold;
+					nextLongCostBasis -= releasedCostBasis;
+					cashAmount =
+						input.amountMode === "shares"
+							? roundCurrency(
+									computeBinarySellPayout(
+										pricingShare,
+										sharesSold,
+										market.liquidityParameter,
+									),
+								)
+							: input.amount;
+					nextBankroll += cashAmount;
+					realizedProfitDelta = roundCurrency(cashAmount - releasedCostBasis);
+					grossCashAmount = roundCurrency(cashAmount);
+					netCashAmount = roundCurrency(cashAmount);
+					positionSide = "long";
+					break;
+				}
+				case "short": {
+					if (longPosition && longPosition.shares > 1e-6) {
+						throw new Error(
+							"You must sell your long position in that outcome before shorting it.",
+						);
+					}
 
-        shareDelta = -sharesToShort;
-        nextPricingShares[tradableIndex] = (nextPricingShares[tradableIndex] ?? 0) + shareDelta;
-        nextOutstandingShares[tradableIndex] = (nextOutstandingShares[tradableIndex] ?? 0) + shareDelta;
-        nextShortShares += sharesToShort;
-        nextShortProceeds += proceedsReceived;
-        nextShortCollateral += collateralToLock;
-        nextBankroll += proceedsReceived - collateralToLock;
-        cashAmount = roundCurrency(proceedsReceived);
-        grossCashAmount = roundCurrency(proceedsReceived);
-        netCashAmount = roundCurrency(proceedsReceived);
-        positionSide = 'short';
-        break;
-      }
-      case 'cover': {
-        const ownedShortShares = shortPosition?.shares ?? 0;
-        if (ownedShortShares <= 1e-6) {
-          throw new Error('You do not have a short position in that outcome yet.');
-        }
+					const sharesToShort =
+						input.amountMode === "shares"
+							? input.amount
+							: solveBinaryShortSharesForAmount(
+									pricingShare,
+									input.amount,
+									market.liquidityParameter,
+								);
+					const proceedsReceived =
+						input.amountMode === "shares"
+							? roundCurrency(
+									computeBinarySellPayout(
+										pricingShare,
+										sharesToShort,
+										market.liquidityParameter,
+									),
+								)
+							: input.amount;
+					const collateralToLock = roundCurrency(sharesToShort);
+					if (account.bankroll + proceedsReceived - collateralToLock < -1e-6) {
+						throw new Error(
+							"You do not have enough bankroll to collateralize that short.",
+						);
+					}
 
-        if (input.amountMode !== 'shares') {
-          const maxCoverCost = computeBuyCost(pricingShares, tradableIndex, ownedShortShares, market.liquidityParameter);
-          if (input.amount > maxCoverCost + 1e-6) {
-            throw new Error('You do not have enough short shares in that outcome to cover that much.');
-          }
-        }
+					shareDelta = -sharesToShort;
+					nextSinglePricingShare = nextPricingShare + shareDelta;
+					nextSingleOutstandingShare = nextOutstandingShare + shareDelta;
+					nextShortShares += sharesToShort;
+					nextShortProceeds += proceedsReceived;
+					nextShortCollateral += collateralToLock;
+					nextBankroll += proceedsReceived - collateralToLock;
+					cashAmount = roundCurrency(proceedsReceived);
+					grossCashAmount = roundCurrency(proceedsReceived);
+					netCashAmount = roundCurrency(proceedsReceived);
+					positionSide = "short";
+					break;
+				}
+				case "cover": {
+					const ownedShortShares = shortPosition?.shares ?? 0;
+					if (ownedShortShares <= 1e-6) {
+						throw new Error(
+							"You do not have a short position in that outcome yet.",
+						);
+					}
 
-        const sharesToCover = input.amountMode === 'shares'
-          ? input.amount
-          : solveBuySharesForAmount(pricingShares, tradableIndex, input.amount, market.liquidityParameter);
-        if (sharesToCover > ownedShortShares + 1e-6) {
-          throw new Error('You do not have enough short shares in that outcome to cover that much.');
-        }
+					if (input.amountMode !== "shares") {
+						const maxCoverCost = computeBinaryBuyCost(
+							pricingShare,
+							ownedShortShares,
+							market.liquidityParameter,
+						);
+						if (input.amount > maxCoverCost + 1e-6) {
+							throw new Error(
+								"You do not have enough short shares in that outcome to cover that much.",
+							);
+						}
+					}
 
-        const coverCost = input.amountMode === 'shares'
-          ? roundCurrency(computeBuyCost(pricingShares, tradableIndex, sharesToCover, market.liquidityParameter))
-          : input.amount;
-        const averageProceeds = (shortPosition?.proceeds ?? 0) / ownedShortShares;
-        const averageCollateral = (shortPosition?.collateralLocked ?? 0) / ownedShortShares;
-        const releasedProceeds = averageProceeds * sharesToCover;
-        const releasedCollateral = averageCollateral * sharesToCover;
-        if (account.bankroll + releasedCollateral < coverCost - 1e-6) {
-          throw new Error('You do not have enough bankroll to cover that short.');
-        }
+					const sharesToCover =
+						input.amountMode === "shares"
+							? input.amount
+							: solveBinaryBuySharesForAmount(
+									pricingShare,
+									input.amount,
+									market.liquidityParameter,
+								);
+					if (sharesToCover > ownedShortShares + 1e-6) {
+						throw new Error(
+							"You do not have enough short shares in that outcome to cover that much.",
+						);
+					}
 
-        shareDelta = sharesToCover;
-        nextPricingShares[tradableIndex] = (nextPricingShares[tradableIndex] ?? 0) + shareDelta;
-        nextOutstandingShares[tradableIndex] = (nextOutstandingShares[tradableIndex] ?? 0) + shareDelta;
-        nextShortShares -= sharesToCover;
-        nextShortProceeds -= releasedProceeds;
-        nextShortCollateral -= releasedCollateral;
-        nextBankroll += releasedCollateral - coverCost;
-        cashAmount = roundCurrency(coverCost);
-        realizedProfitDelta = roundCurrency(releasedProceeds - coverCost);
-        grossCashAmount = roundCurrency(coverCost);
-        netCashAmount = roundCurrency(coverCost);
-        positionSide = 'short';
-        break;
-      }
-      default:
-        throw new Error('Unsupported market trade action.');
-    }
+					const coverCost =
+						input.amountMode === "shares"
+							? roundCurrency(
+									computeBinaryBuyCost(
+										pricingShare,
+										sharesToCover,
+										market.liquidityParameter,
+									),
+								)
+							: input.amount;
+					const averageProceeds =
+						(shortPosition?.proceeds ?? 0) / ownedShortShares;
+					const averageCollateral =
+						(shortPosition?.collateralLocked ?? 0) / ownedShortShares;
+					const releasedProceeds = averageProceeds * sharesToCover;
+					const releasedCollateral = averageCollateral * sharesToCover;
+					if (account.bankroll + releasedCollateral < coverCost - 1e-6) {
+						throw new Error(
+							"You do not have enough bankroll to cover that short.",
+						);
+					}
 
-    const computedProbabilities = tradableOutcomeIndexes.length === 0
-      ? []
-      : computeLmsrProbabilities(nextPricingShares, market.liquidityParameter);
-    const tradableIndexMap = new Map<number, number>(
-      tradableOutcomeIndexes.map((marketOutcomeIndex, activeIndex) => [marketOutcomeIndex, activeIndex]),
-    );
-    await replaceOutcomeState(tx, market.id, market.outcomes.map((marketOutcome, index) => {
-      const activeIndex = tradableIndexMap.get(index);
-      return {
-        id: marketOutcome.id,
-        outstandingShares: activeIndex === undefined
-          ? marketOutcome.outstandingShares
-          : (nextOutstandingShares[activeIndex] ?? marketOutcome.outstandingShares),
-        pricingShares: activeIndex === undefined
-          ? marketOutcome.pricingShares
-          : (nextPricingShares[activeIndex] ?? marketOutcome.pricingShares),
-      };
-    }));
+					shareDelta = sharesToCover;
+					nextSinglePricingShare = nextPricingShare + shareDelta;
+					nextSingleOutstandingShare = nextOutstandingShare + shareDelta;
+					nextShortShares -= sharesToCover;
+					nextShortProceeds -= releasedProceeds;
+					nextShortCollateral -= releasedCollateral;
+					nextBankroll += releasedCollateral - coverCost;
+					cashAmount = roundCurrency(coverCost);
+					realizedProfitDelta = roundCurrency(releasedProceeds - coverCost);
+					grossCashAmount = roundCurrency(coverCost);
+					netCashAmount = roundCurrency(coverCost);
+					positionSide = "short";
+					break;
+				}
+				default:
+					throw new Error("Unsupported market trade action.");
+			}
 
-    await upsertPosition(tx, {
-      marketId: market.id,
-      outcomeId: outcome.id,
-      userId: input.userId,
-      side: 'long',
-      shares: nextLongShares,
-      costBasis: nextLongCostBasis,
-      proceeds: 0,
-      collateralLocked: 0,
-    });
-    if (input.action === 'sell') {
-      await syncLossProtectionForSellTx(tx, {
-        ...(protection ? { existingProtection: protection } : {}),
-        previousLongCostBasis: longPosition?.costBasis ?? 0,
-        nextLongCostBasis,
-      });
-    }
+			await replaceOutcomeState(
+				tx,
+				market.id,
+				market.outcomes.map((marketOutcome, index) => ({
+					id: marketOutcome.id,
+					outstandingShares:
+						index === outcomeIndex
+							? nextSingleOutstandingShare
+							: marketOutcome.outstandingShares,
+					pricingShares:
+						index === outcomeIndex
+							? nextSinglePricingShare
+							: marketOutcome.pricingShares,
+				})),
+			);
 
-    await upsertPosition(tx, {
-      marketId: market.id,
-      outcomeId: outcome.id,
-      userId: input.userId,
-      side: 'short',
-      shares: nextShortShares,
-      costBasis: 0,
-      proceeds: nextShortProceeds,
-      collateralLocked: nextShortCollateral,
-    });
+			await upsertPosition(tx, {
+				marketId: market.id,
+				outcomeId: outcome.id,
+				userId: input.userId,
+				side: "long",
+				shares: nextLongShares,
+				costBasis: nextLongCostBasis,
+				proceeds: 0,
+				collateralLocked: 0,
+			});
+			if (input.action === "sell") {
+				await syncLossProtectionForSellTx(tx, {
+					...(protection ? { existingProtection: protection } : {}),
+					previousLongCostBasis: longPosition?.costBasis ?? 0,
+					nextLongCostBasis,
+				});
+			}
 
-    const updatedAccount = await tx.marketAccount.update({
-      where: {
-        id: account.id,
-      },
-      data: {
-        bankroll: roundCurrency(nextBankroll),
-        realizedProfit: roundCurrency(account.realizedProfit + realizedProfitDelta),
-      },
-    });
+			await upsertPosition(tx, {
+				marketId: market.id,
+				outcomeId: outcome.id,
+				userId: input.userId,
+				side: "short",
+				shares: nextShortShares,
+				costBasis: 0,
+				proceeds: nextShortProceeds,
+				collateralLocked: nextShortCollateral,
+			});
 
-    const updatedMarket = await tx.market.update({
-      where: {
-        id: market.id,
-      },
-      data: {
-        totalVolume: market.totalVolume + cashAmount,
-        trades: {
-          create: {
-            userId: input.userId,
-            outcomeId: outcome.id,
-            side: input.action,
-            cashDelta: input.action === 'buy' || input.action === 'cover' ? -cashAmount : cashAmount,
-            shareDelta: roundCurrency(shareDelta),
-            feeCharged,
-            probabilitySnapshot: computedProbabilities[tradableIndex] ?? 0,
-            cumulativeVolume: market.totalVolume + cashAmount,
-          },
-        },
-      },
-      include: marketInclude,
-    });
+			const updatedAccount = await tx.marketAccount.update({
+				where: {
+					id: account.id,
+				},
+				data: {
+					bankroll: roundCurrency(nextBankroll),
+					realizedProfit: roundCurrency(
+						account.realizedProfit + realizedProfitDelta,
+					),
+				},
+			});
 
-    return {
-      market: updatedMarket,
-      outcome,
-      account: updatedAccount,
-      positionSide,
-      shareDelta: roundCurrency(shareDelta),
-      cashAmount: roundCurrency(cashAmount),
-      grossCashAmount: roundCurrency(grossCashAmount),
-      netCashAmount: roundCurrency(netCashAmount),
-      feeCharged: roundCurrency(feeCharged),
-      realizedProfitDelta,
-    };
-  });
+			const probabilitySnapshot = computeBinaryLmsrProbability(
+				nextSinglePricingShare,
+				market.liquidityParameter,
+			);
+			const updatedMarket = await tx.market.update({
+				where: {
+					id: market.id,
+				},
+				data: {
+					totalVolume: market.totalVolume + cashAmount,
+					trades: {
+						create: {
+							userId: input.userId,
+							outcomeId: outcome.id,
+							side: input.action,
+							cashDelta:
+								input.action === "buy" || input.action === "cover"
+									? -cashAmount
+									: cashAmount,
+							shareDelta: roundCurrency(shareDelta),
+							feeCharged,
+							probabilitySnapshot,
+							cumulativeVolume: market.totalVolume + cashAmount,
+						},
+					},
+				},
+				include: marketInclude,
+			});
+
+			return {
+				market: updatedMarket,
+				outcome,
+				account: updatedAccount,
+				positionSide,
+				shareDelta: roundCurrency(shareDelta),
+				cashAmount: roundCurrency(cashAmount),
+				grossCashAmount: roundCurrency(grossCashAmount),
+				netCashAmount: roundCurrency(netCashAmount),
+				feeCharged: roundCurrency(feeCharged),
+				realizedProfitDelta,
+			};
+		}
+
+		switch (input.action) {
+			case "buy": {
+				if (shortPosition && shortPosition.shares > 1e-6) {
+					throw new Error(
+						"You must cover your short position in that outcome before buying it.",
+					);
+				}
+
+				if (account.bankroll < input.amount - 1e-6) {
+					throw new Error("You do not have enough bankroll for that trade.");
+				}
+
+				shareDelta = solveBuySharesForAmount(
+					pricingShares,
+					tradableIndex,
+					input.amount,
+					market.liquidityParameter,
+				);
+				nextPricingShares[tradableIndex] =
+					(nextPricingShares[tradableIndex] ?? 0) + shareDelta;
+				nextOutstandingShares[tradableIndex] =
+					(nextOutstandingShares[tradableIndex] ?? 0) + shareDelta;
+				nextLongShares += shareDelta;
+				nextLongCostBasis += input.amount;
+				nextBankroll -= input.amount;
+				grossCashAmount = roundCurrency(input.amount);
+				netCashAmount = roundCurrency(input.amount);
+				positionSide = "long";
+				break;
+			}
+			case "sell": {
+				const ownedShares = longPosition?.shares ?? 0;
+				if (ownedShares <= 1e-6) {
+					throw new Error(
+						"You do not own a long position in that outcome yet.",
+					);
+				}
+
+				const requestedSharesToSell =
+					input.amountMode === "shares"
+						? input.amount
+						: solveSellSharesForAmount(
+								pricingShares,
+								tradableIndex,
+								input.amount,
+								ownedShares,
+								market.liquidityParameter,
+							);
+				if (requestedSharesToSell > ownedShares + 1e-6) {
+					throw new Error(
+						"You do not have enough shares in that outcome to sell that much.",
+					);
+				}
+
+				shareDelta = -requestedSharesToSell;
+				nextPricingShares[tradableIndex] =
+					(nextPricingShares[tradableIndex] ?? 0) + shareDelta;
+				nextOutstandingShares[tradableIndex] =
+					(nextOutstandingShares[tradableIndex] ?? 0) + shareDelta;
+				const sharesSold = Math.abs(shareDelta);
+				const averageCostBasis = (longPosition?.costBasis ?? 0) / ownedShares;
+				const releasedCostBasis = averageCostBasis * sharesSold;
+				nextLongShares -= sharesSold;
+				nextLongCostBasis -= releasedCostBasis;
+				cashAmount =
+					input.amountMode === "shares"
+						? roundCurrency(
+								computeSellPayout(
+									pricingShares,
+									tradableIndex,
+									sharesSold,
+									market.liquidityParameter,
+								),
+							)
+						: input.amount;
+				nextBankroll += cashAmount;
+				realizedProfitDelta = roundCurrency(cashAmount - releasedCostBasis);
+				grossCashAmount = roundCurrency(cashAmount);
+				netCashAmount = roundCurrency(cashAmount);
+				positionSide = "long";
+				break;
+			}
+			case "short": {
+				if (longPosition && longPosition.shares > 1e-6) {
+					throw new Error(
+						"You must sell your long position in that outcome before shorting it.",
+					);
+				}
+
+				const sharesToShort =
+					input.amountMode === "shares"
+						? input.amount
+						: solveShortSharesForAmount(
+								pricingShares,
+								tradableIndex,
+								input.amount,
+								market.liquidityParameter,
+							);
+				const proceedsReceived =
+					input.amountMode === "shares"
+						? roundCurrency(
+								computeSellPayout(
+									pricingShares,
+									tradableIndex,
+									sharesToShort,
+									market.liquidityParameter,
+								),
+							)
+						: input.amount;
+				const collateralToLock = roundCurrency(sharesToShort);
+				if (account.bankroll + proceedsReceived - collateralToLock < -1e-6) {
+					throw new Error(
+						"You do not have enough bankroll to collateralize that short.",
+					);
+				}
+
+				shareDelta = -sharesToShort;
+				nextPricingShares[tradableIndex] =
+					(nextPricingShares[tradableIndex] ?? 0) + shareDelta;
+				nextOutstandingShares[tradableIndex] =
+					(nextOutstandingShares[tradableIndex] ?? 0) + shareDelta;
+				nextShortShares += sharesToShort;
+				nextShortProceeds += proceedsReceived;
+				nextShortCollateral += collateralToLock;
+				nextBankroll += proceedsReceived - collateralToLock;
+				cashAmount = roundCurrency(proceedsReceived);
+				grossCashAmount = roundCurrency(proceedsReceived);
+				netCashAmount = roundCurrency(proceedsReceived);
+				positionSide = "short";
+				break;
+			}
+			case "cover": {
+				const ownedShortShares = shortPosition?.shares ?? 0;
+				if (ownedShortShares <= 1e-6) {
+					throw new Error(
+						"You do not have a short position in that outcome yet.",
+					);
+				}
+
+				if (input.amountMode !== "shares") {
+					const maxCoverCost = computeBuyCost(
+						pricingShares,
+						tradableIndex,
+						ownedShortShares,
+						market.liquidityParameter,
+					);
+					if (input.amount > maxCoverCost + 1e-6) {
+						throw new Error(
+							"You do not have enough short shares in that outcome to cover that much.",
+						);
+					}
+				}
+
+				const sharesToCover =
+					input.amountMode === "shares"
+						? input.amount
+						: solveBuySharesForAmount(
+								pricingShares,
+								tradableIndex,
+								input.amount,
+								market.liquidityParameter,
+							);
+				if (sharesToCover > ownedShortShares + 1e-6) {
+					throw new Error(
+						"You do not have enough short shares in that outcome to cover that much.",
+					);
+				}
+
+				const coverCost =
+					input.amountMode === "shares"
+						? roundCurrency(
+								computeBuyCost(
+									pricingShares,
+									tradableIndex,
+									sharesToCover,
+									market.liquidityParameter,
+								),
+							)
+						: input.amount;
+				const averageProceeds =
+					(shortPosition?.proceeds ?? 0) / ownedShortShares;
+				const averageCollateral =
+					(shortPosition?.collateralLocked ?? 0) / ownedShortShares;
+				const releasedProceeds = averageProceeds * sharesToCover;
+				const releasedCollateral = averageCollateral * sharesToCover;
+				if (account.bankroll + releasedCollateral < coverCost - 1e-6) {
+					throw new Error(
+						"You do not have enough bankroll to cover that short.",
+					);
+				}
+
+				shareDelta = sharesToCover;
+				nextPricingShares[tradableIndex] =
+					(nextPricingShares[tradableIndex] ?? 0) + shareDelta;
+				nextOutstandingShares[tradableIndex] =
+					(nextOutstandingShares[tradableIndex] ?? 0) + shareDelta;
+				nextShortShares -= sharesToCover;
+				nextShortProceeds -= releasedProceeds;
+				nextShortCollateral -= releasedCollateral;
+				nextBankroll += releasedCollateral - coverCost;
+				cashAmount = roundCurrency(coverCost);
+				realizedProfitDelta = roundCurrency(releasedProceeds - coverCost);
+				grossCashAmount = roundCurrency(coverCost);
+				netCashAmount = roundCurrency(coverCost);
+				positionSide = "short";
+				break;
+			}
+			default:
+				throw new Error("Unsupported market trade action.");
+		}
+
+		const computedProbabilities =
+			tradableOutcomeIndexes.length === 0
+				? []
+				: computeLmsrProbabilities(
+						nextPricingShares,
+						market.liquidityParameter,
+					);
+		const tradableIndexMap = new Map<number, number>(
+			tradableOutcomeIndexes.map((marketOutcomeIndex, activeIndex) => [
+				marketOutcomeIndex,
+				activeIndex,
+			]),
+		);
+		await replaceOutcomeState(
+			tx,
+			market.id,
+			market.outcomes.map((marketOutcome, index) => {
+				const activeIndex = tradableIndexMap.get(index);
+				return {
+					id: marketOutcome.id,
+					outstandingShares:
+						activeIndex === undefined
+							? marketOutcome.outstandingShares
+							: (nextOutstandingShares[activeIndex] ??
+								marketOutcome.outstandingShares),
+					pricingShares:
+						activeIndex === undefined
+							? marketOutcome.pricingShares
+							: (nextPricingShares[activeIndex] ?? marketOutcome.pricingShares),
+				};
+			}),
+		);
+
+		await upsertPosition(tx, {
+			marketId: market.id,
+			outcomeId: outcome.id,
+			userId: input.userId,
+			side: "long",
+			shares: nextLongShares,
+			costBasis: nextLongCostBasis,
+			proceeds: 0,
+			collateralLocked: 0,
+		});
+		if (input.action === "sell") {
+			await syncLossProtectionForSellTx(tx, {
+				...(protection ? { existingProtection: protection } : {}),
+				previousLongCostBasis: longPosition?.costBasis ?? 0,
+				nextLongCostBasis,
+			});
+		}
+
+		await upsertPosition(tx, {
+			marketId: market.id,
+			outcomeId: outcome.id,
+			userId: input.userId,
+			side: "short",
+			shares: nextShortShares,
+			costBasis: 0,
+			proceeds: nextShortProceeds,
+			collateralLocked: nextShortCollateral,
+		});
+
+		const updatedAccount = await tx.marketAccount.update({
+			where: {
+				id: account.id,
+			},
+			data: {
+				bankroll: roundCurrency(nextBankroll),
+				realizedProfit: roundCurrency(
+					account.realizedProfit + realizedProfitDelta,
+				),
+			},
+		});
+
+		const updatedMarket = await tx.market.update({
+			where: {
+				id: market.id,
+			},
+			data: {
+				totalVolume: market.totalVolume + cashAmount,
+				trades: {
+					create: {
+						userId: input.userId,
+						outcomeId: outcome.id,
+						side: input.action,
+						cashDelta:
+							input.action === "buy" || input.action === "cover"
+								? -cashAmount
+								: cashAmount,
+						shareDelta: roundCurrency(shareDelta),
+						feeCharged,
+						probabilitySnapshot: computedProbabilities[tradableIndex] ?? 0,
+						cumulativeVolume: market.totalVolume + cashAmount,
+					},
+				},
+			},
+			include: marketInclude,
+		});
+
+		return {
+			market: updatedMarket,
+			outcome,
+			account: updatedAccount,
+			positionSide,
+			shareDelta: roundCurrency(shareDelta),
+			cashAmount: roundCurrency(cashAmount),
+			grossCashAmount: roundCurrency(grossCashAmount),
+			netCashAmount: roundCurrency(netCashAmount),
+			feeCharged: roundCurrency(feeCharged),
+			realizedProfitDelta,
+		};
+	});

--- a/src/features/markets/services/trading/quotes.ts
+++ b/src/features/markets/services/trading/quotes.ts
@@ -3,8 +3,6 @@ import {
 	assertMarketOpen,
 	assertOutcomeTradable,
 	getMarketProbabilities,
-	getLossProtection,
-	getLossProtectionMap,
 	getPosition,
 	getPositionMap,
 	getTradeLockReason,
@@ -12,8 +10,14 @@ import {
 	roundCurrency,
 } from "../../core/shared.js";
 import {
+	computeBinaryBuyCost,
+	computeBinaryLmsrProbability,
+	computeBinarySellPayout,
 	computeBuyCost,
 	computeSellPayout,
+	solveBinaryBuySharesForAmount,
+	solveBinarySellSharesForAmount,
+	solveBinaryShortSharesForAmount,
 	solveBuySharesForAmount,
 	solveSellSharesForAmount,
 	solveShortSharesForAmount,
@@ -45,6 +49,55 @@ export const calculateMarketTradeQuote = async (
 		...input,
 		amountMode,
 	});
+};
+
+const buildBinaryProbabilities = (
+	market: Awaited<ReturnType<typeof getMarketById>>,
+	outcomeIndex: number,
+	nextPricingShare: number,
+): { currentProbability: number; nextProbability: number } => {
+	if (!market) {
+		return { currentProbability: 0, nextProbability: 0 };
+	}
+
+	const currentProbability = roundCurrency(
+		getMarketProbabilities(market)[outcomeIndex] ?? 0,
+	);
+	const nextProbability = roundCurrency(
+		computeBinaryLmsrProbability(nextPricingShare, market.liquidityParameter),
+	);
+	return { currentProbability, nextProbability };
+};
+
+const buildCategoricalProbabilities = (
+	market: Awaited<ReturnType<typeof getMarketById>>,
+	outcomeIndex: number,
+	tradableOutcomeIndexes: number[],
+	nextPricingShares: number[],
+): { currentProbability: number; nextProbability: number } => {
+	if (!market) {
+		return { currentProbability: 0, nextProbability: 0 };
+	}
+
+	const currentProbabilities = getMarketProbabilities(market);
+	const currentProbability = roundCurrency(
+		currentProbabilities[outcomeIndex] ?? 0,
+	);
+	const nextProbabilities = getMarketProbabilities({
+		...market,
+		outcomes: market.outcomes.map((marketOutcome, index) => ({
+			...marketOutcome,
+			pricingShares: tradableOutcomeIndexes.includes(index)
+				? (nextPricingShares[tradableOutcomeIndexes.indexOf(index)] ??
+					marketOutcome.pricingShares)
+				: marketOutcome.pricingShares,
+		})),
+	});
+
+	return {
+		currentProbability,
+		nextProbability: roundCurrency(nextProbabilities[outcomeIndex] ?? 0),
+	};
 };
 
 const calculateMarketTradeQuoteUnsafe = async (input: {
@@ -95,37 +148,391 @@ const calculateMarketTradeQuoteUnsafe = async (input: {
 		input.userId,
 	);
 	const amountMode = input.amountMode;
-	const currentProbabilities = getMarketProbabilities(market);
-	const currentProbability = roundCurrency(
-		currentProbabilities[outcomeIndex] ?? 0,
-	);
-	const nextPricingShares = [...pricingShares];
 
+	if (market.contractMode === "independent_binary_set") {
+		const pricingShare = market.outcomes[outcomeIndex]?.pricingShares ?? 0;
+		let nextPricingShare = pricingShare;
+
+		if (input.action === "buy") {
+			if (shortPosition && shortPosition.shares > 1e-6) {
+				throw new Error(
+					"You must cover your short position in that outcome before buying it.",
+				);
+			}
+
+			const feeCharged = 0;
+			if (account.bankroll < input.amount - 1e-6) {
+				throw new Error("You do not have enough bankroll for that trade.");
+			}
+
+			const sharesReceived = solveBinaryBuySharesForAmount(
+				pricingShare,
+				input.amount,
+				market.liquidityParameter,
+			);
+			nextPricingShare += sharesReceived;
+			const positionSharesAfter = roundCurrency(
+				(longPosition?.shares ?? 0) + sharesReceived,
+			);
+			const positionCostBasisAfter = roundCurrency(
+				(longPosition?.costBasis ?? 0) + input.amount,
+			);
+			const bankrollAfter = roundCurrency(account.bankroll - input.amount);
+			const probabilities = buildBinaryProbabilities(
+				market,
+				outcomeIndex,
+				nextPricingShare,
+			);
+
+			return {
+				action: input.action,
+				contractMode: market.contractMode ?? "categorical_single_winner",
+				marketId: market.id,
+				marketTitle: market.title,
+				outcomeId: outcome.id,
+				outcomeLabel: outcome.label,
+				userId: input.userId,
+				guildId: market.guildId,
+				amount: input.amount,
+				amountMode,
+				rawAmount: input.rawAmount,
+				shares: roundCurrency(sharesReceived),
+				averagePrice:
+					sharesReceived > 0
+						? roundCurrency(input.amount / sharesReceived)
+						: null,
+				currentProbability: probabilities.currentProbability,
+				nextProbability: probabilities.nextProbability,
+				immediateCash: roundCurrency(input.amount),
+				grossImmediateCash: roundCurrency(input.amount),
+				netImmediateCash: roundCurrency(input.amount),
+				feeCharged,
+				collateralLocked: 0,
+				collateralReleased: 0,
+				netBankrollChange: roundCurrency(-input.amount),
+				bankrollAfter,
+				positionSide: "long",
+				positionSharesAfter,
+				positionCostBasisAfter,
+				positionProceedsAfter: 0,
+				positionCollateralAfter: 0,
+				realizedProfitDelta: 0,
+				settlementIfChosen: positionSharesAfter,
+				settlementIfNotChosen: 0,
+				maxProfitIfChosen: roundCurrency(
+					positionSharesAfter - positionCostBasisAfter,
+				),
+				maxProfitIfNotChosen: 0,
+				maxLossIfChosen: 0,
+				maxLossIfNotChosen: positionCostBasisAfter,
+			};
+		}
+
+		if (input.action === "sell") {
+			const ownedShares = longPosition?.shares ?? 0;
+			if (ownedShares <= 1e-6) {
+				throw new Error("You do not own a long position in that outcome yet.");
+			}
+
+			const requestedSharesToSell =
+				amountMode === "shares"
+					? input.amount
+					: solveBinarySellSharesForAmount(
+							pricingShare,
+							input.amount,
+							ownedShares,
+							market.liquidityParameter,
+						);
+			if (requestedSharesToSell > ownedShares + 1e-6) {
+				throw new Error(
+					"You do not have enough shares in that outcome to sell that much.",
+				);
+			}
+
+			const sharesSold = roundCurrency(requestedSharesToSell);
+			const cashAmount =
+				amountMode === "shares"
+					? roundCurrency(
+							computeBinarySellPayout(
+								pricingShare,
+								sharesSold,
+								market.liquidityParameter,
+							),
+						)
+					: roundCurrency(input.amount);
+			const averageCostBasis = (longPosition?.costBasis ?? 0) / ownedShares;
+			const releasedCostBasis = roundCurrency(averageCostBasis * sharesSold);
+			nextPricingShare -= sharesSold;
+			const positionSharesAfter = roundCurrency(ownedShares - sharesSold);
+			const positionCostBasisAfter = roundCurrency(
+				(longPosition?.costBasis ?? 0) - releasedCostBasis,
+			);
+			const bankrollAfter = roundCurrency(account.bankroll + cashAmount);
+			const probabilities = buildBinaryProbabilities(
+				market,
+				outcomeIndex,
+				nextPricingShare,
+			);
+
+			return {
+				action: input.action,
+				contractMode: market.contractMode ?? "categorical_single_winner",
+				marketId: market.id,
+				marketTitle: market.title,
+				outcomeId: outcome.id,
+				outcomeLabel: outcome.label,
+				userId: input.userId,
+				guildId: market.guildId,
+				amount: input.amount,
+				amountMode,
+				rawAmount: input.rawAmount,
+				shares: sharesSold,
+				averagePrice:
+					sharesSold > 0 ? roundCurrency(cashAmount / sharesSold) : null,
+				currentProbability: probabilities.currentProbability,
+				nextProbability: probabilities.nextProbability,
+				immediateCash: cashAmount,
+				grossImmediateCash: cashAmount,
+				netImmediateCash: cashAmount,
+				feeCharged: 0,
+				collateralLocked: 0,
+				collateralReleased: 0,
+				netBankrollChange: cashAmount,
+				bankrollAfter,
+				positionSide: "long",
+				positionSharesAfter,
+				positionCostBasisAfter,
+				positionProceedsAfter: 0,
+				positionCollateralAfter: 0,
+				realizedProfitDelta: roundCurrency(cashAmount - releasedCostBasis),
+				settlementIfChosen: positionSharesAfter,
+				settlementIfNotChosen: 0,
+				maxProfitIfChosen: roundCurrency(
+					positionSharesAfter - positionCostBasisAfter,
+				),
+				maxProfitIfNotChosen: 0,
+				maxLossIfChosen: 0,
+				maxLossIfNotChosen: positionCostBasisAfter,
+			};
+		}
+
+		if (longPosition && longPosition.shares > 1e-6) {
+			throw new Error(
+				"You must sell your long position in that outcome before shorting it.",
+			);
+		}
+
+		if (input.action === "short") {
+			const sharesToShort =
+				amountMode === "shares"
+					? input.amount
+					: solveBinaryShortSharesForAmount(
+							pricingShare,
+							input.amount,
+							market.liquidityParameter,
+						);
+			const proceedsReceived =
+				amountMode === "shares"
+					? roundCurrency(
+							computeBinarySellPayout(
+								pricingShare,
+								sharesToShort,
+								market.liquidityParameter,
+							),
+						)
+					: roundCurrency(input.amount);
+			const feeCharged = 0;
+			const collateralToLock = roundCurrency(sharesToShort);
+			if (account.bankroll + proceedsReceived - collateralToLock < -1e-6) {
+				throw new Error(
+					"You do not have enough bankroll to collateralize that short.",
+				);
+			}
+
+			nextPricingShare -= sharesToShort;
+			const positionSharesAfter = roundCurrency(
+				(shortPosition?.shares ?? 0) + sharesToShort,
+			);
+			const positionProceedsAfter = roundCurrency(
+				(shortPosition?.proceeds ?? 0) + proceedsReceived,
+			);
+			const positionCollateralAfter = roundCurrency(
+				(shortPosition?.collateralLocked ?? 0) + collateralToLock,
+			);
+			const bankrollAfter = roundCurrency(
+				account.bankroll + proceedsReceived - collateralToLock,
+			);
+			const probabilities = buildBinaryProbabilities(
+				market,
+				outcomeIndex,
+				nextPricingShare,
+			);
+
+			return {
+				action: input.action,
+				contractMode: market.contractMode ?? "categorical_single_winner",
+				marketId: market.id,
+				marketTitle: market.title,
+				outcomeId: outcome.id,
+				outcomeLabel: outcome.label,
+				userId: input.userId,
+				guildId: market.guildId,
+				amount: input.amount,
+				amountMode,
+				rawAmount: input.rawAmount,
+				shares: roundCurrency(sharesToShort),
+				averagePrice:
+					sharesToShort > 0
+						? roundCurrency(proceedsReceived / sharesToShort)
+						: null,
+				currentProbability: probabilities.currentProbability,
+				nextProbability: probabilities.nextProbability,
+				immediateCash: roundCurrency(proceedsReceived),
+				grossImmediateCash: roundCurrency(proceedsReceived),
+				netImmediateCash: roundCurrency(proceedsReceived),
+				feeCharged,
+				collateralLocked: collateralToLock,
+				collateralReleased: 0,
+				netBankrollChange: roundCurrency(proceedsReceived - collateralToLock),
+				bankrollAfter,
+				positionSide: "short",
+				positionSharesAfter,
+				positionCostBasisAfter: 0,
+				positionProceedsAfter,
+				positionCollateralAfter,
+				realizedProfitDelta: 0,
+				settlementIfChosen: 0,
+				settlementIfNotChosen: positionCollateralAfter,
+				maxProfitIfChosen: 0,
+				maxProfitIfNotChosen: positionProceedsAfter,
+				maxLossIfChosen: roundCurrency(
+					positionCollateralAfter - positionProceedsAfter,
+				),
+				maxLossIfNotChosen: 0,
+			};
+		}
+
+		const ownedShortShares = shortPosition?.shares ?? 0;
+		if (ownedShortShares <= 1e-6) {
+			throw new Error("You do not have a short position in that outcome yet.");
+		}
+
+		if (amountMode !== "shares") {
+			const maxCoverCost = computeBinaryBuyCost(
+				pricingShare,
+				ownedShortShares,
+				market.liquidityParameter,
+			);
+			if (input.amount > maxCoverCost + 1e-6) {
+				throw new Error(
+					"You do not have enough short shares in that outcome to cover that much.",
+				);
+			}
+		}
+
+		const sharesToCover =
+			amountMode === "shares"
+				? input.amount
+				: solveBinaryBuySharesForAmount(
+						pricingShare,
+						input.amount,
+						market.liquidityParameter,
+					);
+		if (sharesToCover > ownedShortShares + 1e-6) {
+			throw new Error(
+				"You do not have enough short shares in that outcome to cover that much.",
+			);
+		}
+
+		const coverCost =
+			amountMode === "shares"
+				? roundCurrency(
+						computeBinaryBuyCost(
+							pricingShare,
+							sharesToCover,
+							market.liquidityParameter,
+						),
+					)
+				: roundCurrency(input.amount);
+		const averageProceeds = (shortPosition?.proceeds ?? 0) / ownedShortShares;
+		const averageCollateral =
+			(shortPosition?.collateralLocked ?? 0) / ownedShortShares;
+		const releasedProceeds = roundCurrency(averageProceeds * sharesToCover);
+		const releasedCollateral = roundCurrency(averageCollateral * sharesToCover);
+		if (account.bankroll + releasedCollateral < coverCost - 1e-6) {
+			throw new Error("You do not have enough bankroll to cover that short.");
+		}
+
+		nextPricingShare += sharesToCover;
+		const positionSharesAfter = roundCurrency(ownedShortShares - sharesToCover);
+		const positionProceedsAfter = roundCurrency(
+			(shortPosition?.proceeds ?? 0) - releasedProceeds,
+		);
+		const positionCollateralAfter = roundCurrency(
+			(shortPosition?.collateralLocked ?? 0) - releasedCollateral,
+		);
+		const bankrollAfter = roundCurrency(
+			account.bankroll + releasedCollateral - coverCost,
+		);
+		const probabilities = buildBinaryProbabilities(
+			market,
+			outcomeIndex,
+			nextPricingShare,
+		);
+
+		return {
+			action: input.action,
+			contractMode: market.contractMode ?? "categorical_single_winner",
+			marketId: market.id,
+			marketTitle: market.title,
+			outcomeId: outcome.id,
+			outcomeLabel: outcome.label,
+			userId: input.userId,
+			guildId: market.guildId,
+			amount: input.amount,
+			amountMode,
+			rawAmount: input.rawAmount,
+			shares: roundCurrency(sharesToCover),
+			averagePrice:
+				sharesToCover > 0 ? roundCurrency(coverCost / sharesToCover) : null,
+			currentProbability: probabilities.currentProbability,
+			nextProbability: probabilities.nextProbability,
+			immediateCash: coverCost,
+			grossImmediateCash: coverCost,
+			netImmediateCash: coverCost,
+			feeCharged: 0,
+			collateralLocked: 0,
+			collateralReleased: releasedCollateral,
+			netBankrollChange: roundCurrency(releasedCollateral - coverCost),
+			bankrollAfter,
+			positionSide: "short",
+			positionSharesAfter,
+			positionCostBasisAfter: 0,
+			positionProceedsAfter,
+			positionCollateralAfter,
+			realizedProfitDelta: roundCurrency(releasedProceeds - coverCost),
+			settlementIfChosen: 0,
+			settlementIfNotChosen: positionCollateralAfter,
+			maxProfitIfChosen: 0,
+			maxProfitIfNotChosen: positionProceedsAfter,
+			maxLossIfChosen: roundCurrency(
+				positionCollateralAfter - positionProceedsAfter,
+			),
+			maxLossIfNotChosen: 0,
+		};
+	}
+
+	let nextPricingShares = [...pricingShares];
 	const buildProbabilities = (): {
 		currentProbability: number;
 		nextProbability: number;
-	} => {
-		const nextActiveProbabilities =
-			tradableOutcomeIndexes.length === 0
-				? []
-				: getMarketProbabilities({
-						...market,
-						outcomes: market.outcomes.map((marketOutcome, index) => ({
-							...marketOutcome,
-							pricingShares: tradableOutcomeIndexes.includes(index)
-								? (nextPricingShares[tradableOutcomeIndexes.indexOf(index)] ??
-									marketOutcome.pricingShares)
-								: marketOutcome.pricingShares,
-						})),
-					});
-
-		return {
-			currentProbability,
-			nextProbability: roundCurrency(
-				nextActiveProbabilities[outcomeIndex] ?? 0,
-			),
-		};
-	};
+	} =>
+		buildCategoricalProbabilities(
+			market,
+			outcomeIndex,
+			tradableOutcomeIndexes,
+			nextPricingShares,
+		);
 
 	if (input.action === "buy") {
 		if (shortPosition && shortPosition.shares > 1e-6) {
@@ -158,6 +565,7 @@ const calculateMarketTradeQuoteUnsafe = async (input: {
 
 		return {
 			action: input.action,
+			contractMode: market.contractMode ?? "categorical_single_winner",
 			marketId: market.id,
 			marketTitle: market.title,
 			outcomeId: outcome.id,
@@ -246,6 +654,7 @@ const calculateMarketTradeQuoteUnsafe = async (input: {
 
 		return {
 			action: input.action,
+			contractMode: market.contractMode ?? "categorical_single_winner",
 			marketId: market.id,
 			marketTitle: market.title,
 			outcomeId: outcome.id,
@@ -338,6 +747,7 @@ const calculateMarketTradeQuoteUnsafe = async (input: {
 
 		return {
 			action: input.action,
+			contractMode: market.contractMode ?? "categorical_single_winner",
 			marketId: market.id,
 			marketTitle: market.title,
 			outcomeId: outcome.id,
@@ -449,6 +859,7 @@ const calculateMarketTradeQuoteUnsafe = async (input: {
 
 	return {
 		action: input.action,
+		contractMode: market.contractMode ?? "categorical_single_winner",
 		marketId: market.id,
 		marketTitle: market.title,
 		outcomeId: outcome.id,

--- a/src/features/markets/services/trading/resolution.ts
+++ b/src/features/markets/services/trading/resolution.ts
@@ -1,291 +1,421 @@
-import { type PermissionsBitField } from 'discord.js';
+import { type PermissionsBitField } from "discord.js";
 
-import { prisma } from '../../../../lib/prisma.js';
-import { runSerializableTransaction } from '../../../../lib/run-serializable-transaction.js';
-import { ensureMarketAccountTx } from '../account.js';
-import { persistForecastRecordsTx } from '../forecast/records.js';
+import { prisma } from "../../../../lib/prisma.js";
+import { runSerializableTransaction } from "../../../../lib/run-serializable-transaction.js";
+import { ensureMarketAccountTx } from "../account.js";
+import { persistForecastRecordsTx } from "../forecast/records.js";
 import {
-  assertCanResolveMarket,
-  assertCanResolveOutcome,
-  computeSupplementaryBonusDistribution,
-  getLossProtection,
-  getLossProtectionMap,
-  getMarketForUpdate,
-  marketInclude,
-  roundCurrency,
-} from '../../core/shared.js';
+	assertCanResolveMarket,
+	assertCanResolveOutcome,
+	computeSupplementaryBonusDistribution,
+	getMarketResolutionVector,
+	isIndependentMarketMode,
+	getLossProtection,
+	getLossProtectionMap,
+	getMarketForUpdate,
+	marketInclude,
+	roundCurrency,
+} from "../../core/shared.js";
 import type {
-  MarketOutcomeResolutionResult,
-  MarketResolutionResult,
-} from '../../core/types.js';
-import { groupPositionsByUser } from './shared.js';
+	MarketOutcomeResolutionResult,
+	MarketResolutionResult,
+} from "../../core/types.js";
+import { groupPositionsByUser } from "./shared.js";
+
+const validateSettlementValue = (value: number): number => {
+	if (!Number.isFinite(value) || value < 0 || value > 1) {
+		throw new Error("Settlement value must be a number between 0 and 1.");
+	}
+
+	return roundCurrency(value);
+};
 
 export const resolveMarketOutcome = async (input: {
-  marketId: string;
-  actorId: string;
-  outcomeId: string;
-  note?: string | null;
-  evidenceUrl?: string | null;
-  permissions?: PermissionsBitField | Readonly<PermissionsBitField> | null;
+	marketId: string;
+	actorId: string;
+	outcomeId: string;
+	settlementValue?: number;
+	note?: string | null;
+	evidenceUrl?: string | null;
+	permissions?: PermissionsBitField | Readonly<PermissionsBitField> | null;
 }): Promise<MarketOutcomeResolutionResult> =>
-  runSerializableTransaction(async (tx) => {
-    const market = await getMarketForUpdate(tx, input.marketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+	runSerializableTransaction(async (tx) => {
+		const market = await getMarketForUpdate(tx, input.marketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
 
-    assertCanResolveOutcome(market, input.actorId, input.permissions);
-    const outcome = market.outcomes.find((entry) => entry.id === input.outcomeId);
-    if (!outcome) {
-      throw new Error('Market outcome not found.');
-    }
+		assertCanResolveOutcome(market, input.actorId, input.permissions);
+		const outcome = market.outcomes.find(
+			(entry) => entry.id === input.outcomeId,
+		);
+		if (!outcome) {
+			throw new Error("Market outcome not found.");
+		}
 
-    if (outcome.settlementValue !== null) {
-      throw new Error('That outcome has already been resolved.');
-    }
+		if (outcome.settlementValue !== null) {
+			throw new Error("That outcome has already been resolved.");
+		}
 
-    const payouts = new Map<string, { payout: number; profit: number; bonus: number }>();
-    const positionsByUser = groupPositionsByUser(
-      market.positions.filter((entry) => entry.outcomeId === outcome.id),
-    );
-    const protectionMap = getLossProtectionMap((market.lossProtections ?? []).filter((entry) => entry.outcomeId === outcome.id));
+		const settlementValue = input.settlementValue ?? 0;
+		const normalizedSettlementValue = validateSettlementValue(settlementValue);
+		if (!isIndependentMarketMode(market) && normalizedSettlementValue > 1e-6) {
+			throw new Error(
+				"Single-winner markets can only resolve an individual outcome to 0.",
+			);
+		}
 
-    for (const [userId, positions] of positionsByUser) {
-      const account = await ensureMarketAccountTx(tx, market.guildId, userId);
-      let payout = 0;
-      let profit = 0;
+		const payouts = new Map<
+			string,
+			{ payout: number; profit: number; bonus: number }
+		>();
+		const positionsByUser = groupPositionsByUser(
+			market.positions.filter((entry) => entry.outcomeId === outcome.id),
+		);
+		const protectionMap = getLossProtectionMap(
+			(market.lossProtections ?? []).filter(
+				(entry) => entry.outcomeId === outcome.id,
+			),
+		);
 
-      for (const position of positions) {
-        if (position.side === 'long') {
-          const protection = getLossProtection(protectionMap, userId, position.outcomeId);
-          payout += protection?.insuredCostBasis ?? 0;
-          profit += protection?.insuredCostBasis ?? 0;
-          profit -= position.costBasis;
-          continue;
-        }
+		for (const [userId, positions] of positionsByUser) {
+			const account = await ensureMarketAccountTx(tx, market.guildId, userId);
+			let payout = 0;
+			let profit = 0;
 
-        payout += position.collateralLocked;
-        profit += position.proceeds;
-      }
+			for (const position of positions) {
+				if (position.side === "long") {
+					const protection = getLossProtection(
+						protectionMap,
+						userId,
+						position.outcomeId,
+					);
+					const insuredCostBasis = protection?.insuredCostBasis ?? 0;
+					const positionPayout =
+						position.shares * normalizedSettlementValue +
+						insuredCostBasis * (1 - normalizedSettlementValue);
+					payout += positionPayout;
+					profit += positionPayout;
+					profit -= position.costBasis;
+					continue;
+				}
 
-      await tx.marketAccount.update({
-        where: {
-          id: account.id,
-        },
-        data: {
-          bankroll: roundCurrency(account.bankroll + payout),
-          realizedProfit: roundCurrency(account.realizedProfit + profit),
-        },
-      });
+				const releasedCollateral =
+					position.collateralLocked * (1 - normalizedSettlementValue);
+				payout += releasedCollateral;
+				profit +=
+					position.proceeds -
+					position.collateralLocked * normalizedSettlementValue;
+			}
 
-      payouts.set(userId, {
-        payout: roundCurrency(payout),
-        profit: roundCurrency(profit),
-        bonus: 0,
-      });
-    }
+			await tx.marketAccount.update({
+				where: {
+					id: account.id,
+				},
+				data: {
+					bankroll: roundCurrency(account.bankroll + payout),
+					realizedProfit: roundCurrency(account.realizedProfit + profit),
+				},
+			});
 
-    await tx.marketPosition.deleteMany({
-      where: {
-        marketId: market.id,
-        outcomeId: outcome.id,
-      },
-    });
-    await tx.marketLossProtection.deleteMany({
-      where: {
-        marketId: market.id,
-        outcomeId: outcome.id,
-      },
-    });
+			payouts.set(userId, {
+				payout: roundCurrency(payout),
+				profit: roundCurrency(profit),
+				bonus: 0,
+			});
+		}
 
-    await tx.marketOutcome.update({
-      where: {
-        id: outcome.id,
-      },
-        data: {
-          outstandingShares: 0,
-          pricingShares: 0,
-          settlementValue: 0,
-          resolvedAt: new Date(),
-        resolvedByUserId: input.actorId,
-        resolutionNote: input.note ?? null,
-        resolutionEvidenceUrl: input.evidenceUrl ?? null,
-      },
-    });
+		await tx.marketPosition.deleteMany({
+			where: {
+				marketId: market.id,
+				outcomeId: outcome.id,
+			},
+		});
+		await tx.marketLossProtection.deleteMany({
+			where: {
+				marketId: market.id,
+				outcomeId: outcome.id,
+			},
+		});
 
-    await tx.market.update({
-      where: {
-        id: market.id,
-      },
-      data: {
-        updatedAt: new Date(),
-      },
-    });
+		await tx.marketOutcome.update({
+			where: {
+				id: outcome.id,
+			},
+			data: {
+				outstandingShares: 0,
+				pricingShares: 0,
+				settlementValue: normalizedSettlementValue,
+				resolvedAt: new Date(),
+				resolvedByUserId: input.actorId,
+				resolutionNote: input.note ?? null,
+				resolutionEvidenceUrl: input.evidenceUrl ?? null,
+			},
+		});
 
-    const updatedMarket = await tx.market.findUniqueOrThrow({
-      where: {
-        id: market.id,
-      },
-      include: marketInclude,
-    });
+		await tx.market.update({
+			where: {
+				id: market.id,
+			},
+			data: {
+				...(isIndependentMarketMode(market)
+					? {
+							...(market.outcomes.every(
+								(entry) =>
+									entry.id === outcome.id || entry.settlementValue !== null,
+							)
+								? {
+										resolvedAt: new Date(),
+										tradingClosedAt: market.tradingClosedAt ?? new Date(),
+										winningOutcomeId: (() => {
+											const resolutionVector = getMarketResolutionVector({
+												contractMode:
+													market.contractMode ?? "categorical_single_winner",
+												winningOutcomeId: market.winningOutcomeId,
+												outcomes: market.outcomes.map((entry) => ({
+													id: entry.id,
+													settlementValue:
+														entry.id === outcome.id
+															? normalizedSettlementValue
+															: entry.settlementValue,
+												})),
+											});
+											let winnerIndex = 0;
+											let winnerValue = -1;
+											for (
+												let index = 0;
+												index < resolutionVector.length;
+												index += 1
+											) {
+												const value = resolutionVector[index] ?? 0;
+												if (value > winnerValue) {
+													winnerValue = value;
+													winnerIndex = index;
+												}
+											}
 
-    return {
-      market: updatedMarket,
-      outcome: updatedMarket.outcomes.find((entry) => entry.id === outcome.id) ?? outcome,
-      payouts: [...payouts.entries()].map(([userId, value]) => ({
-        userId,
-        payout: value.payout,
-        profit: value.profit,
-        bonus: value.bonus,
-      })),
-    };
-  });
+											return (
+												market.outcomes[winnerIndex]?.id ??
+												market.winningOutcomeId ??
+												null
+											);
+										})(),
+										resolvedByUserId: input.actorId,
+										supplementaryBonusExpiredAt:
+											market.supplementaryBonusPool > 0
+												? new Date()
+												: market.supplementaryBonusExpiredAt,
+									}
+								: {}),
+						}
+					: {}),
+				updatedAt: new Date(),
+			},
+		});
+
+		const updatedMarket = await tx.market.findUniqueOrThrow({
+			where: {
+				id: market.id,
+			},
+			include: marketInclude,
+		});
+		if (updatedMarket.resolvedAt) {
+			await persistForecastRecordsTx(tx, updatedMarket);
+		}
+
+		return {
+			market: updatedMarket,
+			outcome:
+				updatedMarket.outcomes.find((entry) => entry.id === outcome.id) ??
+				outcome,
+			payouts: [...payouts.entries()].map(([userId, value]) => ({
+				userId,
+				payout: value.payout,
+				profit: value.profit,
+				bonus: value.bonus,
+			})),
+		};
+	});
 
 export const resolveMarket = async (input: {
-  marketId: string;
-  actorId: string;
-  winningOutcomeId: string;
-  note?: string | null;
-  evidenceUrl?: string | null;
-  permissions?: PermissionsBitField | Readonly<PermissionsBitField> | null;
+	marketId: string;
+	actorId: string;
+	winningOutcomeId: string;
+	note?: string | null;
+	evidenceUrl?: string | null;
+	permissions?: PermissionsBitField | Readonly<PermissionsBitField> | null;
 }): Promise<MarketResolutionResult> =>
-  prisma.$transaction(async (tx) => {
-    const resolvedAt = new Date();
-    const market = await getMarketForUpdate(tx, input.marketId);
-    if (!market) {
-      throw new Error('Market not found.');
-    }
+	prisma.$transaction(async (tx) => {
+		const resolvedAt = new Date();
+		const market = await getMarketForUpdate(tx, input.marketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
 
-    assertCanResolveMarket(market, input.actorId, input.permissions);
-    const winningOutcome = market.outcomes.find((outcome) => outcome.id === input.winningOutcomeId);
-    if (!winningOutcome) {
-      throw new Error('Winning outcome not found.');
-    }
+		assertCanResolveMarket(market, input.actorId, input.permissions);
+		if (isIndependentMarketMode(market)) {
+			throw new Error(
+				"Independent markets must be resolved outcome-by-outcome with settlement values.",
+			);
+		}
+		const winningOutcome = market.outcomes.find(
+			(outcome) => outcome.id === input.winningOutcomeId,
+		);
+		if (!winningOutcome) {
+			throw new Error("Winning outcome not found.");
+		}
 
-    const payouts = new Map<string, {
-      payout: number;
-      profit: number;
-      bonus: number;
-      positions: MarketResolutionResult['payouts'][number]['positions'];
-    }>();
-    const positionsByUser = groupPositionsByUser(market.positions);
-    const protectionMap = getLossProtectionMap(market.lossProtections ?? []);
+		const payouts = new Map<
+			string,
+			{
+				payout: number;
+				profit: number;
+				bonus: number;
+				positions: MarketResolutionResult["payouts"][number]["positions"];
+			}
+		>();
+		const positionsByUser = groupPositionsByUser(market.positions);
+		const protectionMap = getLossProtectionMap(market.lossProtections ?? []);
 
-    for (const [userId, positions] of positionsByUser) {
-      let payout = 0;
-      let profit = 0;
+		for (const [userId, positions] of positionsByUser) {
+			let payout = 0;
+			let profit = 0;
 
-      for (const position of positions) {
-        if (position.side === 'long') {
-          const isWinner = position.outcomeId === winningOutcome.id;
-          const positionPayout = isWinner ? position.shares : 0;
-          const protection = isWinner ? undefined : getLossProtection(protectionMap, userId, position.outcomeId);
-          payout += positionPayout;
-          payout += protection?.insuredCostBasis ?? 0;
-          profit += positionPayout + (protection?.insuredCostBasis ?? 0) - position.costBasis;
-          continue;
-        }
+			for (const position of positions) {
+				if (position.side === "long") {
+					const isWinner = position.outcomeId === winningOutcome.id;
+					const positionPayout = isWinner ? position.shares : 0;
+					const protection = isWinner
+						? undefined
+						: getLossProtection(protectionMap, userId, position.outcomeId);
+					payout += positionPayout;
+					payout += protection?.insuredCostBasis ?? 0;
+					profit +=
+						positionPayout +
+						(protection?.insuredCostBasis ?? 0) -
+						position.costBasis;
+					continue;
+				}
 
-        const shortWins = position.outcomeId !== winningOutcome.id;
-        const releasedCollateral = shortWins ? position.collateralLocked : 0;
-        payout += releasedCollateral;
-        profit += shortWins ? position.proceeds : position.proceeds - position.collateralLocked;
-      }
+				const shortWins = position.outcomeId !== winningOutcome.id;
+				const releasedCollateral = shortWins ? position.collateralLocked : 0;
+				payout += releasedCollateral;
+				profit += shortWins
+					? position.proceeds
+					: position.proceeds - position.collateralLocked;
+			}
 
-      payouts.set(userId, {
-        payout: roundCurrency(payout),
-        profit: roundCurrency(profit),
-        bonus: 0,
-        positions: positions.map((position) => ({
-          outcomeId: position.outcomeId,
-          outcomeLabel: market.outcomes.find((outcome) => outcome.id === position.outcomeId)?.label ?? position.outcomeId,
-          side: position.side,
-          shares: roundCurrency(position.shares),
-          costBasis: roundCurrency(position.costBasis),
-          proceeds: roundCurrency(position.proceeds),
-          collateralLocked: roundCurrency(position.collateralLocked),
-        })),
-      });
-    }
+			payouts.set(userId, {
+				payout: roundCurrency(payout),
+				profit: roundCurrency(profit),
+				bonus: 0,
+				positions: positions.map((position) => ({
+					outcomeId: position.outcomeId,
+					outcomeLabel:
+						market.outcomes.find((outcome) => outcome.id === position.outcomeId)
+							?.label ?? position.outcomeId,
+					side: position.side,
+					shares: roundCurrency(position.shares),
+					costBasis: roundCurrency(position.costBasis),
+					proceeds: roundCurrency(position.proceeds),
+					collateralLocked: roundCurrency(position.collateralLocked),
+				})),
+			});
+		}
 
-    const bonuses = computeSupplementaryBonusDistribution(
-      new Map([...payouts.entries()].map(([userId, value]) => [userId, value.profit])),
-      market.supplementaryBonusPool,
-    );
+		const bonuses = computeSupplementaryBonusDistribution(
+			new Map(
+				[...payouts.entries()].map(([userId, value]) => [userId, value.profit]),
+			),
+			market.supplementaryBonusPool,
+		);
 
-    for (const [userId, value] of payouts) {
-      const account = await ensureMarketAccountTx(tx, market.guildId, userId);
-      const bonus = bonuses.get(userId) ?? 0;
-      value.bonus = bonus;
+		for (const [userId, value] of payouts) {
+			const account = await ensureMarketAccountTx(tx, market.guildId, userId);
+			const bonus = bonuses.get(userId) ?? 0;
+			value.bonus = bonus;
 
-      await tx.marketAccount.update({
-        where: {
-          id: account.id,
-        },
-        data: {
-          bankroll: roundCurrency(account.bankroll + value.payout + bonus),
-          realizedProfit: roundCurrency(account.realizedProfit + value.profit + bonus),
-        },
-      });
-    }
+			await tx.marketAccount.update({
+				where: {
+					id: account.id,
+				},
+				data: {
+					bankroll: roundCurrency(account.bankroll + value.payout + bonus),
+					realizedProfit: roundCurrency(
+						account.realizedProfit + value.profit + bonus,
+					),
+				},
+			});
+		}
 
-    await tx.marketPosition.deleteMany({
-      where: {
-        marketId: market.id,
-      },
-    });
-    await tx.marketLossProtection.deleteMany({
-      where: {
-        marketId: market.id,
-      },
-    });
+		await tx.marketPosition.deleteMany({
+			where: {
+				marketId: market.id,
+			},
+		});
+		await tx.marketLossProtection.deleteMany({
+			where: {
+				marketId: market.id,
+			},
+		});
 
-    await Promise.all(market.outcomes.map((outcome) =>
-      tx.marketOutcome.update({
-        where: {
-          id: outcome.id,
-        },
-        data: {
-          outstandingShares: 0,
-          pricingShares: 0,
-          settlementValue: outcome.id === winningOutcome.id ? 1 : outcome.settlementValue ?? 0,
-          resolvedAt: outcome.resolvedAt ?? resolvedAt,
-          resolvedByUserId: outcome.resolvedByUserId ?? input.actorId,
-          resolutionNote: outcome.id === winningOutcome.id
-            ? input.note ?? outcome.resolutionNote ?? null
-            : outcome.resolutionNote ?? null,
-          resolutionEvidenceUrl: outcome.id === winningOutcome.id
-            ? input.evidenceUrl ?? outcome.resolutionEvidenceUrl ?? null
-            : outcome.resolutionEvidenceUrl ?? null,
-        },
-      })));
+		await Promise.all(
+			market.outcomes.map((outcome) =>
+				tx.marketOutcome.update({
+					where: {
+						id: outcome.id,
+					},
+					data: {
+						outstandingShares: 0,
+						pricingShares: 0,
+						settlementValue:
+							outcome.id === winningOutcome.id
+								? 1
+								: (outcome.settlementValue ?? 0),
+						resolvedAt: outcome.resolvedAt ?? resolvedAt,
+						resolvedByUserId: outcome.resolvedByUserId ?? input.actorId,
+						resolutionNote:
+							outcome.id === winningOutcome.id
+								? (input.note ?? outcome.resolutionNote ?? null)
+								: (outcome.resolutionNote ?? null),
+						resolutionEvidenceUrl:
+							outcome.id === winningOutcome.id
+								? (input.evidenceUrl ?? outcome.resolutionEvidenceUrl ?? null)
+								: (outcome.resolutionEvidenceUrl ?? null),
+					},
+				}),
+			),
+		);
 
-    const resolvedMarket = await tx.market.update({
-      where: {
-        id: market.id,
-      },
-      data: {
-        tradingClosedAt: market.tradingClosedAt ?? resolvedAt,
-        resolvedAt,
-        winningOutcomeId: winningOutcome.id,
-        resolutionNote: input.note ?? null,
-        resolutionEvidenceUrl: input.evidenceUrl ?? null,
-        resolvedByUserId: input.actorId,
-        supplementaryBonusDistributedAt: bonuses.size > 0 ? resolvedAt : null,
-        supplementaryBonusExpiredAt: bonuses.size === 0 && market.supplementaryBonusPool > 0 ? resolvedAt : null,
-      },
-      include: marketInclude,
-    });
-    await persistForecastRecordsTx(tx, resolvedMarket);
+		const resolvedMarket = await tx.market.update({
+			where: {
+				id: market.id,
+			},
+			data: {
+				tradingClosedAt: market.tradingClosedAt ?? resolvedAt,
+				resolvedAt,
+				winningOutcomeId: winningOutcome.id,
+				resolutionNote: input.note ?? null,
+				resolutionEvidenceUrl: input.evidenceUrl ?? null,
+				resolvedByUserId: input.actorId,
+				supplementaryBonusDistributedAt: bonuses.size > 0 ? resolvedAt : null,
+				supplementaryBonusExpiredAt:
+					bonuses.size === 0 && market.supplementaryBonusPool > 0
+						? resolvedAt
+						: null,
+			},
+			include: marketInclude,
+		});
+		await persistForecastRecordsTx(tx, resolvedMarket);
 
-    return {
-      market: resolvedMarket,
-      payouts: [...payouts.entries()].map(([userId, value]) => ({
-        userId,
-        payout: value.payout,
-        profit: value.profit,
-        bonus: value.bonus,
-        positions: value.positions,
-      })),
-    };
-  });
+		return {
+			market: resolvedMarket,
+			payouts: [...payouts.entries()].map(([userId, value]) => ({
+				userId,
+				payout: value.payout,
+				profit: value.profit,
+				bonus: value.bonus,
+				positions: value.positions,
+			})),
+		};
+	});

--- a/src/features/markets/services/trading/resolution.ts
+++ b/src/features/markets/services/trading/resolution.ts
@@ -15,6 +15,7 @@ import {
 	getMarketForUpdate,
 	marketInclude,
 	roundCurrency,
+	roundProbability,
 } from "../../core/shared.js";
 import type {
 	MarketOutcomeResolutionResult,
@@ -27,7 +28,7 @@ const validateSettlementValue = (value: number): number => {
 		throw new Error("Settlement value must be a number between 0 and 1.");
 	}
 
-	return roundCurrency(value);
+	return roundProbability(value);
 };
 
 export const resolveMarketOutcome = async (input: {

--- a/src/features/markets/ui/custom-ids.ts
+++ b/src/features/markets/ui/custom-ids.ts
@@ -69,6 +69,10 @@ export const marketSessionQuickAmountButtonCustomId = (
 	sessionId: string,
 	amount: number,
 ): string => `market:session-quick-amount:${sessionId}:${amount}`;
+export const marketSessionQuickSellButtonCustomId = (
+	sessionId: string,
+	value: "all" | 25 | 50 | 75,
+): string => `market:session-quick-sell:${sessionId}:${value}`;
 export const marketSessionCoverageButtonCustomId = (
 	sessionId: string,
 	coveragePercent: number,

--- a/src/features/markets/ui/render/market.ts
+++ b/src/features/markets/ui/render/market.ts
@@ -56,11 +56,29 @@ const appendButtonToRows = (
 	lastRow.addComponents(button);
 };
 
+const sortOutcomeEntries = <
+	T extends { probability: number; label: string; isResolved: boolean },
+>(
+	entries: T[],
+): T[] =>
+	[...entries].sort((left, right) => {
+		if (left.isResolved !== right.isResolved) {
+			return left.isResolved ? 1 : -1;
+		}
+
+		if (right.probability !== left.probability) {
+			return right.probability - left.probability;
+		}
+
+		return left.label.localeCompare(right.label);
+	});
+
 const buildDetailsFields = (
 	market: MarketWithRelations,
 ): Array<{ name: string; value: string }> => {
 	const summary = getMarketSummary(market);
 	const status = summary.status;
+	const sortedProbabilities = sortOutcomeEntries(summary.probabilities);
 	const isIndependentMarket = market.contractMode === "independent_binary_set";
 	const formatOutcomeStatus = (entry: {
 		isResolved: boolean;
@@ -156,7 +174,7 @@ const buildDetailsFields = (
 		{ name: "Liquidity & Incentives", value: liquidity },
 		{
 			name: "Current Probabilities",
-			value: summary.probabilities
+			value: sortedProbabilities
 				.map(
 					(entry, index) =>
 						`${index + 1}. **${entry.label}** — ${formatOutcomeStatus(entry)} (${entry.shares.toFixed(2)} net shares)`,
@@ -177,6 +195,7 @@ export const buildMarketStatusEmbed = (
 export const buildMarketEmbed = (market: MarketWithRelations): EmbedBuilder => {
 	const summary = getMarketSummary(market);
 	const status = summary.status;
+	const sortedProbabilities = sortOutcomeEntries(summary.probabilities);
 	const isIndependentMarket = market.contractMode === "independent_binary_set";
 	const formatOutcomeStatus = (entry: {
 		isResolved: boolean;
@@ -206,7 +225,7 @@ export const buildMarketEmbed = (market: MarketWithRelations): EmbedBuilder => {
 			},
 			{
 				name: "Current Probabilities",
-				value: summary.probabilities
+				value: sortedProbabilities
 					.map(
 						(entry, index) =>
 							`${index + 1}. **${entry.label}** — ${formatOutcomeStatus(entry)} (${entry.shares.toFixed(2)} net shares)`,

--- a/src/features/markets/ui/render/market.ts
+++ b/src/features/markets/ui/render/market.ts
@@ -30,6 +30,11 @@ const buildMarketSynopsis = (
 	const parts = [
 		`${/^[aeiou]/i.test(status) ? "An" : "A"} ${status} market created by <@${market.creatorId}> that ${closesCopy} <t:${Math.floor(market.closeAt.getTime() / 1000)}:R>.`,
 	];
+	if (market.contractMode === "independent_binary_set") {
+		parts.push(
+			"Outcomes are independent and total displayed probability can exceed 100%.",
+		);
+	}
 
 	if (market.threadId) {
 		parts.push(`Discuss in forum post <#${market.threadId}>.`);
@@ -56,6 +61,22 @@ const buildDetailsFields = (
 ): Array<{ name: string; value: string }> => {
 	const summary = getMarketSummary(market);
 	const status = summary.status;
+	const isIndependentMarket = market.contractMode === "independent_binary_set";
+	const formatOutcomeStatus = (entry: {
+		isResolved: boolean;
+		settlementValue: number | null;
+		probability: number;
+	}): string => {
+		if (!entry.isResolved) {
+			return formatProbabilityPercent(entry.probability);
+		}
+
+		if (isIndependentMarket) {
+			return `Settled ${formatProbabilityPercent(entry.settlementValue ?? 0)}`;
+		}
+
+		return entry.settlementValue === 1 ? "Winner" : "Eliminated";
+	};
 	const timing = [
 		`Created: <t:${Math.floor(market.createdAt.getTime() / 1000)}:F>`,
 		`Closes: <t:${Math.floor(market.closeAt.getTime() / 1000)}:F>`,
@@ -97,6 +118,7 @@ const buildDetailsFields = (
 		`Forum Post Thread ID: ${market.threadId ? `\`${market.threadId}\`` : "No forum post yet"}`,
 		`Creator: <@${market.creatorId}>`,
 		`Button Style: **${market.buttonStyle}**`,
+		`Contract Mode: **${isIndependentMarket ? "Independent Set" : "Single Winner"}**`,
 		`Volume: **${summary.totalVolume} pts**`,
 		`Tags: ${market.tags.length > 0 ? market.tags.map((tag) => `\`${tag}\``).join(" ") : "None"}`,
 	].join("\n");
@@ -104,7 +126,7 @@ const buildDetailsFields = (
 	const resolution =
 		[
 			market.winningOutcomeId
-				? `Winning Outcome: **${market.outcomes.find((outcome) => outcome.id === market.winningOutcomeId)?.label ?? market.winningOutcomeId}**`
+				? `${isIndependentMarket ? "Top Settled Outcome" : "Winning Outcome"}: **${market.outcomes.find((outcome) => outcome.id === market.winningOutcomeId)?.label ?? market.winningOutcomeId}**`
 				: null,
 			market.resolvedByUserId
 				? `Resolved By: <@${market.resolvedByUserId}>`
@@ -137,13 +159,7 @@ const buildDetailsFields = (
 			value: summary.probabilities
 				.map(
 					(entry, index) =>
-						`${index + 1}. **${entry.label}** — ${
-							entry.isResolved
-								? entry.settlementValue === 1
-									? "Winner"
-									: "Eliminated"
-								: formatProbabilityPercent(entry.probability)
-						} (${entry.shares.toFixed(2)} net shares)`,
+						`${index + 1}. **${entry.label}** — ${formatOutcomeStatus(entry)} (${entry.shares.toFixed(2)} net shares)`,
 				)
 				.join("\n"),
 		},
@@ -161,6 +177,22 @@ export const buildMarketStatusEmbed = (
 export const buildMarketEmbed = (market: MarketWithRelations): EmbedBuilder => {
 	const summary = getMarketSummary(market);
 	const status = summary.status;
+	const isIndependentMarket = market.contractMode === "independent_binary_set";
+	const formatOutcomeStatus = (entry: {
+		isResolved: boolean;
+		settlementValue: number | null;
+		probability: number;
+	}): string => {
+		if (!entry.isResolved) {
+			return formatProbabilityPercent(entry.probability);
+		}
+
+		if (isIndependentMarket) {
+			return `Settled ${formatProbabilityPercent(entry.settlementValue ?? 0)}`;
+		}
+
+		return entry.settlementValue === 1 ? "Winner" : "Eliminated";
+	};
 	const unresolvedCount = summary.probabilities.filter(
 		(entry) => !entry.isResolved,
 	).length;
@@ -177,13 +209,7 @@ export const buildMarketEmbed = (market: MarketWithRelations): EmbedBuilder => {
 				value: summary.probabilities
 					.map(
 						(entry, index) =>
-							`${index + 1}. **${entry.label}** — ${
-								entry.isResolved
-									? entry.settlementValue === 1
-										? "Winner"
-										: "Eliminated"
-									: formatProbabilityPercent(entry.probability)
-							} (${entry.shares.toFixed(2)} net shares)`,
+							`${index + 1}. **${entry.label}** — ${formatOutcomeStatus(entry)} (${entry.shares.toFixed(2)} net shares)`,
 					)
 					.join("\n"),
 			},
@@ -200,7 +226,7 @@ export const buildMarketEmbed = (market: MarketWithRelations): EmbedBuilder => {
 				: []),
 		)
 		.setFooter({
-			text: `Market ID: ${market.id} • Volume: ${summary.totalVolume} pts`,
+			text: `${isIndependentMarket ? "Independent Set" : "Single Winner"} • Market ID: ${market.id} • Volume: ${summary.totalVolume} pts`,
 		});
 
 	if (market.description) {
@@ -281,7 +307,9 @@ export const buildMarketResolvePrompt = (
 	embeds: [
 		buildMarketStatusEmbed(
 			"Market Ready To Resolve",
-			`Trading on **${market.title}** is closed. Choose **Resolve** to pick a winner or **Cancel** to refund positions.`,
+			market.contractMode === "independent_binary_set"
+				? `Trading on **${market.title}** is closed. Resolve remaining outcomes with **/market resolve-outcome** and a value between 0 and 1, or cancel to refund positions.`
+				: `Trading on **${market.title}** is closed. Choose **Resolve** to pick a winner or **Cancel** to refund positions.`,
 			0x60a5fa,
 		),
 	],
@@ -290,6 +318,7 @@ export const buildMarketResolvePrompt = (
 			new ButtonBuilder()
 				.setCustomId(marketResolveButtonCustomId(market.id))
 				.setLabel("Resolve")
+				.setDisabled(market.contractMode === "independent_binary_set")
 				.setStyle(ButtonStyle.Success),
 			new ButtonBuilder()
 				.setCustomId(marketCancelButtonCustomId(market.id))

--- a/src/features/markets/ui/render/shared.ts
+++ b/src/features/markets/ui/render/shared.ts
@@ -1,96 +1,102 @@
-import { ButtonStyle } from 'discord.js';
+import { ButtonStyle } from "discord.js";
 
-import { computeMarketSummary, getMarketStatus } from '../../core/shared.js';
-import type { MarketWithRelations } from '../../core/types.js';
+import { computeMarketSummary, getMarketStatus } from "../../core/shared.js";
+import type { MarketWithRelations } from "../../core/types.js";
 
 export const formatMoney = (value: number): string => `${value.toFixed(2)} pts`;
-export const formatPercent = (value: number): string => `${(value * 100).toFixed(1)}%`;
-export const formatBrier = (value: number | null): string => value === null ? 'N/A' : value.toFixed(4);
+export const formatPercent = (value: number): string =>
+	`${(value * 100).toFixed(1)}%`;
+export const formatBrier = (value: number | null): string =>
+	value === null ? "N/A" : value.toFixed(4);
 
 export const truncateLabel = (value: string, max = 16): string => {
-  if (max <= 0) {
-    return '';
-  }
+	if (max <= 0) {
+		return "";
+	}
 
-  if (value.length <= max) {
-    return value;
-  }
+	if (value.length <= max) {
+		return value;
+	}
 
-  if (max === 1) {
-    return '\u2026';
-  }
+	if (max === 1) {
+		return "\u2026";
+	}
 
-  return `${value.slice(0, max - 1)}\u2026`;
+	return `${value.slice(0, max - 1)}\u2026`;
 };
 
-export const getTradeCopy = (action: 'buy' | 'sell' | 'short' | 'cover'): {
-  title: string;
-  description: string;
-  color: number;
-  amountLabel: string;
-  placeholder: string;
+export const getTradeCopy = (
+	action: "buy" | "sell" | "short" | "cover",
+): {
+	title: string;
+	description: string;
+	color: number;
+	amountLabel: string;
+	placeholder: string;
 } => {
-  switch (action) {
-    case 'buy':
-      return {
-        title: 'Buy Position',
-        description: 'Choose the outcome you want to buy.',
-        color: 0x57f287,
-        amountLabel: 'Points to spend',
-        placeholder: '50 or 50 pts',
-      };
-    case 'sell':
-      return {
-        title: 'Sell Position',
-        description: 'Choose the long position you want to sell.',
-        color: 0x60a5fa,
-        amountLabel: 'Amount to sell',
-        placeholder: '10 pts or 2.5 shares',
-      };
-    case 'short':
-      return {
-        title: 'Short Position',
-        description: 'Choose the outcome you want to short.',
-        color: 0xf59e0b,
-        amountLabel: 'Amount to short',
-        placeholder: '10 pts or 2.5 shares',
-      };
-    case 'cover':
-      return {
-        title: 'Cover Position',
-        description: 'Choose the short position you want to cover.',
-        color: 0xeb459e,
-        amountLabel: 'Amount to cover',
-        placeholder: '10 pts or 2.5 shares',
-      };
-  }
+	switch (action) {
+		case "buy":
+			return {
+				title: "Buy Position",
+				description: "Choose the outcome you want to buy.",
+				color: 0x57f287,
+				amountLabel: "Points to spend",
+				placeholder: "50 or 50 pts",
+			};
+		case "sell":
+			return {
+				title: "Sell Position",
+				description: "Choose the long position you want to sell.",
+				color: 0x60a5fa,
+				amountLabel: "Amount to sell",
+				placeholder: "all, 50%, 10 pts, or 2.5 shares",
+			};
+		case "short":
+			return {
+				title: "Short Position",
+				description: "Choose the outcome you want to short.",
+				color: 0xf59e0b,
+				amountLabel: "Amount to short",
+				placeholder: "10 pts or 2.5 shares",
+			};
+		case "cover":
+			return {
+				title: "Cover Position",
+				description: "Choose the short position you want to cover.",
+				color: 0xeb459e,
+				amountLabel: "Amount to cover",
+				placeholder: "all, 50%, 10 pts, or 2.5 shares",
+			};
+	}
 };
 
 export const getStatusColor = (market: MarketWithRelations): number => {
-  const status = getMarketStatus(market);
-  switch (status) {
-    case 'resolved':
-      return 0x57f287;
-    case 'cancelled':
-      return 0xf59e0b;
-    case 'closed':
-      return 0xef4444;
-    default:
-      return 0x60a5fa;
-  }
+	const status = getMarketStatus(market);
+	switch (status) {
+		case "resolved":
+			return 0x57f287;
+		case "cancelled":
+			return 0xf59e0b;
+		case "closed":
+			return 0xef4444;
+		default:
+			return 0x60a5fa;
+	}
 };
 
 export const getMarketSummary = computeMarketSummary;
 
-export const getOutcomeButtonStyle = (market: Pick<MarketWithRelations, 'buttonStyle'>): ButtonStyle => {
-  switch (market.buttonStyle) {
-    case 'secondary':
-      return ButtonStyle.Secondary;
-    case 'success':
-      return ButtonStyle.Success;
-    case 'danger':
-      return ButtonStyle.Danger;
-    default:
-      return ButtonStyle.Primary;
-  }
+export const getOutcomeButtonStyle = (
+	market: Pick<MarketWithRelations, "buttonStyle">,
+): ButtonStyle => {
+	switch (market.buttonStyle) {
+		case "secondary":
+			return ButtonStyle.Secondary;
+		case "success":
+			return ButtonStyle.Success;
+		case "danger":
+			return ButtonStyle.Danger;
+		default:
+			return ButtonStyle.Primary;
+	}
 };

--- a/src/features/markets/ui/render/trades.ts
+++ b/src/features/markets/ui/render/trades.ts
@@ -55,6 +55,11 @@ export const buildMarketTradeSelector = (
 	components: ActionRowBuilder<StringSelectMenuBuilder>[];
 } => {
 	const copy = getTradeCopy(action);
+	const isIndependentMarket = market.contractMode === "independent_binary_set";
+	const description =
+		isIndependentMarket && (action === "buy" || action === "short")
+			? `${copy.description} In independent mode, outcomes settle independently on a 0%-100% scale.`
+			: copy.description;
 	const tradableEntries = getMarketSummary(market).probabilities.filter(
 		(entry) =>
 			!entry.isResolved && !getTradeLockReason(market, entry.outcomeId, action),
@@ -74,7 +79,7 @@ export const buildMarketTradeSelector = (
 	}
 
 	return {
-		embeds: [buildMarketStatusEmbed(copy.title, copy.description, copy.color)],
+		embeds: [buildMarketStatusEmbed(copy.title, description, copy.color)],
 		components: [
 			new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
 				new StringSelectMenuBuilder()
@@ -119,6 +124,7 @@ export const buildMarketOutcomeTradePrompt = (
 
 	const buyLocked = Boolean(getTradeLockReason(market, outcomeId, "buy"));
 	const shortLocked = Boolean(getTradeLockReason(market, outcomeId, "short"));
+	const isIndependentMarket = market.contractMode === "independent_binary_set";
 
 	return {
 		embeds: [
@@ -128,7 +134,9 @@ export const buildMarketOutcomeTradePrompt = (
 					`Current probability: **${formatProbabilityPercent(entry.probability)}**`,
 					`Net shares: **${entry.shares.toFixed(2)}**`,
 					"",
-					"Choose whether you want to buy this outcome or short it.",
+					isIndependentMarket
+						? "Choose whether to buy YES exposure or short YES exposure (take the NO side)."
+						: "Choose whether you want to buy this outcome or short it.",
 				].join("\n"),
 				0x60a5fa,
 			),
@@ -290,8 +298,10 @@ const getPositionAfterCopy = (quote: MarketTradeQuote): string => {
 };
 
 const buildTradeQuoteDescription = (quote: MarketTradeQuote): string => {
+	const isIndependentMarket = quote.contractMode === "independent_binary_set";
 	const lines = [
 		`Outcome: **${quote.outcomeLabel}**`,
+		`Contract mode: **${isIndependentMarket ? "Independent Set" : "Single Winner"}**`,
 		`Board: **${formatPercent(quote.currentProbability)}** -> **${formatPercent(quote.nextProbability)}**`,
 	];
 
@@ -341,8 +351,17 @@ const buildTradeQuoteDescription = (quote: MarketTradeQuote): string => {
 
 	lines.push(
 		"",
-		`If ${quote.outcomeLabel} is chosen: payout **${formatMoney(quote.settlementIfChosen)}**, max loss **${formatMoney(quote.maxLossIfChosen)}**, max profit **${formatMoney(quote.maxProfitIfChosen)}**`,
-		`If ${quote.outcomeLabel} is not chosen: payout **${formatMoney(quote.settlementIfNotChosen)}**, max loss **${formatMoney(quote.maxLossIfNotChosen)}**, max profit **${formatMoney(quote.maxProfitIfNotChosen)}**`,
+		isIndependentMarket
+			? `If ${quote.outcomeLabel} settles to 100%: payout **${formatMoney(quote.settlementIfChosen)}**, max loss **${formatMoney(quote.maxLossIfChosen)}**, max profit **${formatMoney(quote.maxProfitIfChosen)}**`
+			: `If ${quote.outcomeLabel} is chosen: payout **${formatMoney(quote.settlementIfChosen)}**, max loss **${formatMoney(quote.maxLossIfChosen)}**, max profit **${formatMoney(quote.maxProfitIfChosen)}**`,
+		isIndependentMarket
+			? `If ${quote.outcomeLabel} settles to 0%: payout **${formatMoney(quote.settlementIfNotChosen)}**, max loss **${formatMoney(quote.maxLossIfNotChosen)}**, max profit **${formatMoney(quote.maxProfitIfNotChosen)}**`
+			: `If ${quote.outcomeLabel} is not chosen: payout **${formatMoney(quote.settlementIfNotChosen)}**, max loss **${formatMoney(quote.maxLossIfNotChosen)}**, max profit **${formatMoney(quote.maxProfitIfNotChosen)}**`,
+		...(isIndependentMarket
+			? [
+					`For intermediate settlement values (e.g. ${formatPercent(0.35)}), payout scales linearly between those bounds.`,
+				]
+			: []),
 		"",
 		"This quote is based on the current board and may change before you confirm.",
 	);
@@ -392,7 +411,7 @@ const buildProtectionQuoteDescription = (
 		`Target insured basis: **${formatMoney(quote.targetInsuredCostBasis)}**`,
 		`Additional insured basis: **${formatMoney(quote.incrementalInsuredCostBasis)}**`,
 		`Premium now: **${formatMoney(quote.premium)}**`,
-		`Refund if ${quote.outcomeLabel} loses: **${formatMoney(quote.payoutIfLoses)}**`,
+		`Max refund if ${quote.outcomeLabel} settles to 0%: **${formatMoney(quote.payoutIfLoses)}**`,
 		"",
 		"If you sell later, protected basis shrinks with the remaining position. This quote may change before you confirm.",
 	].join("\n");
@@ -417,6 +436,10 @@ export const buildMarketInteractionSessionMessage = (input: {
 	components: ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[];
 } => {
 	const { market, session, positions } = input;
+	const isIndependentMarket = market.contractMode === "independent_binary_set";
+	const contractModeLabel = isIndependentMarket
+		? "Independent Set"
+		: "Single Winner";
 	const rows: ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[] = [];
 
 	if (session.mode === "trade") {
@@ -429,6 +452,7 @@ export const buildMarketInteractionSessionMessage = (input: {
 		);
 		const header = [
 			`Market: **${market.title}**`,
+			`Contract mode: **${contractModeLabel}**`,
 			`Action: **${selectedAction === "buy" ? "Buy" : "Short"}**`,
 			`Outcome: **${selectedOutcome?.label ?? "Choose an outcome"}**`,
 			`Amount: **${session.amountInput ?? "Choose a quick amount or open the modal"}**`,
@@ -553,6 +577,7 @@ export const buildMarketInteractionSessionMessage = (input: {
 			: `${selectedAction.charAt(0).toUpperCase()}${selectedAction.slice(1)}`;
 	const description = [
 		`Market: **${market.title}**`,
+		`Contract mode: **${contractModeLabel}**`,
 		selectedPosition
 			? `Position: **${selectedPosition.side === "long" ? "LONG" : "SHORT"} ${selectedPosition.outcomeLabel} ${selectedPosition.shares.toFixed(2)}**`
 			: "Position: **Choose a position**",
@@ -858,7 +883,7 @@ export const buildLossProtectionQuoteMessage = (
 				`Target insured basis: **${formatMoney(quote.targetInsuredCostBasis)}**`,
 				`Additional insured basis: **${formatMoney(quote.incrementalInsuredCostBasis)}**`,
 				`Premium now: **${formatMoney(quote.premium)}**`,
-				`Refund if ${quote.outcomeLabel} loses: **${formatMoney(quote.targetInsuredCostBasis)}**`,
+				`Max refund if ${quote.outcomeLabel} settles to 0%: **${formatMoney(quote.targetInsuredCostBasis)}**`,
 				"",
 				"If you sell later, protected basis shrinks with the remaining position. This quote may change before you confirm.",
 			].join("\n"),

--- a/src/features/markets/ui/render/trades.ts
+++ b/src/features/markets/ui/render/trades.ts
@@ -921,7 +921,7 @@ export const buildLossProtectionQuoteMessage = (
 				`Target insured basis: **${formatMoney(quote.targetInsuredCostBasis)}**`,
 				`Additional insured basis: **${formatMoney(quote.incrementalInsuredCostBasis)}**`,
 				`Premium now: **${formatMoney(quote.premium)}**`,
-				`Max refund if ${quote.outcomeLabel} settles to 0%: **${formatMoney(quote.targetInsuredCostBasis)}**`,
+				`Max refund if ${quote.outcomeLabel} settles to 0%: **${formatMoney(quote.payoutIfLoses)}**`,
 				"",
 				"If you sell later, protected basis shrinks with the remaining position. This quote may change before you confirm.",
 			].join("\n"),

--- a/src/features/markets/ui/render/trades.ts
+++ b/src/features/markets/ui/render/trades.ts
@@ -20,6 +20,7 @@ import {
 	marketSessionOutcomeSelectCustomId,
 	marketSessionPositionSelectCustomId,
 	marketSessionQuickAmountButtonCustomId,
+	marketSessionQuickSellButtonCustomId,
 	marketSessionSideButtonCustomId,
 	marketProtectionCoverageButtonCustomId,
 	marketProtectionSelectCustomId,
@@ -703,7 +704,44 @@ export const buildMarketInteractionSessionMessage = (input: {
 						.setDisabled(selectedPosition.coverageRatio >= 1),
 				),
 			);
-		} else if (selectedAction === "sell" || selectedAction === "cover") {
+		} else if (selectedAction === "sell") {
+			rows.push(
+				new ActionRowBuilder<ButtonBuilder>().addComponents(
+					new ButtonBuilder()
+						.setCustomId(
+							marketSessionQuickSellButtonCustomId(session.sessionId, "all"),
+						)
+						.setLabel("Sell All")
+						.setStyle(ButtonStyle.Secondary),
+					new ButtonBuilder()
+						.setCustomId(
+							marketSessionQuickSellButtonCustomId(session.sessionId, 25),
+						)
+						.setLabel("25%")
+						.setStyle(ButtonStyle.Secondary),
+					new ButtonBuilder()
+						.setCustomId(
+							marketSessionQuickSellButtonCustomId(session.sessionId, 50),
+						)
+						.setLabel("50%")
+						.setStyle(ButtonStyle.Secondary),
+					new ButtonBuilder()
+						.setCustomId(
+							marketSessionQuickSellButtonCustomId(session.sessionId, 75),
+						)
+						.setLabel("75%")
+						.setStyle(ButtonStyle.Secondary),
+				),
+			);
+			rows.push(
+				new ActionRowBuilder<ButtonBuilder>().addComponents(
+					new ButtonBuilder()
+						.setCustomId(marketSessionAmountButtonCustomId(session.sessionId))
+						.setLabel(session.amountInput ? "Edit Amount" : "Custom Amount")
+						.setStyle(ButtonStyle.Primary),
+				),
+			);
+		} else if (selectedAction === "cover") {
 			rows.push(
 				new ActionRowBuilder<ButtonBuilder>().addComponents(
 					new ButtonBuilder()


### PR DESCRIPTION
## Summary
- add `/market pause-trading` so creators/moderators can immediately halt trading without cancelling the market
- DM users when a market is cancelled with their refund amount (including protection premium refunds when applicable)
- sort market embed outcomes by unresolved-first and then probability for a clearer live board
- support faster position exits by accepting `all` and percentage inputs (`25%`, `50%`, `75%`, etc.) in sell/cover parser paths and manage-session quick actions

## Validation
- `pnpm build`