### PR TITLE
feat(markets): add competitive multi-winner contract mode

### DIFF
--- a/prisma/migrations/20260415153000_add_competitive_multi_winner_mode_and_winner_count/migration.sql
+++ b/prisma/migrations/20260415153000_add_competitive_multi_winner_mode_and_winner_count/migration.sql
@@ -1,0 +1,6 @@
+-- AlterEnum
+ALTER TYPE "MarketContractMode" ADD VALUE IF NOT EXISTS 'competitive_multi_winner';
+
+-- AlterTable
+ALTER TABLE "Market"
+ADD COLUMN "winnerCount" INTEGER NOT NULL DEFAULT 1;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,7 @@ enum MarketButtonStyle {
 enum MarketContractMode {
   categorical_single_winner
   independent_binary_set
+  competitive_multi_winner
 }
 
 enum CasinoGameKind {
@@ -331,6 +332,7 @@ model Market {
   description            String?
   buttonStyle            MarketButtonStyle @default(primary)
   contractMode           MarketContractMode @default(categorical_single_winner)
+  winnerCount            Int              @default(1)
   tags                   String[]         @default([])
   baseLiquidityParameter Int              @default(150)
   liquidityParameter     Int              @default(150)

--- a/src/features/markets/commands/definition.ts
+++ b/src/features/markets/commands/definition.ts
@@ -87,10 +87,23 @@ export const marketCommand = new SlashCommandBuilder()
 							value: "categorical_single_winner",
 						},
 						{
+							name: "Competitive Multi-Winner (sum ~k*100%)",
+							value: "competitive_multi_winner",
+						},
+						{
 							name: "Independent Set (sum can exceed 100%)",
 							value: "independent_binary_set",
 						},
 					),
+			)
+			.addIntegerOption((option) =>
+				option
+					.setName("winner_count")
+					.setDescription(
+						"Required for competitive multi-winner (for example 2 in a top-2 market)",
+					)
+					.setRequired(false)
+					.setMinValue(1),
 			)
 			.addStringOption((option) =>
 				option
@@ -146,6 +159,33 @@ export const marketCommand = new SlashCommandBuilder()
 						{ name: "Success", value: "success" },
 						{ name: "Danger", value: "danger" },
 					),
+			)
+			.addStringOption((option) =>
+				option
+					.setName("contract_mode")
+					.setDescription("Updated contract mode")
+					.setRequired(false)
+					.addChoices(
+						{
+							name: "Single Winner (sum ~100%)",
+							value: "categorical_single_winner",
+						},
+						{
+							name: "Competitive Multi-Winner (sum ~k*100%)",
+							value: "competitive_multi_winner",
+						},
+						{
+							name: "Independent Set (sum can exceed 100%)",
+							value: "independent_binary_set",
+						},
+					),
+			)
+			.addIntegerOption((option) =>
+				option
+					.setName("winner_count")
+					.setDescription("Updated winner count for competitive multi-winner")
+					.setRequired(false)
+					.setMinValue(1),
 			)
 			.addStringOption((option) =>
 				option
@@ -294,7 +334,7 @@ export const marketCommand = new SlashCommandBuilder()
 	.addSubcommand((subcommand) =>
 		subcommand
 			.setName("resolve")
-			.setDescription("Resolve a market by naming the winner.")
+			.setDescription("Resolve a market by naming the winner(s).")
 			.addStringOption((option) =>
 				option
 					.setName("query")
@@ -304,7 +344,9 @@ export const marketCommand = new SlashCommandBuilder()
 			.addStringOption((option) =>
 				option
 					.setName("winning_outcome")
-					.setDescription("Winning outcome number, ID, or exact label")
+					.setDescription(
+						"Winner(s): number, ID, or exact label; comma-separated for multi-winner",
+					)
 					.setRequired(true),
 			)
 			.addStringOption((option) =>

--- a/src/features/markets/core/math.ts
+++ b/src/features/markets/core/math.ts
@@ -3,6 +3,306 @@ const binarySearchIterations = 60;
 const clampSmall = (value: number): number =>
 	Math.abs(value) < 1e-9 ? 0 : value;
 
+const computeLogSumExp = (values: number[]): number => {
+	if (values.length === 0) {
+		return Number.NEGATIVE_INFINITY;
+	}
+
+	const max = Math.max(...values);
+	const total = values.reduce((sum, value) => sum + Math.exp(value - max), 0);
+	return max + Math.log(total);
+};
+
+const validateTopKInputs = (
+	shares: number[],
+	liquidity: number,
+	winnerCount: number,
+): void => {
+	if (!Number.isFinite(liquidity) || liquidity <= 0) {
+		throw new Error("Liquidity must be a positive finite number.");
+	}
+
+	if (!Number.isInteger(winnerCount) || winnerCount < 0) {
+		throw new Error("Winner count must be a non-negative integer.");
+	}
+
+	if (winnerCount > shares.length) {
+		throw new Error("Winner count cannot exceed the number of outcomes.");
+	}
+};
+
+export const computeCombinationCount = (n: number, k: number): number => {
+	if (!Number.isInteger(n) || !Number.isInteger(k) || n < 0) {
+		return 0;
+	}
+
+	if (k < 0 || k > n) {
+		return 0;
+	}
+
+	if (k === 0 || k === n) {
+		return 1;
+	}
+
+	const smallerK = Math.min(k, n - k);
+	let result = 1;
+	for (let index = 1; index <= smallerK; index += 1) {
+		result = (result * (n - smallerK + index)) / index;
+	}
+
+	return Math.round(result);
+};
+
+export const enumerateWinnerSubsets = (
+	outcomeCount: number,
+	winnerCount: number,
+): number[][] => {
+	if (!Number.isInteger(outcomeCount) || outcomeCount < 0) {
+		throw new Error("Outcome count must be a non-negative integer.");
+	}
+
+	if (
+		!Number.isInteger(winnerCount) ||
+		winnerCount < 0 ||
+		winnerCount > outcomeCount
+	) {
+		throw new Error(
+			"Winner count must be an integer between 0 and the number of outcomes.",
+		);
+	}
+
+	if (winnerCount === 0) {
+		return [[]];
+	}
+
+	const subsets: number[][] = [];
+	const current: number[] = [];
+
+	const build = (startIndex: number): void => {
+		if (current.length === winnerCount) {
+			subsets.push([...current]);
+			return;
+		}
+
+		const remainingNeeded = winnerCount - current.length;
+		for (
+			let index = startIndex;
+			index <= outcomeCount - remainingNeeded;
+			index += 1
+		) {
+			current.push(index);
+			build(index + 1);
+			current.pop();
+		}
+	};
+
+	build(0);
+	return subsets;
+};
+
+const computeTopKScaledScores = (
+	shares: number[],
+	liquidity: number,
+	winnerCount: number,
+): {
+	subsets: number[][];
+	scaledScores: number[];
+} => {
+	const subsets = enumerateWinnerSubsets(shares.length, winnerCount);
+	const scaledScores = subsets.map((subset) => {
+		const score = subset.reduce(
+			(sum, outcomeIndex) => sum + (shares[outcomeIndex] ?? 0),
+			0,
+		);
+		return score / liquidity;
+	});
+
+	return {
+		subsets,
+		scaledScores,
+	};
+};
+
+export const computeTopKCost = (
+	shares: number[],
+	liquidity: number,
+	winnerCount: number,
+): number => {
+	validateTopKInputs(shares, liquidity, winnerCount);
+
+	if (shares.length === 0 || winnerCount === 0) {
+		return 0;
+	}
+
+	if (winnerCount === shares.length) {
+		return shares.reduce((sum, value) => sum + value, 0);
+	}
+
+	const { scaledScores } = computeTopKScaledScores(
+		shares,
+		liquidity,
+		winnerCount,
+	);
+	return liquidity * computeLogSumExp(scaledScores);
+};
+
+export const computeTopKMarginals = (
+	shares: number[],
+	liquidity: number,
+	winnerCount: number,
+): number[] => {
+	validateTopKInputs(shares, liquidity, winnerCount);
+
+	if (shares.length === 0) {
+		return [];
+	}
+
+	if (winnerCount === 0) {
+		return shares.map(() => 0);
+	}
+
+	if (winnerCount === shares.length) {
+		return shares.map(() => 1);
+	}
+
+	const { subsets, scaledScores } = computeTopKScaledScores(
+		shares,
+		liquidity,
+		winnerCount,
+	);
+	const max = Math.max(...scaledScores);
+	const weights = scaledScores.map((value) => Math.exp(value - max));
+	const totalWeight = weights.reduce((sum, value) => sum + value, 0);
+	const marginals = shares.map(() => 0);
+
+	subsets.forEach((subset, subsetIndex) => {
+		const stateProbability = (weights[subsetIndex] ?? 0) / totalWeight;
+		subset.forEach((outcomeIndex) => {
+			marginals[outcomeIndex] =
+				(marginals[outcomeIndex] ?? 0) + stateProbability;
+		});
+	});
+
+	return marginals;
+};
+
+export const computeTopKBuyCost = (
+	shares: number[],
+	outcomeIndex: number,
+	sharesToBuy: number,
+	liquidity: number,
+	winnerCount: number,
+): number => {
+	const baseline = computeTopKCost(shares, liquidity, winnerCount);
+	const nextShares = shares.map((value, index) =>
+		index === outcomeIndex ? value + sharesToBuy : value,
+	);
+	return clampSmall(
+		computeTopKCost(nextShares, liquidity, winnerCount) - baseline,
+	);
+};
+
+export const computeTopKSellPayout = (
+	shares: number[],
+	outcomeIndex: number,
+	sharesToSell: number,
+	liquidity: number,
+	winnerCount: number,
+): number => {
+	const baseline = computeTopKCost(shares, liquidity, winnerCount);
+	const nextShares = shares.map((value, index) =>
+		index === outcomeIndex ? value - sharesToSell : value,
+	);
+	return clampSmall(
+		baseline - computeTopKCost(nextShares, liquidity, winnerCount),
+	);
+};
+
+export const solveTopKBuySharesForAmount = (
+	shares: number[],
+	outcomeIndex: number,
+	amount: number,
+	liquidity: number,
+	winnerCount: number,
+): number => {
+	const baseline = computeTopKCost(shares, liquidity, winnerCount);
+	let low = 0;
+	let high = Math.max(1, amount);
+
+	while (
+		computeTopKCost(
+			shares.map((value, index) =>
+				index === outcomeIndex ? value + high : value,
+			),
+			liquidity,
+			winnerCount,
+		) -
+			baseline <
+		amount
+	) {
+		high *= 2;
+	}
+
+	for (let index = 0; index < binarySearchIterations; index += 1) {
+		const mid = (low + high) / 2;
+		const nextShares = shares.map((value, shareIndex) =>
+			shareIndex === outcomeIndex ? value + mid : value,
+		);
+		const costDelta =
+			computeTopKCost(nextShares, liquidity, winnerCount) - baseline;
+		if (costDelta < amount) {
+			low = mid;
+		} else {
+			high = mid;
+		}
+	}
+
+	return clampSmall(high);
+};
+
+export const solveTopKSellSharesForAmount = (
+	shares: number[],
+	outcomeIndex: number,
+	desiredPayout: number,
+	ownedShares: number,
+	liquidity: number,
+	winnerCount: number,
+): number => {
+	const maxPayout = computeTopKSellPayout(
+		shares,
+		outcomeIndex,
+		ownedShares,
+		liquidity,
+		winnerCount,
+	);
+	if (desiredPayout > maxPayout + 1e-6) {
+		throw new Error(
+			"You do not have enough shares in that outcome to sell that much.",
+		);
+	}
+
+	let low = 0;
+	let high = ownedShares;
+
+	for (let index = 0; index < binarySearchIterations; index += 1) {
+		const mid = (low + high) / 2;
+		const payout = computeTopKSellPayout(
+			shares,
+			outcomeIndex,
+			mid,
+			liquidity,
+			winnerCount,
+		);
+		if (payout < desiredPayout) {
+			low = mid;
+		} else {
+			high = mid;
+		}
+	}
+
+	return clampSmall(high);
+};
+
 export const computeLmsrCost = (
 	shares: number[],
 	liquidity: number,

--- a/src/features/markets/core/shared.ts
+++ b/src/features/markets/core/shared.ts
@@ -18,6 +18,8 @@ import {
 	computeBinaryLmsrProbability,
 	computeBinarySellPayout,
 	computeLmsrProbabilities,
+	computeTopKMarginals,
+	computeTopKSellPayout,
 	computeSellPayout,
 } from "./math.js";
 import type { MarketStatus, MarketWithRelations } from "./types.js";
@@ -33,6 +35,7 @@ export const refreshDelayMs = 5_000;
 export const maxOpenProbability = 0.98;
 export const minOpenProbability = 0.02;
 export const protectionPremiumMultiplier = 1.05;
+export const maxCompetitiveWinnerSubsets = 1_000;
 
 export const marketInclude = {
 	outcomes: {
@@ -76,6 +79,19 @@ export const clamp = (value: number, min: number, max: number): number =>
 const resolveMarketContractMode = (
 	contractMode?: MarketContractMode | null,
 ): MarketContractMode => contractMode ?? "categorical_single_winner";
+
+export const isCompetitiveMultiWinnerMarketMode = (market: {
+	contractMode?: MarketContractMode | null;
+}): boolean =>
+	resolveMarketContractMode(market.contractMode) === "competitive_multi_winner";
+
+export const resolveMarketWinnerCount = (market: {
+	contractMode?: MarketContractMode | null;
+	winnerCount?: number | null;
+}): number =>
+	isCompetitiveMultiWinnerMarketMode(market)
+		? Math.max(1, Math.floor(market.winnerCount ?? 1))
+		: 1;
 
 export const compareMarketHistoryEvents = <
 	T extends {
@@ -148,10 +164,14 @@ export const isIndependentMarketMode = (market: {
 export const getMarketResolutionVector = (
 	market: Pick<Market, "winningOutcomeId"> & {
 		contractMode?: MarketContractMode | null;
+		winnerCount?: number | null;
 		outcomes: Array<Pick<MarketOutcome, "id" | "settlementValue">>;
 	},
 ): number[] => {
-	if (isIndependentMarketMode(market)) {
+	if (
+		isIndependentMarketMode(market) ||
+		isCompetitiveMultiWinnerMarketMode(market)
+	) {
 		return market.outcomes.map((outcome) =>
 			clamp(outcome.settlementValue ?? 0, 0, 1),
 		);
@@ -178,6 +198,7 @@ export const getMarketProbabilities = (
 		"resolvedAt" | "winningOutcomeId" | "liquidityParameter"
 	> & {
 		contractMode?: MarketContractMode | null;
+		winnerCount?: number | null;
 		outcomes: Array<
 			Pick<MarketOutcome, "id" | "pricingShares" | "settlementValue">
 		>;
@@ -203,6 +224,43 @@ export const getMarketProbabilities = (
 	}
 
 	const activeIndexes = getActiveOutcomeIndexes(market.outcomes);
+
+	if (isCompetitiveMultiWinnerMarketMode(market)) {
+		const settledWinnerCount = market.outcomes.reduce(
+			(sum, outcome) =>
+				isMarketOutcomeResolved(outcome)
+					? sum + clamp(outcome.settlementValue ?? 0, 0, 1)
+					: sum,
+			0,
+		);
+		const remainingWinnerCount = Math.max(
+			0,
+			Math.min(
+				activeIndexes.length,
+				Math.round(resolveMarketWinnerCount(market) - settledWinnerCount),
+			),
+		);
+		const activeProbabilities =
+			activeIndexes.length === 0
+				? []
+				: computeTopKMarginals(
+						activeIndexes.map(
+							(index) => market.outcomes[index]?.pricingShares ?? 0,
+						),
+						market.liquidityParameter,
+						remainingWinnerCount,
+					);
+
+		return market.outcomes.map((outcome, index) => {
+			if (isMarketOutcomeResolved(outcome)) {
+				return clamp(outcome.settlementValue ?? 0, 0, 1);
+			}
+
+			const activeIndex = activeIndexes.indexOf(index);
+			return activeIndex >= 0 ? (activeProbabilities[activeIndex] ?? 0) : 0;
+		});
+	}
+
 	if (activeIndexes.length === 0) {
 		return market.outcomes.map((outcome) => outcome.settlementValue ?? 0);
 	}
@@ -366,6 +424,10 @@ export const getTradeLockReason = (
 	outcomeId: string,
 	action: MarketTradeSide,
 ): string | null => {
+	if (isCompetitiveMultiWinnerMarketMode(market) && action === "short") {
+		return "Shorting is not yet supported for competitive multi-winner markets.";
+	}
+
 	if (action !== "buy" && action !== "short") {
 		return null;
 	}
@@ -628,6 +690,35 @@ export const getMaxSellPayout = (
 	const tradableIndex = tradableIndexes.indexOf(index);
 	if (tradableIndex < 0) {
 		return 0;
+	}
+
+	if (isCompetitiveMultiWinnerMarketMode(market)) {
+		const settledWinnerCount = market.outcomes.reduce(
+			(sum, outcome) =>
+				isMarketOutcomeResolved(outcome)
+					? sum + clamp(outcome.settlementValue ?? 0, 0, 1)
+					: sum,
+			0,
+		);
+		const remainingWinnerCount = Math.max(
+			0,
+			Math.min(
+				tradableIndexes.length,
+				Math.round(resolveMarketWinnerCount(market) - settledWinnerCount),
+			),
+		);
+
+		return roundCurrency(
+			computeTopKSellPayout(
+				tradableIndexes.map(
+					(outcomeIndex) => market.outcomes[outcomeIndex]?.pricingShares ?? 0,
+				),
+				tradableIndex,
+				ownedShares,
+				market.liquidityParameter,
+				remainingWinnerCount,
+			),
+		);
 	}
 
 	return roundCurrency(

--- a/src/features/markets/core/types.ts
+++ b/src/features/markets/core/types.ts
@@ -12,8 +12,12 @@ import type {
 	MarketTrade,
 } from "@prisma/client";
 
-export type MarketWithRelations = Omit<Market, "contractMode"> & {
+export type MarketWithRelations = Omit<
+	Market,
+	"contractMode" | "winnerCount"
+> & {
 	contractMode?: MarketContractMode;
+	winnerCount?: number;
 	outcomes: MarketOutcome[];
 	trades: MarketTrade[];
 	positions: MarketPosition[];
@@ -23,7 +27,10 @@ export type MarketWithRelations = Omit<Market, "contractMode"> & {
 };
 
 export type MarketPositionWithProtection = MarketPosition & {
-	market: Omit<Market, "contractMode"> & { contractMode?: MarketContractMode };
+	market: Omit<Market, "contractMode" | "winnerCount"> & {
+		contractMode?: MarketContractMode;
+		winnerCount?: number;
+	};
 	outcome: MarketOutcome;
 	insuredCostBasis?: number;
 	premiumPaid?: number;
@@ -47,6 +54,7 @@ export type MarketCreationInput = {
 	description: string | null;
 	buttonStyle: MarketButtonStyle;
 	contractMode?: MarketContractMode;
+	winnerCount?: number;
 	outcomes: string[];
 	tags: string[];
 	closeAt: Date;
@@ -70,6 +78,7 @@ export type MarketTradeQuoteAction = "buy" | "sell" | "short" | "cover";
 export type MarketTradeQuote = {
 	action: MarketTradeQuoteAction;
 	contractMode?: MarketContractMode;
+	winnerCount?: number;
 	marketId: string;
 	marketTitle: string;
 	outcomeId: string;
@@ -110,6 +119,7 @@ export type MarketTradeQuoteSession = {
 	sessionId: string;
 	action: MarketTradeQuoteAction;
 	contractMode?: MarketContractMode;
+	winnerCount?: number;
 	guildId: string;
 	marketId: string;
 	marketTitle: string;

--- a/src/features/markets/handlers/interactions/commands.ts
+++ b/src/features/markets/handlers/interactions/commands.ts
@@ -64,6 +64,7 @@ import {
 	parseMarketOutcomes,
 	parseMarketTags,
 	parseOutcomeSelection,
+	parseOutcomeSelections,
 	sanitizeMarketDescription,
 	sanitizeMarketTitle,
 } from "../../parsing/market.js";
@@ -79,6 +80,10 @@ import {
 } from "./shared.js";
 import { handleMarketConfigCommand } from "./config.js";
 import type { MarketWithRelations } from "../../core/types.js";
+import {
+	isCompetitiveMultiWinnerMarketMode,
+	resolveMarketWinnerCount,
+} from "../../core/shared.js";
 
 const describeMarketEditChanges = (
 	previous: MarketWithRelations,
@@ -102,6 +107,18 @@ const describeMarketEditChanges = (
 	if (previous.buttonStyle !== updated.buttonStyle) {
 		changes.push(
 			`Button style: **${previous.buttonStyle}** -> **${updated.buttonStyle}**`,
+		);
+	}
+
+	if (previous.contractMode !== updated.contractMode) {
+		changes.push(
+			`Contract mode: **${previous.contractMode}** -> **${updated.contractMode}**`,
+		);
+	}
+
+	if (previous.winnerCount !== updated.winnerCount) {
+		changes.push(
+			`Winner count: **${previous.winnerCount}** -> **${updated.winnerCount}**`,
 		);
 	}
 
@@ -190,6 +207,11 @@ export const handleMarketCommand = async (
 					(interaction.options.getString("contract_mode") as
 						| MarketWithRelations["contractMode"]
 						| null) ?? "categorical_single_winner",
+				...(interaction.options.getInteger("winner_count") !== null
+					? {
+							winnerCount: interaction.options.getInteger("winner_count", true),
+						}
+					: {}),
 				outcomes: parseMarketOutcomes(
 					interaction.options.getString("outcomes", true),
 				),
@@ -258,6 +280,19 @@ export const handleMarketCommand = async (
 								"button_style",
 								true,
 							) as MarketWithRelations["buttonStyle"],
+						}
+					: {}),
+				...(interaction.options.getString("contract_mode") !== null
+					? {
+							contractMode: interaction.options.getString(
+								"contract_mode",
+								true,
+							) as MarketWithRelations["contractMode"],
+						}
+					: {}),
+				...(interaction.options.getInteger("winner_count") !== null
+					? {
+							winnerCount: interaction.options.getInteger("winner_count", true),
 						}
 					: {}),
 				...(interaction.options.getString("tags") !== null
@@ -466,14 +501,21 @@ export const handleMarketCommand = async (
 				throw new Error("Market not found.");
 			}
 
-			const outcome = parseOutcomeSelection(
-				interaction.options.getString("winning_outcome", true),
-				market.outcomes,
+			const winningOutcomeInput = interaction.options.getString(
+				"winning_outcome",
+				true,
 			);
+			const winningOutcomes = isCompetitiveMultiWinnerMarketMode(market)
+				? parseOutcomeSelections(winningOutcomeInput, market.outcomes)
+				: [parseOutcomeSelection(winningOutcomeInput, market.outcomes)];
 			const resolved = await resolveMarket({
 				marketId: market.id,
 				actorId: interaction.user.id,
-				winningOutcomeId: outcome.id,
+				...(isCompetitiveMultiWinnerMarketMode(market)
+					? {
+							winningOutcomeIds: winningOutcomes.map((entry) => entry.id),
+						}
+					: { winningOutcomeId: winningOutcomes[0]!.id }),
 				note: interaction.options.getString("note"),
 				evidenceUrl: validateEvidenceUrl(
 					interaction.options.getString("evidence_url"),
@@ -487,7 +529,9 @@ export const handleMarketCommand = async (
 				embeds: [
 					buildMarketStatusEmbed(
 						"Market Resolved",
-						`Resolved **${resolved.market.title}** in favor of **${outcome.label}**.`,
+						isCompetitiveMultiWinnerMarketMode(market)
+							? `Resolved **${resolved.market.title}** with **${resolveMarketWinnerCount(market)}** winners: **${winningOutcomes.map((entry) => entry.label).join(", ")}**.`
+							: `Resolved **${resolved.market.title}** in favor of **${winningOutcomes[0]?.label ?? "Unknown"}**.`,
 						0x57f287,
 					),
 				],

--- a/src/features/markets/handlers/interactions/modals.ts
+++ b/src/features/markets/handlers/interactions/modals.ts
@@ -16,7 +16,14 @@ import { getMarketById } from "../../services/records.js";
 import { scheduleMarketRefresh } from "../../services/scheduler.js";
 import { cancelMarket } from "../../services/trading/cancel.js";
 import { resolveMarket } from "../../services/trading/resolution.js";
-import { parseOutcomeSelection } from "../../parsing/market.js";
+import {
+	parseOutcomeSelection,
+	parseOutcomeSelections,
+} from "../../parsing/market.js";
+import {
+	isCompetitiveMultiWinnerMarketMode,
+	resolveMarketWinnerCount,
+} from "../../core/shared.js";
 import { createTradeQuotePreview } from "./quotes.js";
 import {
 	buildRootMarketInteractionSessionResponse,
@@ -96,14 +103,19 @@ export const handleMarketModal = async (
 			throw new Error("Market not found.");
 		}
 
-		const outcome = parseOutcomeSelection(
-			interaction.fields.getTextInputValue("winning_outcome"),
-			market.outcomes,
-		);
+		const winningOutcomeInput =
+			interaction.fields.getTextInputValue("winning_outcome");
+		const winningOutcomes = isCompetitiveMultiWinnerMarketMode(market)
+			? parseOutcomeSelections(winningOutcomeInput, market.outcomes)
+			: [parseOutcomeSelection(winningOutcomeInput, market.outcomes)];
 		const resolved = await resolveMarket({
 			marketId: market.id,
 			actorId: interaction.user.id,
-			winningOutcomeId: outcome.id,
+			...(isCompetitiveMultiWinnerMarketMode(market)
+				? {
+						winningOutcomeIds: winningOutcomes.map((entry) => entry.id),
+					}
+				: { winningOutcomeId: winningOutcomes[0]!.id }),
 			note: interaction.fields.getTextInputValue("note").trim() || null,
 			evidenceUrl: validateEvidenceUrl(
 				interaction.fields.getTextInputValue("evidence_url"),
@@ -120,7 +132,9 @@ export const handleMarketModal = async (
 			embeds: [
 				buildMarketStatusEmbed(
 					"Market Resolved",
-					`Resolved **${market.title}** in favor of **${outcome.label}**.`,
+					isCompetitiveMultiWinnerMarketMode(market)
+						? `Resolved **${market.title}** with **${resolveMarketWinnerCount(market)}** winners: **${winningOutcomes.map((entry) => entry.label).join(", ")}**.`
+						: `Resolved **${market.title}** in favor of **${winningOutcomes[0]?.label ?? "Unknown"}**.`,
 					0x57f287,
 				),
 			],

--- a/src/features/markets/handlers/interactions/quotes.ts
+++ b/src/features/markets/handlers/interactions/quotes.ts
@@ -80,6 +80,9 @@ export const createTradeQuotePreview = async (input: {
 		sessionId,
 		action: quote.action,
 		...(quote.contractMode ? { contractMode: quote.contractMode } : {}),
+		...(quote.winnerCount !== undefined
+			? { winnerCount: quote.winnerCount }
+			: {}),
 		guildId: quote.guildId,
 		marketId: quote.marketId,
 		marketTitle: quote.marketTitle,

--- a/src/features/markets/handlers/interactions/shared.ts
+++ b/src/features/markets/handlers/interactions/shared.ts
@@ -5,6 +5,7 @@ import {
 
 import { env } from "../../../../app/config.js";
 import { executeMarketTrade } from "../../services/trading/execution.js";
+import { isCompetitiveMultiWinnerMarketMode } from "../../core/shared.js";
 import {
 	parseFlexibleTradeAmount,
 	parseTradeAmount,
@@ -317,6 +318,9 @@ export const buildTradeExecutionDescription = (
 	outcomeLabel: string,
 	result: Awaited<ReturnType<typeof executeMarketTrade>>,
 ): string => {
+	const isCompetitiveMultiWinner = isCompetitiveMultiWinnerMarketMode(
+		result.market,
+	);
 	const netCashAmount = result.netCashAmount ?? result.cashAmount;
 	const settledShares = Math.abs(result.shareDelta);
 	const payoutSummary =
@@ -337,8 +341,12 @@ export const buildTradeExecutionDescription = (
 		`Bankroll: ${result.account.bankroll.toFixed(2)} pts`,
 		...(payoutSummary
 			? [
-					`If ${outcomeLabel} is chosen: ${payoutSummary.ifChosen.toFixed(2)} pts`,
-					`If ${outcomeLabel} is not chosen: ${payoutSummary.ifNotChosen.toFixed(2)} pts`,
+					isCompetitiveMultiWinner
+						? `If ${outcomeLabel} is among the winners: ${payoutSummary.ifChosen.toFixed(2)} pts`
+						: `If ${outcomeLabel} is chosen: ${payoutSummary.ifChosen.toFixed(2)} pts`,
+					isCompetitiveMultiWinner
+						? `If ${outcomeLabel} misses the winner set: ${payoutSummary.ifNotChosen.toFixed(2)} pts`
+						: `If ${outcomeLabel} is not chosen: ${payoutSummary.ifNotChosen.toFixed(2)} pts`,
 				]
 			: []),
 	]

--- a/src/features/markets/parsing/market.ts
+++ b/src/features/markets/parsing/market.ts
@@ -1,7 +1,7 @@
 import {
-  parseDiscordMessageLink,
-  type DiscordEntityLookup,
-} from '../../../lib/discord-message-links.js';
+	parseDiscordMessageLink,
+	type DiscordEntityLookup,
+} from "../../../lib/discord-message-links.js";
 
 const maxOutcomes = 5;
 const minOutcomes = 2;
@@ -11,213 +11,264 @@ const maxOutcomeLength = 80;
 const maxTags = 10;
 const maxTagLength = 24;
 const minTradeAmount = 10;
-const sellSharesPattern = /^(?<amount>\d+(?:\.\d+)?)\s*(?<unit>share|shares|sh)$/i;
+const sellSharesPattern =
+	/^(?<amount>\d+(?:\.\d+)?)\s*(?<unit>share|shares|sh)$/i;
 const sellPointsPattern = /^(?<amount>\d+)\s*(?<unit>pt|pts|point|points)?$/i;
 
-export type MarketLookup = DiscordEntityLookup<'market-id'>;
+export type MarketLookup = DiscordEntityLookup<"market-id">;
 
 export const sanitizeMarketTitle = (value: string): string => {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    throw new Error('Market title cannot be empty.');
-  }
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error("Market title cannot be empty.");
+	}
 
-  if (trimmed.length > maxTitleLength) {
-    throw new Error(`Market title cannot exceed ${maxTitleLength} characters.`);
-  }
+	if (trimmed.length > maxTitleLength) {
+		throw new Error(`Market title cannot exceed ${maxTitleLength} characters.`);
+	}
 
-  return trimmed;
+	return trimmed;
 };
 
-export const sanitizeMarketDescription = (value: string | null | undefined): string | null => {
-  const trimmed = value?.trim() ?? '';
-  if (!trimmed) {
-    return null;
-  }
+export const sanitizeMarketDescription = (
+	value: string | null | undefined,
+): string | null => {
+	const trimmed = value?.trim() ?? "";
+	if (!trimmed) {
+		return null;
+	}
 
-  if (trimmed.length > maxDescriptionLength) {
-    throw new Error(`Market description cannot exceed ${maxDescriptionLength} characters.`);
-  }
+	if (trimmed.length > maxDescriptionLength) {
+		throw new Error(
+			`Market description cannot exceed ${maxDescriptionLength} characters.`,
+		);
+	}
 
-  return trimmed;
+	return trimmed;
 };
 
 export const parseMarketOutcomes = (value: string): string[] => {
-  const outcomes = parseOutcomeList(value);
-  if (outcomes.length < minOutcomes) {
-    throw new Error(`Markets need at least ${minOutcomes} outcomes.`);
-  }
+	const outcomes = parseOutcomeList(value);
+	if (outcomes.length < minOutcomes) {
+		throw new Error(`Markets need at least ${minOutcomes} outcomes.`);
+	}
 
-  return outcomes;
+	return outcomes;
 };
 
 export const parseAdditionalMarketOutcomes = (value: string): string[] => {
-  const outcomes = parseOutcomeList(value);
-  if (outcomes.length === 0) {
-    throw new Error('Add at least one outcome.');
-  }
+	const outcomes = parseOutcomeList(value);
+	if (outcomes.length === 0) {
+		throw new Error("Add at least one outcome.");
+	}
 
-  return outcomes;
+	return outcomes;
 };
 
 export const parseMarketTags = (value: string | null | undefined): string[] => {
-  if (!value?.trim()) {
-    return [];
-  }
+	if (!value?.trim()) {
+		return [];
+	}
 
-  const tags = [...new Set(
-    value
-      .split(',')
-      .map((part) => part.trim().toLowerCase())
-      .filter(Boolean),
-  )];
+	const tags = [
+		...new Set(
+			value
+				.split(",")
+				.map((part) => part.trim().toLowerCase())
+				.filter(Boolean),
+		),
+	];
 
-  if (tags.length > maxTags) {
-    throw new Error(`Markets can have at most ${maxTags} tags.`);
-  }
+	if (tags.length > maxTags) {
+		throw new Error(`Markets can have at most ${maxTags} tags.`);
+	}
 
-  for (const tag of tags) {
-    if (!/^[a-z0-9][a-z0-9-_]*$/.test(tag)) {
-      throw new Error('Tags must use letters, numbers, hyphens, or underscores.');
-    }
+	for (const tag of tags) {
+		if (!/^[a-z0-9][a-z0-9-_]*$/.test(tag)) {
+			throw new Error(
+				"Tags must use letters, numbers, hyphens, or underscores.",
+			);
+		}
 
-    if (tag.length > maxTagLength) {
-      throw new Error(`Tags must be ${maxTagLength} characters or fewer.`);
-    }
-  }
+		if (tag.length > maxTagLength) {
+			throw new Error(`Tags must be ${maxTagLength} characters or fewer.`);
+		}
+	}
 
-  return tags;
+	return tags;
 };
 
-
 export const parseMarketLookup = (value: string): MarketLookup => {
-  const trimmed = value.trim();
+	const trimmed = value.trim();
 
-  if (!trimmed) {
-    throw new Error('Market lookup value cannot be empty.');
-  }
+	if (!trimmed) {
+		throw new Error("Market lookup value cannot be empty.");
+	}
 
-  const linkMatch = parseDiscordMessageLink(trimmed);
-  if (linkMatch) {
-    return {
-      kind: 'message-link',
-      guildId: linkMatch.guildId,
-      channelId: linkMatch.channelId,
-      messageId: linkMatch.messageId,
-    };
-  }
+	const linkMatch = parseDiscordMessageLink(trimmed);
+	if (linkMatch) {
+		return {
+			kind: "message-link",
+			guildId: linkMatch.guildId,
+			channelId: linkMatch.channelId,
+			messageId: linkMatch.messageId,
+		};
+	}
 
-  if (/^\d{16,25}$/.test(trimmed)) {
-    return {
-      kind: 'message-id',
-      value: trimmed,
-    };
-  }
+	if (/^\d{16,25}$/.test(trimmed)) {
+		return {
+			kind: "message-id",
+			value: trimmed,
+		};
+	}
 
-  return {
-    kind: 'market-id',
-    value: trimmed,
-  };
+	return {
+		kind: "market-id",
+		value: trimmed,
+	};
 };
 
 export const parseTradeAmount = (value: string | number): number => {
-  const normalized = typeof value === 'number'
-    ? value
-    : (() => {
-        const trimmed = value.trim();
-        const match = sellPointsPattern.exec(trimmed);
-        return match?.groups?.amount ? Number(match.groups.amount) : Number.NaN;
-      })();
-  if (!Number.isInteger(normalized) || normalized < minTradeAmount) {
-    throw new Error(`Trade amount must be a whole number of at least ${minTradeAmount} points.`);
-  }
+	const normalized =
+		typeof value === "number"
+			? value
+			: (() => {
+					const trimmed = value.trim();
+					const match = sellPointsPattern.exec(trimmed);
+					return match?.groups?.amount
+						? Number(match.groups.amount)
+						: Number.NaN;
+				})();
+	if (!Number.isInteger(normalized) || normalized < minTradeAmount) {
+		throw new Error(
+			`Trade amount must be a whole number of at least ${minTradeAmount} points.`,
+		);
+	}
 
-  return normalized;
+	return normalized;
 };
 
 export type ParsedTradeAmount =
-  | {
-      mode: 'points';
-      amount: number;
-    }
-  | {
-      mode: 'shares';
-      amount: number;
-    };
+	| {
+			mode: "points";
+			amount: number;
+	  }
+	| {
+			mode: "shares";
+			amount: number;
+	  };
 
 export const parseFlexibleTradeAmount = (value: string): ParsedTradeAmount => {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    throw new Error('Trade amount cannot be empty. Use formats like 10 pts or 2.5 shares.');
-  }
+	const trimmed = value.trim();
+	if (!trimmed) {
+		throw new Error(
+			"Trade amount cannot be empty. Use formats like 10 pts or 2.5 shares.",
+		);
+	}
 
-  const pointsMatch = sellPointsPattern.exec(trimmed);
-  if (pointsMatch?.groups?.amount) {
-    return {
-      mode: 'points',
-      amount: parseTradeAmount(Number(pointsMatch.groups.amount)),
-    };
-  }
+	const pointsMatch = sellPointsPattern.exec(trimmed);
+	if (pointsMatch?.groups?.amount) {
+		return {
+			mode: "points",
+			amount: parseTradeAmount(Number(pointsMatch.groups.amount)),
+		};
+	}
 
-  const sharesMatch = sellSharesPattern.exec(trimmed);
-  if (sharesMatch?.groups?.amount) {
-    const amount = Number(sharesMatch.groups.amount);
-    if (!Number.isFinite(amount) || amount <= 0) {
-      throw new Error('Sell share amount must be greater than 0.');
-    }
+	const sharesMatch = sellSharesPattern.exec(trimmed);
+	if (sharesMatch?.groups?.amount) {
+		const amount = Number(sharesMatch.groups.amount);
+		if (!Number.isFinite(amount) || amount <= 0) {
+			throw new Error("Sell share amount must be greater than 0.");
+		}
 
-    return {
-      mode: 'shares',
-      amount,
-    };
-  }
+		return {
+			mode: "shares",
+			amount,
+		};
+	}
 
-  throw new Error('Trade amount must look like 10 pts or 2.5 shares.');
+	throw new Error("Trade amount must look like 10 pts or 2.5 shares.");
 };
 
 export const parseOutcomeSelection = (
-  value: string,
-  outcomes: Array<{ id: string; label: string }>,
+	value: string,
+	outcomes: Array<{ id: string; label: string }>,
 ): { id: string; label: string } => {
-  const trimmed = value.trim();
-  const byId = outcomes.find((outcome) => outcome.id === trimmed);
-  if (byId) {
-    return byId;
-  }
+	const trimmed = value.trim();
+	const byId = outcomes.find((outcome) => outcome.id === trimmed);
+	if (byId) {
+		return byId;
+	}
 
-  if (/^\d+$/.test(trimmed)) {
-    const index = Number(trimmed) - 1;
-    const byIndex = outcomes[index];
-    if (byIndex) {
-      return byIndex;
-    }
-  }
+	if (/^\d+$/.test(trimmed)) {
+		const index = Number(trimmed) - 1;
+		const byIndex = outcomes[index];
+		if (byIndex) {
+			return byIndex;
+		}
+	}
 
-  const byLabel = outcomes.find((outcome) => outcome.label.toLowerCase() === trimmed.toLowerCase());
-  if (byLabel) {
-    return byLabel;
-  }
+	const byLabel = outcomes.find(
+		(outcome) => outcome.label.toLowerCase() === trimmed.toLowerCase(),
+	);
+	if (byLabel) {
+		return byLabel;
+	}
 
-  throw new Error('Choose a valid market outcome by number, outcome ID, or exact label.');
+	throw new Error(
+		"Choose a valid market outcome by number, outcome ID, or exact label.",
+	);
+};
+
+export const parseOutcomeSelections = (
+	value: string,
+	outcomes: Array<{ id: string; label: string }>,
+): Array<{ id: string; label: string }> => {
+	const tokens = value
+		.split(",")
+		.map((part) => part.trim())
+		.filter(Boolean);
+
+	if (tokens.length === 0) {
+		throw new Error("Choose at least one winning outcome.");
+	}
+
+	const selected = tokens.map((token) =>
+		parseOutcomeSelection(token, outcomes),
+	);
+	const seen = new Set<string>();
+	for (const outcome of selected) {
+		if (seen.has(outcome.id)) {
+			throw new Error("Winning outcomes cannot include duplicates.");
+		}
+
+		seen.add(outcome.id);
+	}
+
+	return selected;
 };
 
 const parseOutcomeList = (value: string): string[] => {
-  const outcomes = [...new Set(
-    value
-      .split(',')
-      .map((part) => part.trim())
-      .filter(Boolean),
-  )];
+	const outcomes = [
+		...new Set(
+			value
+				.split(",")
+				.map((part) => part.trim())
+				.filter(Boolean),
+		),
+	];
 
-  if (outcomes.length > maxOutcomes) {
-    throw new Error(`Markets can have at most ${maxOutcomes} outcomes.`);
-  }
+	if (outcomes.length > maxOutcomes) {
+		throw new Error(`Markets can have at most ${maxOutcomes} outcomes.`);
+	}
 
-  for (const outcome of outcomes) {
-    if (outcome.length > maxOutcomeLength) {
-      throw new Error(`Each outcome must be ${maxOutcomeLength} characters or fewer.`);
-    }
-  }
+	for (const outcome of outcomes) {
+		if (outcome.length > maxOutcomeLength) {
+			throw new Error(
+				`Each outcome must be ${maxOutcomeLength} characters or fewer.`,
+			);
+		}
+	}
 
-  return outcomes;
+	return outcomes;
 };

--- a/src/features/markets/services/forecast/shared.ts
+++ b/src/features/markets/services/forecast/shared.ts
@@ -87,6 +87,7 @@ const inferResolutionVectorFromWinningOutcome = (
 const normalizeForecastVector = (
 	market: Pick<Market, "winningOutcomeId"> & {
 		contractMode?: Market["contractMode"] | null;
+		winnerCount?: number | null;
 		outcomes: Array<Pick<MarketOutcome, "id">>;
 	},
 	weightedProbabilities: Map<string, { weightedSum: number; weight: number }>,
@@ -116,21 +117,43 @@ const normalizeForecastVector = (
 					filledValues[index] = 0.5;
 				}
 			}
-		} else if (knownSum < 1) {
-			const filler = (1 - knownSum) / missingCount;
-			for (let index = 0; index < filledValues.length; index += 1) {
-				if (values[index] === null) {
-					filledValues[index] = filler;
+		} else {
+			const targetTotal =
+				market.contractMode === "competitive_multi_winner"
+					? Math.max(1, Math.floor(market.winnerCount ?? 1))
+					: 1;
+			if (knownSum < targetTotal) {
+				const filler = Math.max(0, targetTotal - knownSum) / missingCount;
+				for (let index = 0; index < filledValues.length; index += 1) {
+					if (values[index] === null) {
+						filledValues[index] = filler;
+					}
 				}
 			}
 		}
 	}
 
-	if (market.contractMode === "independent_binary_set") {
+	if (
+		market.contractMode === "independent_binary_set" ||
+		market.contractMode === "competitive_multi_winner"
+	) {
+		const targetTotal =
+			market.contractMode === "competitive_multi_winner"
+				? Math.max(1, Math.floor(market.winnerCount ?? 1))
+				: null;
+		const total = filledValues.reduce((sum, value) => sum + value, 0);
 		return market.outcomes.map((outcome, index) => ({
 			outcomeId: outcome.id,
 			probability: roundProbability(
-				Math.min(1, Math.max(0, filledValues[index] ?? 0)),
+				Math.min(
+					1,
+					Math.max(
+						0,
+						targetTotal && total > 0
+							? ((filledValues[index] ?? 0) * targetTotal) / total
+							: (filledValues[index] ?? 0),
+					),
+				),
 			),
 		}));
 	}
@@ -218,6 +241,7 @@ export const hydrateForecastRecord = (
 const buildHistoricalProbabilityVector = (
 	market: Pick<Market, "winningOutcomeId"> & {
 		contractMode?: Market["contractMode"] | null;
+		winnerCount?: number | null;
 		outcomes: Array<
 			Pick<MarketOutcome, "id" | "resolvedAt" | "settlementValue">
 		>;
@@ -229,6 +253,9 @@ const buildHistoricalProbabilityVector = (
 	const probabilities = getMarketProbabilities({
 		...(market.contractMode !== undefined
 			? { contractMode: market.contractMode }
+			: {}),
+		...(market.winnerCount !== undefined
+			? { winnerCount: market.winnerCount }
 			: {}),
 		liquidityParameter,
 		resolvedAt: null,
@@ -253,6 +280,7 @@ const buildHistoricalProbabilityVector = (
 const reconstructMarketProfitByUser = (
 	market: Pick<Market, "winningOutcomeId"> & {
 		contractMode?: Market["contractMode"] | null;
+		winnerCount?: number | null;
 		trades: MarketTrade[];
 		outcomes: Array<Pick<MarketOutcome, "id" | "settlementValue">>;
 	},
@@ -351,6 +379,9 @@ const reconstructMarketProfitByUser = (
 	const resolutionVector = getMarketResolutionVector({
 		...(market.contractMode !== undefined
 			? { contractMode: market.contractMode }
+			: {}),
+		...(market.winnerCount !== undefined
+			? { winnerCount: market.winnerCount }
 			: {}),
 		winningOutcomeId: market.winningOutcomeId,
 		outcomes: market.outcomes,

--- a/src/features/markets/services/lifecycle.ts
+++ b/src/features/markets/services/lifecycle.ts
@@ -27,6 +27,10 @@ import type { MarketWithRelations } from "../core/types.js";
 import type { MarketResolutionResult } from "../core/types.js";
 import type { MarketCancellationRefund } from "../core/types.js";
 import { buildMarketDiagram } from "../ui/visualize.js";
+import {
+	isCompetitiveMultiWinnerMarketMode,
+	resolveMarketWinnerCount,
+} from "../core/shared.js";
 
 const buildMarketMessagePayload = async (
 	market: MarketWithRelations,
@@ -283,7 +287,14 @@ export const notifyMarketResolved = async (
 		resolved.market,
 		"Market Resolved",
 		[
-			`**${resolved.market.title}** resolved in favor of **${resolved.market.winningOutcome?.label ?? "Unknown"}**.`,
+			isCompetitiveMultiWinnerMarketMode(resolved.market)
+				? `**${resolved.market.title}** resolved with ${resolveMarketWinnerCount(resolved.market)} winners: **${
+						resolved.market.outcomes
+							.filter((outcome) => (outcome.settlementValue ?? 0) >= 1 - 1e-6)
+							.map((outcome) => outcome.label)
+							.join(", ") || "Unknown"
+					}**.`
+				: `**${resolved.market.title}** resolved in favor of **${resolved.market.winningOutcome?.label ?? "Unknown"}**.`,
 			resolved.market.resolutionNote
 				? `Note: ${resolved.market.resolutionNote}`
 				: null,
@@ -321,7 +332,17 @@ export const notifyMarketResolved = async (
 						buildMarketStatusEmbed(
 							"Your Market Position Resolved",
 							[
-								`**${resolved.market.title}** resolved in favor of **${resolved.market.winningOutcome?.label ?? "Unknown"}**.`,
+								isCompetitiveMultiWinnerMarketMode(resolved.market)
+									? `**${resolved.market.title}** resolved with ${resolveMarketWinnerCount(resolved.market)} winners: **${
+											resolved.market.outcomes
+												.filter(
+													(outcome) =>
+														(outcome.settlementValue ?? 0) >= 1 - 1e-6,
+												)
+												.map((outcome) => outcome.label)
+												.join(", ") || "Unknown"
+										}**.`
+									: `**${resolved.market.title}** resolved in favor of **${resolved.market.winningOutcome?.label ?? "Unknown"}**.`,
 								"",
 								"Your positions in this market:",
 								positionLines,

--- a/src/features/markets/services/records.ts
+++ b/src/features/markets/services/records.ts
@@ -48,7 +48,8 @@ const resolveValidatedWinnerCount = (input: {
 	winnerCount: number | null | undefined;
 	outcomeCount: number;
 }): number => {
-	if (isCompetitiveMultiWinnerMarketMode(input)) {
+	const contractMode = input.contractMode ?? null;
+	if (isCompetitiveMultiWinnerMarketMode({ contractMode })) {
 		const winnerCount = input.winnerCount ?? 1;
 		validateCompetitiveWinnerCount({
 			winnerCount,
@@ -367,7 +368,7 @@ export const appendMarketOutcomes = async (
 
 		if (isCompetitiveMultiWinnerMarketMode(market)) {
 			validateCompetitiveWinnerCount({
-				winnerCount: market.winnerCount,
+				winnerCount: market.winnerCount ?? 1,
 				outcomeCount: market.outcomes.length + nextOutcomes.length,
 			});
 		}

--- a/src/features/markets/services/records.ts
+++ b/src/features/markets/services/records.ts
@@ -1,10 +1,13 @@
 import { prisma } from "../../../lib/prisma.js";
 import { parseMarketLookup } from "../parsing/market.js";
+import { computeCombinationCount } from "../core/math.js";
 import {
 	assertMarketCanAddOutcomes,
 	assertMarketEditable,
 	getMarketForUpdate,
+	isCompetitiveMultiWinnerMarketMode,
 	liquidityParameter,
+	maxCompetitiveWinnerSubsets,
 	maxLiquidityParameter,
 	marketInclude,
 } from "../core/shared.js";
@@ -15,9 +18,64 @@ import type {
 	MarketWithRelations,
 } from "../core/types.js";
 
+const validateCompetitiveWinnerCount = (input: {
+	winnerCount: number;
+	outcomeCount: number;
+}): void => {
+	if (!Number.isInteger(input.winnerCount) || input.winnerCount < 1) {
+		throw new Error(
+			"Winner count must be an integer greater than or equal to 1.",
+		);
+	}
+
+	if (input.winnerCount >= input.outcomeCount) {
+		throw new Error("Winner count must be less than the number of outcomes.");
+	}
+
+	const subsetCount = computeCombinationCount(
+		input.outcomeCount,
+		input.winnerCount,
+	);
+	if (subsetCount > maxCompetitiveWinnerSubsets) {
+		throw new Error(
+			`Too many winner combinations for competitive multi-winner pricing (${subsetCount} > ${maxCompetitiveWinnerSubsets}). Reduce outcomes or winner count.`,
+		);
+	}
+};
+
+const resolveValidatedWinnerCount = (input: {
+	contractMode: MarketWithRelations["contractMode"] | null | undefined;
+	winnerCount: number | null | undefined;
+	outcomeCount: number;
+}): number => {
+	if (isCompetitiveMultiWinnerMarketMode(input)) {
+		const winnerCount = input.winnerCount ?? 1;
+		validateCompetitiveWinnerCount({
+			winnerCount,
+			outcomeCount: input.outcomeCount,
+		});
+		return winnerCount;
+	}
+
+	if (input.winnerCount !== undefined && input.winnerCount !== null) {
+		throw new Error(
+			"Winner count is only supported for competitive multi-winner markets.",
+		);
+	}
+
+	return 1;
+};
+
 export const createMarketRecord = async (
 	input: MarketCreationInput,
 ): Promise<MarketWithRelations> => {
+	const contractMode = input.contractMode ?? "categorical_single_winner";
+	const winnerCount = resolveValidatedWinnerCount({
+		contractMode,
+		winnerCount: input.winnerCount,
+		outcomeCount: input.outcomes.length,
+	});
+
 	const market = await prisma.market.create({
 		data: {
 			guildId: input.guildId,
@@ -27,7 +85,8 @@ export const createMarketRecord = async (
 			title: input.title,
 			description: input.description,
 			buttonStyle: input.buttonStyle,
-			contractMode: input.contractMode ?? "categorical_single_winner",
+			contractMode,
+			winnerCount,
 			tags: input.tags,
 			baseLiquidityParameter: liquidityParameter,
 			liquidityParameter,
@@ -174,6 +233,8 @@ export const editMarketRecord = async (
 		title?: string;
 		description?: string | null;
 		buttonStyle?: MarketWithRelations["buttonStyle"];
+		contractMode?: MarketWithRelations["contractMode"];
+		winnerCount?: number;
 		tags?: string[];
 		closeAt?: Date;
 		outcomes?: string[];
@@ -191,6 +252,8 @@ export const editMarketRecord = async (
 		const editsRequireNoTrades =
 			input.title !== undefined ||
 			input.description !== undefined ||
+			input.contractMode !== undefined ||
+			input.winnerCount !== undefined ||
 			input.tags !== undefined ||
 			input.outcomes !== undefined;
 		if (hasTrades && editsRequireNoTrades) {
@@ -198,6 +261,21 @@ export const editMarketRecord = async (
 				"After the first trade, only close time and button style can be edited.",
 			);
 		}
+
+		const nextContractMode =
+			input.contractMode ?? market.contractMode ?? "categorical_single_winner";
+		const nextOutcomeCount = input.outcomes?.length ?? market.outcomes.length;
+		const nextWinnerCount = resolveValidatedWinnerCount({
+			contractMode: nextContractMode,
+			winnerCount:
+				input.winnerCount ??
+				(isCompetitiveMultiWinnerMarketMode({
+					contractMode: nextContractMode,
+				})
+					? market.winnerCount
+					: undefined),
+			outcomeCount: nextOutcomeCount,
+		});
 
 		await tx.market.update({
 			where: {
@@ -210,6 +288,13 @@ export const editMarketRecord = async (
 					: {}),
 				...(input.buttonStyle !== undefined
 					? { buttonStyle: input.buttonStyle }
+					: {}),
+				...(input.contractMode !== undefined
+					? { contractMode: input.contractMode }
+					: {}),
+				...(input.winnerCount !== undefined ||
+				market.winnerCount !== nextWinnerCount
+					? { winnerCount: nextWinnerCount }
 					: {}),
 				...(input.tags !== undefined ? { tags: input.tags } : {}),
 				...(input.closeAt !== undefined ? { closeAt: input.closeAt } : {}),
@@ -278,6 +363,13 @@ export const appendMarketOutcomes = async (
 
 		if (market.outcomes.length + nextOutcomes.length > 5) {
 			throw new Error("Markets can have at most 5 outcomes.");
+		}
+
+		if (isCompetitiveMultiWinnerMarketMode(market)) {
+			validateCompetitiveWinnerCount({
+				winnerCount: market.winnerCount,
+				outcomeCount: market.outcomes.length + nextOutcomes.length,
+			});
 		}
 
 		await tx.market.update({

--- a/src/features/markets/services/trading/execution.ts
+++ b/src/features/markets/services/trading/execution.ts
@@ -618,10 +618,7 @@ export const executeMarketTrade = async (input: {
 							userId: input.userId,
 							outcomeId: outcome.id,
 							side: input.action,
-							cashDelta:
-								input.action === "buy" || input.action === "cover"
-									? -cashAmount
-									: cashAmount,
+							cashDelta: input.action === "buy" ? -cashAmount : cashAmount,
 							shareDelta: roundCurrency(shareDelta),
 							feeCharged,
 							probabilitySnapshot: computedProbabilities[tradableIndex] ?? 0,
@@ -942,10 +939,7 @@ export const executeMarketTrade = async (input: {
 						userId: input.userId,
 						outcomeId: outcome.id,
 						side: input.action,
-						cashDelta:
-							input.action === "buy" || input.action === "cover"
-								? -cashAmount
-								: cashAmount,
+						cashDelta: input.action === "buy" ? -cashAmount : cashAmount,
 						shareDelta: roundCurrency(shareDelta),
 						feeCharged,
 						probabilitySnapshot: computedProbabilities[tradableIndex] ?? 0,

--- a/src/features/markets/services/trading/execution.ts
+++ b/src/features/markets/services/trading/execution.ts
@@ -939,7 +939,10 @@ export const executeMarketTrade = async (input: {
 						userId: input.userId,
 						outcomeId: outcome.id,
 						side: input.action,
-						cashDelta: input.action === "buy" ? -cashAmount : cashAmount,
+						cashDelta:
+							input.action === "buy" || input.action === "cover"
+								? -cashAmount
+								: cashAmount,
 						shareDelta: roundCurrency(shareDelta),
 						feeCharged,
 						probabilitySnapshot: computedProbabilities[tradableIndex] ?? 0,

--- a/src/features/markets/services/trading/execution.ts
+++ b/src/features/markets/services/trading/execution.ts
@@ -6,11 +6,12 @@ import {
 	assertMarketOpen,
 	assertOutcomeTradable,
 	getMarketForUpdate,
-	getMarketProbabilities,
+	isCompetitiveMultiWinnerMarketMode,
 	getLossProtection,
 	getLossProtectionMap,
 	getPosition,
 	getPositionMap,
+	resolveMarketWinnerCount,
 	getTradeLockReason,
 	getTradableOutcomeIndexes,
 	marketInclude,
@@ -25,11 +26,15 @@ import {
 	computeBuyCost,
 	computeLmsrProbabilities,
 	computeSellPayout,
+	computeTopKMarginals,
+	computeTopKSellPayout,
 	solveBinaryBuySharesForAmount,
 	solveBinarySellSharesForAmount,
 	solveBinaryShortSharesForAmount,
 	solveBuySharesForAmount,
 	solveSellSharesForAmount,
+	solveTopKBuySharesForAmount,
+	solveTopKSellSharesForAmount,
 	solveShortSharesForAmount,
 } from "../../core/math.js";
 import type { MarketTradeResult } from "../../core/types.js";
@@ -394,6 +399,232 @@ export const executeMarketTrade = async (input: {
 							shareDelta: roundCurrency(shareDelta),
 							feeCharged,
 							probabilitySnapshot,
+							cumulativeVolume: market.totalVolume + cashAmount,
+						},
+					},
+				},
+				include: marketInclude,
+			});
+
+			return {
+				market: updatedMarket,
+				outcome,
+				account: updatedAccount,
+				positionSide,
+				shareDelta: roundCurrency(shareDelta),
+				cashAmount: roundCurrency(cashAmount),
+				grossCashAmount: roundCurrency(grossCashAmount),
+				netCashAmount: roundCurrency(netCashAmount),
+				feeCharged: roundCurrency(feeCharged),
+				realizedProfitDelta,
+			};
+		}
+
+		if (isCompetitiveMultiWinnerMarketMode(market)) {
+			if (input.action === "short" || input.action === "cover") {
+				throw new Error(
+					"Shorting is not yet supported for competitive multi-winner markets.",
+				);
+			}
+
+			const settledWinnerCount = market.outcomes.reduce(
+				(sum, marketOutcome) =>
+					marketOutcome.settlementValue === null
+						? sum
+						: sum + Math.min(1, Math.max(0, marketOutcome.settlementValue)),
+				0,
+			);
+			const remainingWinnerCount = Math.max(
+				0,
+				Math.min(
+					tradableOutcomeIndexes.length,
+					Math.round(resolveMarketWinnerCount(market) - settledWinnerCount),
+				),
+			);
+
+			switch (input.action) {
+				case "buy": {
+					if (shortPosition && shortPosition.shares > 1e-6) {
+						throw new Error(
+							"Shorting is not yet supported for competitive multi-winner markets.",
+						);
+					}
+
+					if (account.bankroll < input.amount - 1e-6) {
+						throw new Error("You do not have enough bankroll for that trade.");
+					}
+
+					shareDelta = solveTopKBuySharesForAmount(
+						pricingShares,
+						tradableIndex,
+						input.amount,
+						market.liquidityParameter,
+						remainingWinnerCount,
+					);
+					nextPricingShares[tradableIndex] =
+						(nextPricingShares[tradableIndex] ?? 0) + shareDelta;
+					nextOutstandingShares[tradableIndex] =
+						(nextOutstandingShares[tradableIndex] ?? 0) + shareDelta;
+					nextLongShares += shareDelta;
+					nextLongCostBasis += input.amount;
+					nextBankroll -= input.amount;
+					grossCashAmount = roundCurrency(input.amount);
+					netCashAmount = roundCurrency(input.amount);
+					positionSide = "long";
+					break;
+				}
+				case "sell": {
+					const ownedShares = longPosition?.shares ?? 0;
+					if (ownedShares <= 1e-6) {
+						throw new Error(
+							"You do not own a long position in that outcome yet.",
+						);
+					}
+
+					const requestedSharesToSell =
+						input.amountMode === "shares"
+							? input.amount
+							: solveTopKSellSharesForAmount(
+									pricingShares,
+									tradableIndex,
+									input.amount,
+									ownedShares,
+									market.liquidityParameter,
+									remainingWinnerCount,
+								);
+					if (requestedSharesToSell > ownedShares + 1e-6) {
+						throw new Error(
+							"You do not have enough shares in that outcome to sell that much.",
+						);
+					}
+
+					shareDelta = -requestedSharesToSell;
+					nextPricingShares[tradableIndex] =
+						(nextPricingShares[tradableIndex] ?? 0) + shareDelta;
+					nextOutstandingShares[tradableIndex] =
+						(nextOutstandingShares[tradableIndex] ?? 0) + shareDelta;
+					const sharesSold = Math.abs(shareDelta);
+					const averageCostBasis = (longPosition?.costBasis ?? 0) / ownedShares;
+					const releasedCostBasis = averageCostBasis * sharesSold;
+					nextLongShares -= sharesSold;
+					nextLongCostBasis -= releasedCostBasis;
+					cashAmount =
+						input.amountMode === "shares"
+							? roundCurrency(
+									computeTopKSellPayout(
+										pricingShares,
+										tradableIndex,
+										sharesSold,
+										market.liquidityParameter,
+										remainingWinnerCount,
+									),
+								)
+							: input.amount;
+					nextBankroll += cashAmount;
+					realizedProfitDelta = roundCurrency(cashAmount - releasedCostBasis);
+					grossCashAmount = roundCurrency(cashAmount);
+					netCashAmount = roundCurrency(cashAmount);
+					positionSide = "long";
+					break;
+				}
+				default:
+					throw new Error("Unsupported market trade action.");
+			}
+
+			const computedProbabilities =
+				tradableOutcomeIndexes.length === 0
+					? []
+					: computeTopKMarginals(
+							nextPricingShares,
+							market.liquidityParameter,
+							remainingWinnerCount,
+						);
+			const tradableIndexMap = new Map<number, number>(
+				tradableOutcomeIndexes.map((marketOutcomeIndex, activeIndex) => [
+					marketOutcomeIndex,
+					activeIndex,
+				]),
+			);
+			await replaceOutcomeState(
+				tx,
+				market.id,
+				market.outcomes.map((marketOutcome, index) => {
+					const activeIndex = tradableIndexMap.get(index);
+					return {
+						id: marketOutcome.id,
+						outstandingShares:
+							activeIndex === undefined
+								? marketOutcome.outstandingShares
+								: (nextOutstandingShares[activeIndex] ??
+									marketOutcome.outstandingShares),
+						pricingShares:
+							activeIndex === undefined
+								? marketOutcome.pricingShares
+								: (nextPricingShares[activeIndex] ??
+									marketOutcome.pricingShares),
+					};
+				}),
+			);
+
+			await upsertPosition(tx, {
+				marketId: market.id,
+				outcomeId: outcome.id,
+				userId: input.userId,
+				side: "long",
+				shares: nextLongShares,
+				costBasis: nextLongCostBasis,
+				proceeds: 0,
+				collateralLocked: 0,
+			});
+			if (input.action === "sell") {
+				await syncLossProtectionForSellTx(tx, {
+					...(protection ? { existingProtection: protection } : {}),
+					previousLongCostBasis: longPosition?.costBasis ?? 0,
+					nextLongCostBasis,
+				});
+			}
+
+			await upsertPosition(tx, {
+				marketId: market.id,
+				outcomeId: outcome.id,
+				userId: input.userId,
+				side: "short",
+				shares: nextShortShares,
+				costBasis: 0,
+				proceeds: nextShortProceeds,
+				collateralLocked: nextShortCollateral,
+			});
+
+			const updatedAccount = await tx.marketAccount.update({
+				where: {
+					id: account.id,
+				},
+				data: {
+					bankroll: roundCurrency(nextBankroll),
+					realizedProfit: roundCurrency(
+						account.realizedProfit + realizedProfitDelta,
+					),
+				},
+			});
+
+			const updatedMarket = await tx.market.update({
+				where: {
+					id: market.id,
+				},
+				data: {
+					totalVolume: market.totalVolume + cashAmount,
+					trades: {
+						create: {
+							userId: input.userId,
+							outcomeId: outcome.id,
+							side: input.action,
+							cashDelta:
+								input.action === "buy" || input.action === "cover"
+									? -cashAmount
+									: cashAmount,
+							shareDelta: roundCurrency(shareDelta),
+							feeCharged,
+							probabilitySnapshot: computedProbabilities[tradableIndex] ?? 0,
 							cumulativeVolume: market.totalVolume + cashAmount,
 						},
 					},

--- a/src/features/markets/services/trading/quotes.ts
+++ b/src/features/markets/services/trading/quotes.ts
@@ -3,8 +3,10 @@ import {
 	assertMarketOpen,
 	assertOutcomeTradable,
 	getMarketProbabilities,
+	isCompetitiveMultiWinnerMarketMode,
 	getPosition,
 	getPositionMap,
+	resolveMarketWinnerCount,
 	getTradeLockReason,
 	getTradableOutcomeIndexes,
 	roundCurrency,
@@ -15,11 +17,14 @@ import {
 	computeBinarySellPayout,
 	computeBuyCost,
 	computeSellPayout,
+	computeTopKSellPayout,
 	solveBinaryBuySharesForAmount,
 	solveBinarySellSharesForAmount,
 	solveBinaryShortSharesForAmount,
 	solveBuySharesForAmount,
 	solveSellSharesForAmount,
+	solveTopKBuySharesForAmount,
+	solveTopKSellSharesForAmount,
 	solveShortSharesForAmount,
 } from "../../core/math.js";
 import { getMarketById } from "../records.js";
@@ -520,6 +525,203 @@ const calculateMarketTradeQuoteUnsafe = async (input: {
 			),
 			maxLossIfNotChosen: 0,
 		};
+	}
+
+	if (isCompetitiveMultiWinnerMarketMode(market)) {
+		const settledWinnerCount = market.outcomes.reduce(
+			(sum, marketOutcome) =>
+				marketOutcome.settlementValue === null
+					? sum
+					: sum + Math.min(1, Math.max(0, marketOutcome.settlementValue)),
+			0,
+		);
+		const remainingWinnerCount = Math.max(
+			0,
+			Math.min(
+				tradableOutcomeIndexes.length,
+				Math.round(resolveMarketWinnerCount(market) - settledWinnerCount),
+			),
+		);
+		let nextPricingShares = [...pricingShares];
+		const buildProbabilities = (): {
+			currentProbability: number;
+			nextProbability: number;
+		} =>
+			buildCategoricalProbabilities(
+				market,
+				outcomeIndex,
+				tradableOutcomeIndexes,
+				nextPricingShares,
+			);
+
+		if (input.action === "buy") {
+			if (shortPosition && shortPosition.shares > 1e-6) {
+				throw new Error(
+					"Shorting is not yet supported for competitive multi-winner markets.",
+				);
+			}
+
+			const feeCharged = 0;
+			if (account.bankroll < input.amount - 1e-6) {
+				throw new Error("You do not have enough bankroll for that trade.");
+			}
+
+			const sharesReceived = solveTopKBuySharesForAmount(
+				pricingShares,
+				tradableIndex,
+				input.amount,
+				market.liquidityParameter,
+				remainingWinnerCount,
+			);
+			nextPricingShares[tradableIndex] =
+				(nextPricingShares[tradableIndex] ?? 0) + sharesReceived;
+			const positionSharesAfter = roundCurrency(
+				(longPosition?.shares ?? 0) + sharesReceived,
+			);
+			const positionCostBasisAfter = roundCurrency(
+				(longPosition?.costBasis ?? 0) + input.amount,
+			);
+			const bankrollAfter = roundCurrency(account.bankroll - input.amount);
+			const probabilities = buildProbabilities();
+
+			return {
+				action: input.action,
+				contractMode: market.contractMode ?? "categorical_single_winner",
+				winnerCount: market.winnerCount,
+				marketId: market.id,
+				marketTitle: market.title,
+				outcomeId: outcome.id,
+				outcomeLabel: outcome.label,
+				userId: input.userId,
+				guildId: market.guildId,
+				amount: input.amount,
+				amountMode,
+				rawAmount: input.rawAmount,
+				shares: roundCurrency(sharesReceived),
+				averagePrice:
+					sharesReceived > 0
+						? roundCurrency(input.amount / sharesReceived)
+						: null,
+				currentProbability: probabilities.currentProbability,
+				nextProbability: probabilities.nextProbability,
+				immediateCash: roundCurrency(input.amount),
+				grossImmediateCash: roundCurrency(input.amount),
+				netImmediateCash: roundCurrency(input.amount),
+				feeCharged,
+				collateralLocked: 0,
+				collateralReleased: 0,
+				netBankrollChange: roundCurrency(-input.amount),
+				bankrollAfter,
+				positionSide: "long",
+				positionSharesAfter,
+				positionCostBasisAfter,
+				positionProceedsAfter: 0,
+				positionCollateralAfter: 0,
+				realizedProfitDelta: 0,
+				settlementIfChosen: positionSharesAfter,
+				settlementIfNotChosen: 0,
+				maxProfitIfChosen: roundCurrency(
+					positionSharesAfter - positionCostBasisAfter,
+				),
+				maxProfitIfNotChosen: 0,
+				maxLossIfChosen: 0,
+				maxLossIfNotChosen: positionCostBasisAfter,
+			};
+		}
+
+		if (input.action === "sell") {
+			const ownedShares = longPosition?.shares ?? 0;
+			if (ownedShares <= 1e-6) {
+				throw new Error("You do not own a long position in that outcome yet.");
+			}
+
+			const requestedSharesToSell =
+				amountMode === "shares"
+					? input.amount
+					: solveTopKSellSharesForAmount(
+							pricingShares,
+							tradableIndex,
+							input.amount,
+							ownedShares,
+							market.liquidityParameter,
+							remainingWinnerCount,
+						);
+			if (requestedSharesToSell > ownedShares + 1e-6) {
+				throw new Error(
+					"You do not have enough shares in that outcome to sell that much.",
+				);
+			}
+
+			const sharesSold = roundCurrency(requestedSharesToSell);
+			const cashAmount =
+				amountMode === "shares"
+					? roundCurrency(
+							computeTopKSellPayout(
+								pricingShares,
+								tradableIndex,
+								sharesSold,
+								market.liquidityParameter,
+								remainingWinnerCount,
+							),
+						)
+					: roundCurrency(input.amount);
+			const averageCostBasis = (longPosition?.costBasis ?? 0) / ownedShares;
+			const releasedCostBasis = roundCurrency(averageCostBasis * sharesSold);
+			nextPricingShares[tradableIndex] =
+				(nextPricingShares[tradableIndex] ?? 0) - sharesSold;
+			const positionSharesAfter = roundCurrency(ownedShares - sharesSold);
+			const positionCostBasisAfter = roundCurrency(
+				(longPosition?.costBasis ?? 0) - releasedCostBasis,
+			);
+			const bankrollAfter = roundCurrency(account.bankroll + cashAmount);
+			const probabilities = buildProbabilities();
+
+			return {
+				action: input.action,
+				contractMode: market.contractMode ?? "categorical_single_winner",
+				winnerCount: market.winnerCount,
+				marketId: market.id,
+				marketTitle: market.title,
+				outcomeId: outcome.id,
+				outcomeLabel: outcome.label,
+				userId: input.userId,
+				guildId: market.guildId,
+				amount: input.amount,
+				amountMode,
+				rawAmount: input.rawAmount,
+				shares: sharesSold,
+				averagePrice:
+					sharesSold > 0 ? roundCurrency(cashAmount / sharesSold) : null,
+				currentProbability: probabilities.currentProbability,
+				nextProbability: probabilities.nextProbability,
+				immediateCash: cashAmount,
+				grossImmediateCash: cashAmount,
+				netImmediateCash: cashAmount,
+				feeCharged: 0,
+				collateralLocked: 0,
+				collateralReleased: 0,
+				netBankrollChange: cashAmount,
+				bankrollAfter,
+				positionSide: "long",
+				positionSharesAfter,
+				positionCostBasisAfter,
+				positionProceedsAfter: 0,
+				positionCollateralAfter: 0,
+				realizedProfitDelta: roundCurrency(cashAmount - releasedCostBasis),
+				settlementIfChosen: positionSharesAfter,
+				settlementIfNotChosen: 0,
+				maxProfitIfChosen: roundCurrency(
+					positionSharesAfter - positionCostBasisAfter,
+				),
+				maxProfitIfNotChosen: 0,
+				maxLossIfChosen: 0,
+				maxLossIfNotChosen: positionCostBasisAfter,
+			};
+		}
+
+		throw new Error(
+			"Shorting is not yet supported for competitive multi-winner markets.",
+		);
 	}
 
 	let nextPricingShares = [...pricingShares];

--- a/src/features/markets/services/trading/quotes.ts
+++ b/src/features/markets/services/trading/quotes.ts
@@ -587,7 +587,7 @@ const calculateMarketTradeQuoteUnsafe = async (input: {
 			return {
 				action: input.action,
 				contractMode: market.contractMode ?? "categorical_single_winner",
-				winnerCount: market.winnerCount,
+				winnerCount: market.winnerCount ?? 1,
 				marketId: market.id,
 				marketTitle: market.title,
 				outcomeId: outcome.id,
@@ -679,7 +679,7 @@ const calculateMarketTradeQuoteUnsafe = async (input: {
 			return {
 				action: input.action,
 				contractMode: market.contractMode ?? "categorical_single_winner",
-				winnerCount: market.winnerCount,
+				winnerCount: market.winnerCount ?? 1,
 				marketId: market.id,
 				marketTitle: market.title,
 				outcomeId: outcome.id,

--- a/src/features/markets/services/trading/resolution.ts
+++ b/src/features/markets/services/trading/resolution.ts
@@ -10,11 +10,13 @@ import {
 	clearMarketExposureTx,
 	computeSupplementaryBonusDistribution,
 	getMarketResolutionVector,
+	isCompetitiveMultiWinnerMarketMode,
 	isIndependentMarketMode,
 	getLossProtection,
 	getLossProtectionMap,
 	getMarketForUpdate,
 	marketInclude,
+	resolveMarketWinnerCount,
 	roundCurrency,
 	roundProbability,
 } from "../../core/shared.js";
@@ -48,6 +50,11 @@ export const resolveMarketOutcome = async (input: {
 		}
 
 		assertCanResolveOutcome(market, input.actorId, input.permissions);
+		if (isCompetitiveMultiWinnerMarketMode(market)) {
+			throw new Error(
+				"Competitive multi-winner markets must be resolved by selecting all winners at once.",
+			);
+		}
 		const outcome = market.outcomes.find(
 			(entry) => entry.id === input.outcomeId,
 		);
@@ -234,7 +241,8 @@ export const resolveMarketOutcome = async (input: {
 export const resolveMarket = async (input: {
 	marketId: string;
 	actorId: string;
-	winningOutcomeId: string;
+	winningOutcomeId?: string;
+	winningOutcomeIds?: string[];
 	note?: string | null;
 	evidenceUrl?: string | null;
 	permissions?: PermissionsBitField | Readonly<PermissionsBitField> | null;
@@ -252,11 +260,43 @@ export const resolveMarket = async (input: {
 				"Independent markets must be resolved outcome-by-outcome with settlement values.",
 			);
 		}
-		const winningOutcome = market.outcomes.find(
-			(outcome) => outcome.id === input.winningOutcomeId,
+
+		const requestedWinningOutcomeIds = (
+			isCompetitiveMultiWinnerMarketMode(market)
+				? (input.winningOutcomeIds ??
+					(input.winningOutcomeId ? [input.winningOutcomeId] : []))
+				: input.winningOutcomeId
+					? [input.winningOutcomeId]
+					: input.winningOutcomeIds && input.winningOutcomeIds.length > 0
+						? [input.winningOutcomeIds[0] as string]
+						: []
+		).map((value) => value.trim());
+		if (requestedWinningOutcomeIds.length === 0) {
+			throw new Error("Select at least one winning outcome.");
+		}
+
+		const uniqueWinningOutcomeIds = [...new Set(requestedWinningOutcomeIds)];
+		if (uniqueWinningOutcomeIds.length !== requestedWinningOutcomeIds.length) {
+			throw new Error("Winning outcomes cannot include duplicates.");
+		}
+
+		const winningOutcomeIdSet = new Set(uniqueWinningOutcomeIds);
+		const winningOutcomes = market.outcomes.filter((outcome) =>
+			winningOutcomeIdSet.has(outcome.id),
 		);
-		if (!winningOutcome) {
+		if (winningOutcomes.length !== uniqueWinningOutcomeIds.length) {
 			throw new Error("Winning outcome not found.");
+		}
+
+		if (isCompetitiveMultiWinnerMarketMode(market)) {
+			const expectedWinnerCount = resolveMarketWinnerCount(market);
+			if (winningOutcomes.length !== expectedWinnerCount) {
+				throw new Error(
+					`Competitive multi-winner markets must resolve exactly ${expectedWinnerCount} winner${expectedWinnerCount === 1 ? "" : "s"}.`,
+				);
+			}
+		} else if (winningOutcomes.length !== 1) {
+			throw new Error("Single-winner markets must resolve exactly one winner.");
 		}
 
 		const payouts = new Map<
@@ -277,7 +317,7 @@ export const resolveMarket = async (input: {
 
 			for (const position of positions) {
 				if (position.side === "long") {
-					const isWinner = position.outcomeId === winningOutcome.id;
+					const isWinner = winningOutcomeIdSet.has(position.outcomeId);
 					const positionPayout = isWinner ? position.shares : 0;
 					const protection = isWinner
 						? undefined
@@ -291,7 +331,7 @@ export const resolveMarket = async (input: {
 					continue;
 				}
 
-				const shortWins = position.outcomeId !== winningOutcome.id;
+				const shortWins = !winningOutcomeIdSet.has(position.outcomeId);
 				const releasedCollateral = shortWins ? position.collateralLocked : 0;
 				payout += releasedCollateral;
 				profit += shortWins
@@ -345,32 +385,34 @@ export const resolveMarket = async (input: {
 		await clearMarketExposureTx(tx, { marketId: market.id });
 
 		await Promise.all(
-			market.outcomes.map((outcome) =>
-				tx.marketOutcome.update({
+			market.outcomes.map((outcome) => {
+				const isWinningOutcome = winningOutcomeIdSet.has(outcome.id);
+				return tx.marketOutcome.update({
 					where: {
 						id: outcome.id,
 					},
 					data: {
 						outstandingShares: 0,
 						pricingShares: 0,
-						settlementValue:
-							outcome.id === winningOutcome.id
-								? 1
-								: (outcome.settlementValue ?? 0),
+						settlementValue: isWinningOutcome ? 1 : 0,
 						resolvedAt: outcome.resolvedAt ?? resolvedAt,
 						resolvedByUserId: outcome.resolvedByUserId ?? input.actorId,
-						resolutionNote:
-							outcome.id === winningOutcome.id
-								? (input.note ?? outcome.resolutionNote ?? null)
-								: (outcome.resolutionNote ?? null),
-						resolutionEvidenceUrl:
-							outcome.id === winningOutcome.id
-								? (input.evidenceUrl ?? outcome.resolutionEvidenceUrl ?? null)
-								: (outcome.resolutionEvidenceUrl ?? null),
+						resolutionNote: isWinningOutcome
+							? (input.note ?? outcome.resolutionNote ?? null)
+							: (outcome.resolutionNote ?? null),
+						resolutionEvidenceUrl: isWinningOutcome
+							? (input.evidenceUrl ?? outcome.resolutionEvidenceUrl ?? null)
+							: (outcome.resolutionEvidenceUrl ?? null),
 					},
-				}),
-			),
+				});
+			}),
 		);
+
+		const sortedWinningOutcomeIds = market.outcomes
+			.filter((outcome) => winningOutcomeIdSet.has(outcome.id))
+			.map((outcome) => outcome.id);
+		const primaryWinningOutcomeId =
+			sortedWinningOutcomeIds[0] ?? market.outcomes[0]?.id ?? null;
 
 		const resolvedMarket = await tx.market.update({
 			where: {
@@ -379,7 +421,7 @@ export const resolveMarket = async (input: {
 			data: {
 				tradingClosedAt: market.tradingClosedAt ?? resolvedAt,
 				resolvedAt,
-				winningOutcomeId: winningOutcome.id,
+				winningOutcomeId: primaryWinningOutcomeId,
 				resolutionNote: input.note ?? null,
 				resolutionEvidenceUrl: input.evidenceUrl ?? null,
 				resolvedByUserId: input.actorId,

--- a/src/features/markets/ui/render/market.ts
+++ b/src/features/markets/ui/render/market.ts
@@ -18,9 +18,22 @@ import { formatProbabilityPercent } from "../../core/math.js";
 import type { MarketWithRelations } from "../../core/types.js";
 import {
 	getMarketSummary,
+	resolveMarketWinnerCount,
 	getOutcomeButtonStyle,
 	getStatusColor,
 } from "./shared.js";
+
+const getContractModeLabel = (market: MarketWithRelations): string => {
+	if (market.contractMode === "independent_binary_set") {
+		return "Independent Set";
+	}
+
+	if (market.contractMode === "competitive_multi_winner") {
+		return `Competitive Top-${resolveMarketWinnerCount(market)}`;
+	}
+
+	return "Single Winner";
+};
 
 const buildMarketSynopsis = (
 	market: MarketWithRelations,
@@ -33,6 +46,10 @@ const buildMarketSynopsis = (
 	if (market.contractMode === "independent_binary_set") {
 		parts.push(
 			"Outcomes are independent and total displayed probability can exceed 100%.",
+		);
+	} else if (market.contractMode === "competitive_multi_winner") {
+		parts.push(
+			`Exactly ${resolveMarketWinnerCount(market)} outcome${resolveMarketWinnerCount(market) === 1 ? "" : "s"} win. Displayed marginals sum to ${resolveMarketWinnerCount(market) * 100}%.`,
 		);
 	}
 
@@ -80,6 +97,9 @@ const buildDetailsFields = (
 	const status = summary.status;
 	const sortedProbabilities = sortOutcomeEntries(summary.probabilities);
 	const isIndependentMarket = market.contractMode === "independent_binary_set";
+	const isCompetitiveMultiWinner =
+		market.contractMode === "competitive_multi_winner";
+	const winnerCount = resolveMarketWinnerCount(market);
 	const formatOutcomeStatus = (entry: {
 		isResolved: boolean;
 		settlementValue: number | null;
@@ -136,16 +156,27 @@ const buildDetailsFields = (
 		`Forum Post Thread ID: ${market.threadId ? `\`${market.threadId}\`` : "No forum post yet"}`,
 		`Creator: <@${market.creatorId}>`,
 		`Button Style: **${market.buttonStyle}**`,
-		`Contract Mode: **${isIndependentMarket ? "Independent Set" : "Single Winner"}**`,
+		`Contract Mode: **${getContractModeLabel(market)}**`,
 		`Volume: **${summary.totalVolume} pts**`,
 		`Tags: ${market.tags.length > 0 ? market.tags.map((tag) => `\`${tag}\``).join(" ") : "None"}`,
 	].join("\n");
+	const resolvedWinners = market.outcomes.filter(
+		(outcome) => (outcome.settlementValue ?? 0) >= 1 - 1e-6,
+	);
 
 	const resolution =
 		[
-			market.winningOutcomeId
-				? `${isIndependentMarket ? "Top Settled Outcome" : "Winning Outcome"}: **${market.outcomes.find((outcome) => outcome.id === market.winningOutcomeId)?.label ?? market.winningOutcomeId}**`
-				: null,
+			isCompetitiveMultiWinner
+				? `Winning Outcomes: ${
+						resolvedWinners.length > 0
+							? resolvedWinners
+									.map((outcome) => `**${outcome.label}**`)
+									.join(", ")
+							: `None selected yet (${winnerCount} required)`
+					}`
+				: market.winningOutcomeId
+					? `${isIndependentMarket ? "Top Settled Outcome" : "Winning Outcome"}: **${market.outcomes.find((outcome) => outcome.id === market.winningOutcomeId)?.label ?? market.winningOutcomeId}**`
+					: null,
 			market.resolvedByUserId
 				? `Resolved By: <@${market.resolvedByUserId}>`
 				: null,
@@ -173,7 +204,9 @@ const buildDetailsFields = (
 		{ name: "Timing", value: timing },
 		{ name: "Liquidity & Incentives", value: liquidity },
 		{
-			name: "Current Probabilities",
+			name: isCompetitiveMultiWinner
+				? "Current Chances To Be Among Winners"
+				: "Current Probabilities",
 			value: sortedProbabilities
 				.map(
 					(entry, index) =>
@@ -197,6 +230,8 @@ export const buildMarketEmbed = (market: MarketWithRelations): EmbedBuilder => {
 	const status = summary.status;
 	const sortedProbabilities = sortOutcomeEntries(summary.probabilities);
 	const isIndependentMarket = market.contractMode === "independent_binary_set";
+	const isCompetitiveMultiWinner =
+		market.contractMode === "competitive_multi_winner";
 	const formatOutcomeStatus = (entry: {
 		isResolved: boolean;
 		settlementValue: number | null;
@@ -224,7 +259,9 @@ export const buildMarketEmbed = (market: MarketWithRelations): EmbedBuilder => {
 				value: buildMarketSynopsis(market, status),
 			},
 			{
-				name: "Current Probabilities",
+				name: isCompetitiveMultiWinner
+					? "Current Chances To Be Among Winners"
+					: "Current Probabilities",
 				value: sortedProbabilities
 					.map(
 						(entry, index) =>
@@ -245,7 +282,7 @@ export const buildMarketEmbed = (market: MarketWithRelations): EmbedBuilder => {
 				: []),
 		)
 		.setFooter({
-			text: `${isIndependentMarket ? "Independent Set" : "Single Winner"} • Market ID: ${market.id} • Volume: ${summary.totalVolume} pts`,
+			text: `${getContractModeLabel(market)} • Market ID: ${market.id} • Volume: ${summary.totalVolume} pts`,
 		});
 
 	if (market.description) {
@@ -328,7 +365,9 @@ export const buildMarketResolvePrompt = (
 			"Market Ready To Resolve",
 			market.contractMode === "independent_binary_set"
 				? `Trading on **${market.title}** is closed. Resolve remaining outcomes with **/market resolve-outcome** and a value between 0 and 1, or cancel to refund positions.`
-				: `Trading on **${market.title}** is closed. Choose **Resolve** to pick a winner or **Cancel** to refund positions.`,
+				: market.contractMode === "competitive_multi_winner"
+					? `Trading on **${market.title}** is closed. Choose **Resolve** and provide exactly ${resolveMarketWinnerCount(market)} winners (comma-separated), or **Cancel** to refund positions.`
+					: `Trading on **${market.title}** is closed. Choose **Resolve** to pick a winner or **Cancel** to refund positions.`,
 			0x60a5fa,
 		),
 	],

--- a/src/features/markets/ui/render/shared.ts
+++ b/src/features/markets/ui/render/shared.ts
@@ -1,6 +1,10 @@
 import { ButtonStyle } from "discord.js";
 
-import { computeMarketSummary, getMarketStatus } from "../../core/shared.js";
+import {
+	computeMarketSummary,
+	getMarketStatus,
+	resolveMarketWinnerCount,
+} from "../../core/shared.js";
 import type {
 	MarketTradeQuoteAction,
 	MarketWithRelations,
@@ -88,6 +92,7 @@ export const getStatusColor = (market: MarketWithRelations): number => {
 };
 
 export const getMarketSummary = computeMarketSummary;
+export { resolveMarketWinnerCount };
 
 export const getOutcomeButtonStyle = (
 	market: Pick<MarketWithRelations, "buttonStyle">,

--- a/src/features/markets/ui/render/trades.ts
+++ b/src/features/markets/ui/render/trades.ts
@@ -46,8 +46,25 @@ import {
 	formatPercent,
 	getMarketSummary,
 	getTradeCopy,
+	resolveMarketWinnerCount,
 	truncateLabel,
 } from "./shared.js";
+
+const getContractModeLabel = (input: {
+	contractMode?: MarketWithRelations["contractMode"];
+	winnerCount?: number;
+}): string => {
+	if (input.contractMode === "independent_binary_set") {
+		return "Independent Set";
+	}
+
+	if (input.contractMode === "competitive_multi_winner") {
+		const winnerCount = Math.max(1, Math.floor(input.winnerCount ?? 1));
+		return `Competitive Top-${winnerCount}`;
+	}
+
+	return "Single Winner";
+};
 
 export const buildMarketTradeSelector = (
 	market: MarketWithRelations,
@@ -127,18 +144,26 @@ export const buildMarketOutcomeTradePrompt = (
 	const buyLocked = Boolean(getTradeLockReason(market, outcomeId, "buy"));
 	const shortLocked = Boolean(getTradeLockReason(market, outcomeId, "short"));
 	const isIndependentMarket = market.contractMode === "independent_binary_set";
+	const isCompetitiveMultiWinner =
+		market.contractMode === "competitive_multi_winner";
 
 	return {
 		embeds: [
 			buildMarketStatusEmbed(
 				`Trade ${entry.label}`,
 				[
-					`Current probability: **${formatProbabilityPercent(entry.probability)}**`,
+					`${
+						isCompetitiveMultiWinner
+							? "Current chance to be among winners"
+							: "Current probability"
+					}: **${formatProbabilityPercent(entry.probability)}**`,
 					`Net shares: **${entry.shares.toFixed(2)}**`,
 					"",
 					isIndependentMarket
 						? "Choose whether to buy YES exposure or short YES exposure (take the NO side)."
-						: "Choose whether you want to buy this outcome or short it.",
+						: isCompetitiveMultiWinner
+							? `Choose whether you want to buy this outcome's chance to finish in the top ${resolveMarketWinnerCount(market)}.`
+							: "Choose whether you want to buy this outcome or short it.",
 				].join("\n"),
 				0x60a5fa,
 			),
@@ -156,7 +181,11 @@ export const buildMarketOutcomeTradePrompt = (
 					.setCustomId(
 						marketQuickTradeButtonCustomId("short", market.id, outcomeId),
 					)
-					.setLabel(`Short ${formatProbabilityPercent(1 - entry.probability)}`)
+					.setLabel(
+						isCompetitiveMultiWinner
+							? "Short (unavailable)"
+							: `Short ${formatProbabilityPercent(1 - entry.probability)}`,
+					)
 					.setDisabled(shortLocked)
 					.setStyle(ButtonStyle.Danger),
 			),
@@ -223,10 +252,10 @@ export const buildMarketResolveModal = (marketId: string): ModalBuilder =>
 			new ActionRowBuilder<TextInputBuilder>().addComponents(
 				new TextInputBuilder()
 					.setCustomId("winning_outcome")
-					.setLabel("Winning outcome")
+					.setLabel("Winning outcome(s)")
 					.setStyle(TextInputStyle.Short)
 					.setRequired(true)
-					.setPlaceholder("1 or exact label"),
+					.setPlaceholder("1 or exact label; comma-separated for multi-winner"),
 			),
 			new ActionRowBuilder<TextInputBuilder>().addComponents(
 				new TextInputBuilder()
@@ -301,9 +330,15 @@ const getPositionAfterCopy = (quote: MarketTradeQuote): string => {
 
 const buildTradeQuoteDescription = (quote: MarketTradeQuote): string => {
 	const isIndependentMarket = quote.contractMode === "independent_binary_set";
+	const isCompetitiveMultiWinner =
+		quote.contractMode === "competitive_multi_winner";
+	const contractModeLabel = getContractModeLabel({
+		contractMode: quote.contractMode,
+		winnerCount: quote.winnerCount,
+	});
 	const lines = [
 		`Outcome: **${quote.outcomeLabel}**`,
-		`Contract mode: **${isIndependentMarket ? "Independent Set" : "Single Winner"}**`,
+		`Contract mode: **${contractModeLabel}**`,
 		`Board: **${formatPercent(quote.currentProbability)}** -> **${formatPercent(quote.nextProbability)}**`,
 	];
 
@@ -355,10 +390,14 @@ const buildTradeQuoteDescription = (quote: MarketTradeQuote): string => {
 		"",
 		isIndependentMarket
 			? `If ${quote.outcomeLabel} settles to 100%: payout **${formatMoney(quote.settlementIfChosen)}**, max loss **${formatMoney(quote.maxLossIfChosen)}**, max profit **${formatMoney(quote.maxProfitIfChosen)}**`
-			: `If ${quote.outcomeLabel} is chosen: payout **${formatMoney(quote.settlementIfChosen)}**, max loss **${formatMoney(quote.maxLossIfChosen)}**, max profit **${formatMoney(quote.maxProfitIfChosen)}**`,
+			: isCompetitiveMultiWinner
+				? `If ${quote.outcomeLabel} is among the winners: payout **${formatMoney(quote.settlementIfChosen)}**, max loss **${formatMoney(quote.maxLossIfChosen)}**, max profit **${formatMoney(quote.maxProfitIfChosen)}**`
+				: `If ${quote.outcomeLabel} is chosen: payout **${formatMoney(quote.settlementIfChosen)}**, max loss **${formatMoney(quote.maxLossIfChosen)}**, max profit **${formatMoney(quote.maxProfitIfChosen)}**`,
 		isIndependentMarket
 			? `If ${quote.outcomeLabel} settles to 0%: payout **${formatMoney(quote.settlementIfNotChosen)}**, max loss **${formatMoney(quote.maxLossIfNotChosen)}**, max profit **${formatMoney(quote.maxProfitIfNotChosen)}**`
-			: `If ${quote.outcomeLabel} is not chosen: payout **${formatMoney(quote.settlementIfNotChosen)}**, max loss **${formatMoney(quote.maxLossIfNotChosen)}**, max profit **${formatMoney(quote.maxProfitIfNotChosen)}**`,
+			: isCompetitiveMultiWinner
+				? `If ${quote.outcomeLabel} misses the winner set: payout **${formatMoney(quote.settlementIfNotChosen)}**, max loss **${formatMoney(quote.maxLossIfNotChosen)}**, max profit **${formatMoney(quote.maxProfitIfNotChosen)}**`
+				: `If ${quote.outcomeLabel} is not chosen: payout **${formatMoney(quote.settlementIfNotChosen)}**, max loss **${formatMoney(quote.maxLossIfNotChosen)}**, max profit **${formatMoney(quote.maxProfitIfNotChosen)}**`,
 		...(isIndependentMarket
 			? [
 					`For intermediate settlement values (e.g. ${formatPercent(0.35)}), payout scales linearly between those bounds.`,
@@ -439,12 +478,15 @@ export const buildMarketInteractionSessionMessage = (input: {
 } => {
 	const { market, session, positions } = input;
 	const isIndependentMarket = market.contractMode === "independent_binary_set";
-	const contractModeLabel = isIndependentMarket
-		? "Independent Set"
-		: "Single Winner";
+	const contractModeLabel = getContractModeLabel({
+		contractMode: market.contractMode,
+		winnerCount: market.winnerCount,
+	});
 	const rows: ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[] = [];
 
 	if (session.mode === "trade") {
+		const isCompetitiveMultiWinner =
+			market.contractMode === "competitive_multi_winner";
 		const tradableEntries = getMarketSummary(market).probabilities.filter(
 			(entry) => !entry.isResolved,
 		);
@@ -463,7 +505,9 @@ export const buildMarketInteractionSessionMessage = (input: {
 				? "No tradable outcomes are available right now."
 				: session.preview?.kind === "trade"
 					? buildTradeQuoteDescription(session.preview.quote)
-					: "Select an outcome, then use a quick amount or enter a custom amount to preview the trade.",
+					: isCompetitiveMultiWinner
+						? "Select an outcome, then use a quick amount or enter a custom amount to preview the trade. Shorting is not yet supported for competitive multi-winner markets."
+						: "Select an outcome, then use a quick amount or enter a custom amount to preview the trade.",
 		].join("\n");
 
 		rows.push(
@@ -483,6 +527,7 @@ export const buildMarketInteractionSessionMessage = (input: {
 						marketSessionSideButtonCustomId(session.sessionId, "short"),
 					)
 					.setLabel("Short")
+					.setDisabled(isCompetitiveMultiWinner)
 					.setStyle(
 						selectedAction === "short"
 							? ButtonStyle.Danger

--- a/src/features/markets/ui/render/trades.ts
+++ b/src/features/markets/ui/render/trades.ts
@@ -52,7 +52,7 @@ import {
 
 const getContractModeLabel = (input: {
 	contractMode?: MarketWithRelations["contractMode"];
-	winnerCount?: number;
+	winnerCount?: number | undefined;
 }): string => {
 	if (input.contractMode === "independent_binary_set") {
 		return "Independent Set";

--- a/src/features/markets/ui/visualize.ts
+++ b/src/features/markets/ui/visualize.ts
@@ -1,1031 +1,1190 @@
-import { AttachmentBuilder } from 'discord.js';
-import { existsSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { AttachmentBuilder } from "discord.js";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
-  createCanvas,
-  GlobalFonts,
-  loadImage,
-  type SKRSContext2D,
-} from '@napi-rs/canvas';
+	createCanvas,
+	GlobalFonts,
+	loadImage,
+	type SKRSContext2D,
+} from "@napi-rs/canvas";
 import {
-  bin,
-  line,
-  scaleBand,
-  scaleLinear,
-  scaleOrdinal,
-  scaleTime,
-  schemeTableau10,
-} from 'd3';
+	bin,
+	line,
+	scaleBand,
+	scaleLinear,
+	scaleOrdinal,
+	scaleTime,
+	schemeTableau10,
+} from "d3";
 
-import { computeLmsrProbabilities } from '../core/math.js';
 import {
-  compareMarketHistoryEvents,
-  computeMarketSummary,
-  getMarketStatus,
-} from '../core/shared.js';
-import type { MarketWithRelations } from '../core/types.js';
+	compareMarketHistoryEvents,
+	computeMarketSummary,
+	getMarketProbabilities,
+	getMarketStatus,
+} from "../core/shared.js";
+import type { MarketWithRelations } from "../core/types.js";
 
 const width = 1200;
 const height = 760;
-const background = '#15181d';
-const border = '#2b313a';
-const text = '#f4f7fb';
-const muted = '#a3adba';
-const quiet = '#66707d';
-const grid = '#2f3640';
-const gridStrong = '#404856';
-const volumeColor = '#6f8fc0';
-const fontFamily = 'Public Sans';
+const background = "#15181d";
+const border = "#2b313a";
+const text = "#f4f7fb";
+const muted = "#a3adba";
+const quiet = "#66707d";
+const grid = "#2f3640";
+const gridStrong = "#404856";
+const volumeColor = "#6f8fc0";
+const fontFamily = "Public Sans";
 const fontStack = `'${fontFamily}', 'DejaVu Sans', 'Noto Sans', 'Liberation Sans', sans-serif`;
 const PROBABILITY_EPSILON = 1e-6;
 const VOLUME_BUCKET_COUNT = 28;
 
 const seriesPalette = schemeTableau10.concat([
-  '#7cb7ff',
-  '#ff9f43',
-  '#5fd0a5',
-  '#ff6b8a',
-  '#c490ff',
-  '#ffd166',
-  '#8ce99a',
-  '#7bdff2',
+	"#7cb7ff",
+	"#ff9f43",
+	"#5fd0a5",
+	"#ff6b8a",
+	"#c490ff",
+	"#ffd166",
+	"#8ce99a",
+	"#7bdff2",
 ]);
 
 const tablerIconNames = {
-  volume: 'coins',
-  trades: 'chart-histogram',
-  state: 'clock',
-  bonusBank: 'wallet',
+	volume: "coins",
+	trades: "chart-histogram",
+	state: "clock",
+	bonusBank: "wallet",
 } as const;
 
 type LoadedImage = Awaited<ReturnType<typeof loadImage>>;
 
 type DiagramPayload = {
-  attachment: AttachmentBuilder;
-  fileName: string;
+	attachment: AttachmentBuilder;
+	fileName: string;
 };
 
 type Snapshot = {
-  at: Date;
-  probabilities: number[];
-  cumulativeVolume: number;
+	at: Date;
+	probabilities: number[];
+	cumulativeVolume: number;
 };
 
 type HistoryEvent =
-  | {
-      kind: 'trade';
-      createdAt: Date;
-      outcomeId: string;
-      shareDelta: number;
-      cumulativeVolume: number;
-    }
-  | {
-      kind: 'liquidity';
-      createdAt: Date;
-      scaleFactor: number;
-      liquidityParameter: number;
-    };
+	| {
+			kind: "trade";
+			createdAt: Date;
+			outcomeId: string;
+			shareDelta: number;
+			cumulativeVolume: number;
+	  }
+	| {
+			kind: "liquidity";
+			createdAt: Date;
+			scaleFactor: number;
+			liquidityParameter: number;
+	  };
 
 export type ChartBounds = {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
+	x: number;
+	y: number;
+	width: number;
+	height: number;
 };
 
 export type ProbabilityPoint = {
-  time: number;
-  probability: number;
+	time: number;
+	probability: number;
 };
 
 export type ProbabilitySeries = {
-  outcomeId: string;
-  label: string;
-  color: string;
-  latestProbability: number;
-  points: ProbabilityPoint[];
+	outcomeId: string;
+	label: string;
+	color: string;
+	latestProbability: number;
+	points: ProbabilityPoint[];
 };
 
 export type VolumeBucket = {
-  index: number;
-  startTime: number;
-  endTime: number;
-  volume: number;
-  tradeCount: number;
+	index: number;
+	startTime: number;
+	endTime: number;
+	volume: number;
+	tradeCount: number;
 };
 
 export type MetadataItem = {
-  icon: keyof typeof tablerIconNames;
-  label: string;
-  value: string;
-  accent: string;
+	icon: keyof typeof tablerIconNames;
+	label: string;
+	value: string;
+	accent: string;
 };
 
 export type MarketChartModel = {
-  startTime: number;
-  endTime: number;
-  probabilitySeries: ProbabilitySeries[];
-  volumeBuckets: VolumeBucket[];
-  maxBucketVolume: number;
-  metadata: MetadataItem[];
-  liquidityMarkers: Array<{
-    time: number;
-    label: string;
-  }>;
+	startTime: number;
+	endTime: number;
+	probabilitySeries: ProbabilitySeries[];
+	volumeBuckets: VolumeBucket[];
+	maxBucketVolume: number;
+	metadata: MetadataItem[];
+	liquidityMarkers: Array<{
+		time: number;
+		label: string;
+	}>;
 };
 
 const imageCache = new Map<string, Promise<LoadedImage | null>>();
 
-const axisDateFormatter = new Intl.DateTimeFormat('en-US', {
-  month: 'short',
-  day: 'numeric',
+const axisDateFormatter = new Intl.DateTimeFormat("en-US", {
+	month: "short",
+	day: "numeric",
 });
 
-const axisDateTimeFormatter = new Intl.DateTimeFormat('en-US', {
-  month: 'short',
-  day: 'numeric',
-  hour: 'numeric',
+const axisDateTimeFormatter = new Intl.DateTimeFormat("en-US", {
+	month: "short",
+	day: "numeric",
+	hour: "numeric",
 });
 
-const compactNumberFormatter = new Intl.NumberFormat('en-US', {
-  maximumFractionDigits: 1,
-  notation: 'compact',
+const compactNumberFormatter = new Intl.NumberFormat("en-US", {
+	maximumFractionDigits: 1,
+	notation: "compact",
 });
-const footerDateTimeFormatter = new Intl.DateTimeFormat('en-US', {
-  month: 'short',
-  day: 'numeric',
-  hour: 'numeric',
-  minute: '2-digit',
-  timeZoneName: 'short',
+const footerDateTimeFormatter = new Intl.DateTimeFormat("en-US", {
+	month: "short",
+	day: "numeric",
+	hour: "numeric",
+	minute: "2-digit",
+	timeZoneName: "short",
 });
 
 let publicSansRegistered = false;
 
 const drawLabel = (
-  context: SKRSContext2D,
-  label: string,
-  x: number,
-  y: number,
-  options: {
-    font: string;
-    color: string;
-    align?: CanvasTextAlign;
-    baseline?: CanvasTextBaseline;
-  },
+	context: SKRSContext2D,
+	label: string,
+	x: number,
+	y: number,
+	options: {
+		font: string;
+		color: string;
+		align?: CanvasTextAlign;
+		baseline?: CanvasTextBaseline;
+	},
 ): void => {
-  context.font = options.font;
-  context.fillStyle = options.color;
-  context.textAlign = options.align ?? 'left';
-  context.textBaseline = options.baseline ?? 'alphabetic';
-  context.fillText(label, x, y);
+	context.font = options.font;
+	context.fillStyle = options.color;
+	context.textAlign = options.align ?? "left";
+	context.textBaseline = options.baseline ?? "alphabetic";
+	context.fillText(label, x, y);
 };
 
 const truncateToWidth = (
-  context: SKRSContext2D,
-  label: string,
-  maxWidth: number,
+	context: SKRSContext2D,
+	label: string,
+	maxWidth: number,
 ): string => {
-  if (context.measureText(label).width <= maxWidth) {
-    return label;
-  }
+	if (context.measureText(label).width <= maxWidth) {
+		return label;
+	}
 
-  let value = label;
-  while (value.length > 1 && context.measureText(`${value}...`).width > maxWidth) {
-    value = value.slice(0, -1);
-  }
+	let value = label;
+	while (
+		value.length > 1 &&
+		context.measureText(`${value}...`).width > maxWidth
+	) {
+		value = value.slice(0, -1);
+	}
 
-  return `${value}...`;
+	return `${value}...`;
 };
 
 const wrapText = (
-  context: SKRSContext2D,
-  label: string,
-  maxWidth: number,
-  maxLines: number,
+	context: SKRSContext2D,
+	label: string,
+	maxWidth: number,
+	maxLines: number,
 ): string[] => {
-  const words = label.trim().split(/\s+/).filter(Boolean);
-  if (words.length === 0) {
-    return [''];
-  }
+	const words = label.trim().split(/\s+/).filter(Boolean);
+	if (words.length === 0) {
+		return [""];
+	}
 
-  const lines: string[] = [];
-  let current = '';
+	const lines: string[] = [];
+	let current = "";
 
-  for (const word of words) {
-    const next = current ? `${current} ${word}` : word;
-    if (context.measureText(next).width <= maxWidth) {
-      current = next;
-      continue;
-    }
+	for (const word of words) {
+		const next = current ? `${current} ${word}` : word;
+		if (context.measureText(next).width <= maxWidth) {
+			current = next;
+			continue;
+		}
 
-    if (current) {
-      lines.push(current);
-    }
-    current = word;
+		if (current) {
+			lines.push(current);
+		}
+		current = word;
 
-    if (lines.length === maxLines - 1) {
-      break;
-    }
-  }
+		if (lines.length === maxLines - 1) {
+			break;
+		}
+	}
 
-  if (lines.length < maxLines) {
-    lines.push(current);
-  }
+	if (lines.length < maxLines) {
+		lines.push(current);
+	}
 
-  const consumedWordCount = lines.join(' ').trim().split(/\s+/).filter(Boolean).length;
-  if (consumedWordCount < words.length) {
-    const lastLine = lines[lines.length - 1] ?? '';
-    lines[lines.length - 1] = truncateToWidth(context, `${lastLine} ${words.slice(consumedWordCount).join(' ')}`.trim(), maxWidth);
-  }
+	const consumedWordCount = lines
+		.join(" ")
+		.trim()
+		.split(/\s+/)
+		.filter(Boolean).length;
+	if (consumedWordCount < words.length) {
+		const lastLine = lines[lines.length - 1] ?? "";
+		lines[lines.length - 1] = truncateToWidth(
+			context,
+			`${lastLine} ${words.slice(consumedWordCount).join(" ")}`.trim(),
+			maxWidth,
+		);
+	}
 
-  return lines.slice(0, maxLines);
+	return lines.slice(0, maxLines);
 };
 
-const formatPercent = (value: number, digits = 1): string => `${(value * 100).toFixed(digits)}%`;
+const formatPercent = (value: number, digits = 1): string =>
+	`${(value * 100).toFixed(digits)}%`;
 
 const formatPoints = (value: number): string => {
-  const rounded = Math.round(value);
-  if (Math.abs(value - rounded) < 0.01) {
-    return `${rounded} pts`;
-  }
+	const rounded = Math.round(value);
+	if (Math.abs(value - rounded) < 0.01) {
+		return `${rounded} pts`;
+	}
 
-  return `${value.toFixed(1)} pts`;
+	return `${value.toFixed(1)} pts`;
 };
 
-const formatCompactPoints = (value: number): string => `${compactNumberFormatter.format(value)} pts`;
+const formatCompactPoints = (value: number): string =>
+	`${compactNumberFormatter.format(value)} pts`;
 
-const formatAxisTime = (value: number, startTime: number, endTime: number): string => (
-  endTime - startTime <= 36 * 60 * 60 * 1_000
-    ? axisDateTimeFormatter
-    : axisDateFormatter
-).format(new Date(value));
+const formatAxisTime = (
+	value: number,
+	startTime: number,
+	endTime: number,
+): string =>
+	(endTime - startTime <= 36 * 60 * 60 * 1_000
+		? axisDateTimeFormatter
+		: axisDateFormatter
+	).format(new Date(value));
 
-const formatFooterTimestamp = (value: Date): string => footerDateTimeFormatter.format(value);
+const formatFooterTimestamp = (value: Date): string =>
+	footerDateTimeFormatter.format(value);
 
 const resolvePublicSansPath = (
-  weight: 400 | 500 | 700,
-  moduleUrl: string = import.meta.url,
+	weight: 400 | 500 | 700,
+	moduleUrl: string = import.meta.url,
 ): string | null => {
-  const relativePath = `files/public-sans-latin-${weight}-normal.woff2`;
-  const candidates = [
-    resolve(process.cwd(), 'node_modules', '@fontsource', 'public-sans', relativePath),
-    fileURLToPath(new URL(`../../../../node_modules/@fontsource/public-sans/${relativePath}`, moduleUrl)),
-  ];
+	const relativePath = `files/public-sans-latin-${weight}-normal.woff2`;
+	const candidates = [
+		resolve(
+			process.cwd(),
+			"node_modules",
+			"@fontsource",
+			"public-sans",
+			relativePath,
+		),
+		fileURLToPath(
+			new URL(
+				`../../../../node_modules/@fontsource/public-sans/${relativePath}`,
+				moduleUrl,
+			),
+		),
+	];
 
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-  }
+	for (const candidate of candidates) {
+		if (existsSync(candidate)) {
+			return candidate;
+		}
+	}
 
-  return null;
+	return null;
 };
 
 const ensurePublicSansLoaded = (): void => {
-  if (publicSansRegistered) {
-    return;
-  }
+	if (publicSansRegistered) {
+		return;
+	}
 
-  for (const weight of [400, 500, 700] as const) {
-    const path = resolvePublicSansPath(weight);
-    if (path) {
-      GlobalFonts.registerFromPath(path, fontFamily);
-    }
-  }
+	for (const weight of [400, 500, 700] as const) {
+		const path = resolvePublicSansPath(weight);
+		if (path) {
+			GlobalFonts.registerFromPath(path, fontFamily);
+		}
+	}
 
-  publicSansRegistered = true;
+	publicSansRegistered = true;
 };
 
 const resolveTablerIconPath = (
-  iconName: string,
-  moduleUrl: string = import.meta.url,
+	iconName: string,
+	moduleUrl: string = import.meta.url,
 ): string | null => {
-  const relativePath = `icons/outline/${iconName}.svg`;
-  const candidates = [
-    resolve(process.cwd(), 'node_modules', '@tabler', 'icons', relativePath),
-    fileURLToPath(new URL(`../../../../node_modules/@tabler/icons/${relativePath}`, moduleUrl)),
-  ];
+	const relativePath = `icons/outline/${iconName}.svg`;
+	const candidates = [
+		resolve(process.cwd(), "node_modules", "@tabler", "icons", relativePath),
+		fileURLToPath(
+			new URL(
+				`../../../../node_modules/@tabler/icons/${relativePath}`,
+				moduleUrl,
+			),
+		),
+	];
 
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) {
-      return candidate;
-    }
-  }
+	for (const candidate of candidates) {
+		if (existsSync(candidate)) {
+			return candidate;
+		}
+	}
 
-  return null;
+	return null;
 };
 
 const loadTablerIcon = async (
-  iconName: keyof typeof tablerIconNames,
-  size: number,
-  tint: string,
-) : Promise<LoadedImage | null> => {
-  const file = resolveTablerIconPath(tablerIconNames[iconName]);
-  if (!file) {
-    return null;
-  }
+	iconName: keyof typeof tablerIconNames,
+	size: number,
+	tint: string,
+): Promise<LoadedImage | null> => {
+	const file = resolveTablerIconPath(tablerIconNames[iconName]);
+	if (!file) {
+		return null;
+	}
 
-  const cacheKey = `${file}:${size}:${tint}`;
-  const cached = imageCache.get(cacheKey);
-  if (cached) {
-    return cached;
-  }
+	const cacheKey = `${file}:${size}:${tint}`;
+	const cached = imageCache.get(cacheKey);
+	if (cached) {
+		return cached;
+	}
 
-  const pending = readFile(file, 'utf8')
-    .then((svg) => svg
-      .replace('<svg ', `<svg width="${size}" height="${size}" `)
-      .replaceAll('currentColor', tint))
-    .then((svg) => loadImage(Buffer.from(svg)));
+	const pending = readFile(file, "utf8")
+		.then((svg) =>
+			svg
+				.replace("<svg ", `<svg width="${size}" height="${size}" `)
+				.replaceAll("currentColor", tint),
+		)
+		.then((svg) => loadImage(Buffer.from(svg)));
 
-  imageCache.set(cacheKey, pending);
-  return pending;
+	imageCache.set(cacheKey, pending);
+	return pending;
 };
 
-export const resolveMarketDiagramEndTime = (market: MarketWithRelations, now = new Date()): Date => {
-  if (market.resolvedAt) {
-    return market.resolvedAt;
-  }
+export const resolveMarketDiagramEndTime = (
+	market: MarketWithRelations,
+	now = new Date(),
+): Date => {
+	if (market.resolvedAt) {
+		return market.resolvedAt;
+	}
 
-  if (market.cancelledAt) {
-    return market.cancelledAt;
-  }
+	if (market.cancelledAt) {
+		return market.cancelledAt;
+	}
 
-  if (market.tradingClosedAt) {
-    return market.tradingClosedAt;
-  }
+	if (market.tradingClosedAt) {
+		return market.tradingClosedAt;
+	}
 
-  let latestHistoryTime = market.createdAt.getTime();
+	let latestHistoryTime = market.createdAt.getTime();
 
-  for (const trade of market.trades) {
-    latestHistoryTime = Math.max(latestHistoryTime, trade.createdAt.getTime());
-  }
+	for (const trade of market.trades) {
+		latestHistoryTime = Math.max(latestHistoryTime, trade.createdAt.getTime());
+	}
 
-  for (const event of market.liquidityEvents) {
-    latestHistoryTime = Math.max(latestHistoryTime, event.createdAt.getTime());
-  }
+	for (const event of market.liquidityEvents) {
+		latestHistoryTime = Math.max(latestHistoryTime, event.createdAt.getTime());
+	}
 
-  return new Date(Math.max(now.getTime(), latestHistoryTime));
+	return new Date(Math.max(now.getTime(), latestHistoryTime));
 };
 
-export const buildSnapshots = (market: MarketWithRelations, now = new Date()): Snapshot[] => {
-  const pricingShares = market.outcomes.map(() => 0);
-  let liquidityParameter = market.baseLiquidityParameter;
-  const initialProbabilities = computeLmsrProbabilities(pricingShares, liquidityParameter);
-  const snapshots: Snapshot[] = [{
-    at: market.createdAt,
-    probabilities: initialProbabilities,
-    cumulativeVolume: 0,
-  }];
+export const buildSnapshots = (
+	market: MarketWithRelations,
+	now = new Date(),
+): Snapshot[] => {
+	const pricingShares = market.outcomes.map(() => 0);
+	let liquidityParameter = market.baseLiquidityParameter;
+	const computeSnapshotProbabilities = (at: Date): number[] =>
+		getMarketProbabilities({
+			contractMode: market.contractMode,
+			winnerCount: market.winnerCount,
+			liquidityParameter,
+			resolvedAt: null,
+			winningOutcomeId: market.winningOutcomeId,
+			outcomes: market.outcomes.map((outcome, index) => ({
+				id: outcome.id,
+				pricingShares: pricingShares[index] ?? 0,
+				settlementValue:
+					outcome.resolvedAt && outcome.resolvedAt.getTime() <= at.getTime()
+						? outcome.settlementValue
+						: null,
+			})),
+		});
+	const initialProbabilities = computeSnapshotProbabilities(market.createdAt);
+	const snapshots: Snapshot[] = [
+		{
+			at: market.createdAt,
+			probabilities: initialProbabilities,
+			cumulativeVolume: 0,
+		},
+	];
 
-  const history: HistoryEvent[] = [
-    ...market.trades.map((trade) => ({
-      kind: 'trade' as const,
-      createdAt: trade.createdAt,
-      outcomeId: trade.outcomeId,
-      shareDelta: trade.shareDelta,
-      cumulativeVolume: trade.cumulativeVolume,
-    })),
-    ...market.liquidityEvents.map((event) => ({
-      kind: 'liquidity' as const,
-      createdAt: event.createdAt,
-      scaleFactor: event.scaleFactor,
-      liquidityParameter: event.nextLiquidityParameter,
-    })),
-  ].sort(compareMarketHistoryEvents);
+	const history: HistoryEvent[] = [
+		...market.trades.map((trade) => ({
+			kind: "trade" as const,
+			createdAt: trade.createdAt,
+			outcomeId: trade.outcomeId,
+			shareDelta: trade.shareDelta,
+			cumulativeVolume: trade.cumulativeVolume,
+		})),
+		...market.liquidityEvents.map((event) => ({
+			kind: "liquidity" as const,
+			createdAt: event.createdAt,
+			scaleFactor: event.scaleFactor,
+			liquidityParameter: event.nextLiquidityParameter,
+		})),
+	].sort(compareMarketHistoryEvents);
 
-  for (const event of history) {
-    if (event.kind === 'liquidity') {
-      liquidityParameter = event.liquidityParameter;
-      for (let index = 0; index < market.outcomes.length; index += 1) {
-        const outcome = market.outcomes[index];
-        if (outcome?.resolvedAt && outcome.resolvedAt.getTime() <= event.createdAt.getTime()) {
-          continue;
-        }
+	for (const event of history) {
+		if (event.kind === "liquidity") {
+			liquidityParameter = event.liquidityParameter;
+			for (let index = 0; index < market.outcomes.length; index += 1) {
+				const outcome = market.outcomes[index];
+				if (
+					outcome?.resolvedAt &&
+					outcome.resolvedAt.getTime() <= event.createdAt.getTime()
+				) {
+					continue;
+				}
 
-        pricingShares[index] = (pricingShares[index] ?? 0) * event.scaleFactor;
-      }
+				pricingShares[index] = (pricingShares[index] ?? 0) * event.scaleFactor;
+			}
 
-      snapshots.push({
-        at: event.createdAt,
-        probabilities: computeLmsrProbabilities(pricingShares, liquidityParameter),
-        cumulativeVolume: snapshots[snapshots.length - 1]?.cumulativeVolume ?? 0,
-      });
-      continue;
-    }
+			snapshots.push({
+				at: event.createdAt,
+				probabilities: computeSnapshotProbabilities(event.createdAt),
+				cumulativeVolume:
+					snapshots[snapshots.length - 1]?.cumulativeVolume ?? 0,
+			});
+			continue;
+		}
 
-    const outcomeIndex = market.outcomes.findIndex((outcome) => outcome.id === event.outcomeId);
-    if (outcomeIndex >= 0) {
-      pricingShares[outcomeIndex] = (pricingShares[outcomeIndex] ?? 0) + event.shareDelta;
-    }
+		const outcomeIndex = market.outcomes.findIndex(
+			(outcome) => outcome.id === event.outcomeId,
+		);
+		if (outcomeIndex >= 0) {
+			pricingShares[outcomeIndex] =
+				(pricingShares[outcomeIndex] ?? 0) + event.shareDelta;
+		}
 
-    snapshots.push({
-      at: event.createdAt,
-      probabilities: computeLmsrProbabilities(pricingShares, liquidityParameter),
-      cumulativeVolume: event.cumulativeVolume,
-    });
-  }
+		snapshots.push({
+			at: event.createdAt,
+			probabilities: computeSnapshotProbabilities(event.createdAt),
+			cumulativeVolume: event.cumulativeVolume,
+		});
+	}
 
-  if (snapshots.length === 1) {
-    snapshots.push({
-      at: resolveMarketDiagramEndTime(market, now),
-      probabilities: initialProbabilities,
-      cumulativeVolume: 0,
-    });
-  }
+	if (snapshots.length === 1) {
+		snapshots.push({
+			at: resolveMarketDiagramEndTime(market, now),
+			probabilities: initialProbabilities,
+			cumulativeVolume: 0,
+		});
+	}
 
-  const finalProbabilities = computeMarketSummary(market).probabilities.map((entry) => entry.probability);
-  const latestSnapshot = snapshots[snapshots.length - 1];
-  const needsTerminalSnapshot = market.outcomes.some((outcome) => outcome.settlementValue !== null)
-    || latestSnapshot?.probabilities.some(
-      (value, index) => Math.abs(value - (finalProbabilities[index] ?? 0)) > PROBABILITY_EPSILON,
-    );
-  if (needsTerminalSnapshot) {
-    snapshots.push({
-      at: resolveMarketDiagramEndTime(market, now),
-      probabilities: finalProbabilities,
-      cumulativeVolume: market.totalVolume,
-    });
-  }
+	const finalProbabilities = computeMarketSummary(market).probabilities.map(
+		(entry) => entry.probability,
+	);
+	const latestSnapshot = snapshots[snapshots.length - 1];
+	const needsTerminalSnapshot =
+		market.outcomes.some((outcome) => outcome.settlementValue !== null) ||
+		latestSnapshot?.probabilities.some(
+			(value, index) =>
+				Math.abs(value - (finalProbabilities[index] ?? 0)) >
+				PROBABILITY_EPSILON,
+		);
+	if (needsTerminalSnapshot) {
+		snapshots.push({
+			at: resolveMarketDiagramEndTime(market, now),
+			probabilities: finalProbabilities,
+			cumulativeVolume: market.totalVolume,
+		});
+	}
 
-  return snapshots;
+	return snapshots;
 };
 
 export const bucketTradeVolumes = (
-  market: MarketWithRelations,
-  startTime: number,
-  endTime: number,
-  bucketCount = VOLUME_BUCKET_COUNT,
+	market: MarketWithRelations,
+	startTime: number,
+	endTime: number,
+	bucketCount = VOLUME_BUCKET_COUNT,
 ): VolumeBucket[] => {
-  if (bucketCount <= 0) {
-    return [];
-  }
+	if (bucketCount <= 0) {
+		return [];
+	}
 
-  const safeEndTime = Math.max(startTime + 1, endTime);
-  const bucketSpan = (safeEndTime - startTime) / bucketCount;
-  const thresholds = Array.from({ length: bucketCount + 1 }, (_, index) => (
-    index === bucketCount ? safeEndTime : startTime + (bucketSpan * index)
-  ));
-  const sortedTrades = [...market.trades].sort((left, right) => (
-    left.createdAt.getTime() - right.createdAt.getTime()
-  ));
-  let previousCumulativeVolume = 0;
-  const tradeDeltas = sortedTrades.map((trade) => {
-    const delta = Math.max(0, trade.cumulativeVolume - previousCumulativeVolume);
-    previousCumulativeVolume = trade.cumulativeVolume;
-    return {
-      time: trade.createdAt.getTime(),
-      volume: delta,
-    };
-  });
-  const histogram = bin<{ time: number; volume: number }, number>()
-    .value((trade) => trade.time)
-    .domain([startTime, safeEndTime])
-    .thresholds(thresholds);
-  const bins = histogram(tradeDeltas);
+	const safeEndTime = Math.max(startTime + 1, endTime);
+	const bucketSpan = (safeEndTime - startTime) / bucketCount;
+	const thresholds = Array.from({ length: bucketCount + 1 }, (_, index) =>
+		index === bucketCount ? safeEndTime : startTime + bucketSpan * index,
+	);
+	const sortedTrades = [...market.trades].sort(
+		(left, right) => left.createdAt.getTime() - right.createdAt.getTime(),
+	);
+	let previousCumulativeVolume = 0;
+	const tradeDeltas = sortedTrades.map((trade) => {
+		const delta = Math.max(
+			0,
+			trade.cumulativeVolume - previousCumulativeVolume,
+		);
+		previousCumulativeVolume = trade.cumulativeVolume;
+		return {
+			time: trade.createdAt.getTime(),
+			volume: delta,
+		};
+	});
+	const histogram = bin<{ time: number; volume: number }, number>()
+		.value((trade) => trade.time)
+		.domain([startTime, safeEndTime])
+		.thresholds(thresholds);
+	const bins = histogram(tradeDeltas);
 
-  return Array.from({ length: bucketCount }, (_, index) => {
-    const bucket = bins[index];
-    return {
-      index,
-      startTime: thresholds[index] ?? startTime,
-      endTime: thresholds[index + 1] ?? safeEndTime,
-      volume: bucket?.reduce((sum, trade) => sum + trade.volume, 0) ?? 0,
-      tradeCount: bucket?.length ?? 0,
-    };
-  });
+	return Array.from({ length: bucketCount }, (_, index) => {
+		const bucket = bins[index];
+		return {
+			index,
+			startTime: thresholds[index] ?? startTime,
+			endTime: thresholds[index + 1] ?? safeEndTime,
+			volume: bucket?.reduce((sum, trade) => sum + trade.volume, 0) ?? 0,
+			tradeCount: bucket?.length ?? 0,
+		};
+	});
 };
 
 const buildMetadata = (market: MarketWithRelations): MetadataItem[] => {
-  const status = getMarketStatus(market);
-  const stateAccent = status === 'resolved'
-    ? '#5fd0a5'
-    : status === 'cancelled'
-      ? '#ff7d7d'
-      : status === 'closed'
-        ? '#ffb454'
-        : '#7cb7ff';
+	const status = getMarketStatus(market);
+	const stateAccent =
+		status === "resolved"
+			? "#5fd0a5"
+			: status === "cancelled"
+				? "#ff7d7d"
+				: status === "closed"
+					? "#ffb454"
+					: "#7cb7ff";
 
-  const stateLabel = status === 'open'
-    ? `Closes ${axisDateFormatter.format(market.closeAt)}`
-    : status === 'closed'
-      ? `Closed ${axisDateFormatter.format(market.tradingClosedAt ?? market.closeAt)}`
-      : status === 'resolved'
-        ? `Resolved ${axisDateFormatter.format(market.resolvedAt ?? market.closeAt)}`
-        : `Cancelled ${axisDateFormatter.format(market.cancelledAt ?? market.closeAt)}`;
+	const stateLabel =
+		status === "open"
+			? `Closes ${axisDateFormatter.format(market.closeAt)}`
+			: status === "closed"
+				? `Closed ${axisDateFormatter.format(market.tradingClosedAt ?? market.closeAt)}`
+				: status === "resolved"
+					? `Resolved ${axisDateFormatter.format(market.resolvedAt ?? market.closeAt)}`
+					: `Cancelled ${axisDateFormatter.format(market.cancelledAt ?? market.closeAt)}`;
 
-  return [
-    {
-      icon: 'volume',
-      value: formatCompactPoints(market.totalVolume),
-      label: 'Total volume',
-      accent: text,
-    },
-    {
-      icon: 'trades',
-      value: compactNumberFormatter.format(market.trades.length),
-      label: 'Trades',
-      accent: text,
-    },
-    {
-      icon: 'state',
-      value: status.charAt(0).toUpperCase() + status.slice(1),
-      label: stateLabel,
-      accent: stateAccent,
-    },
-    {
-      icon: 'bonusBank',
-      value: formatCompactPoints(market.supplementaryBonusPool ?? 0),
-      label: 'Bonus bank',
-      accent: text,
-    },
-  ];
+	return [
+		{
+			icon: "volume",
+			value: formatCompactPoints(market.totalVolume),
+			label: "Total volume",
+			accent: text,
+		},
+		{
+			icon: "trades",
+			value: compactNumberFormatter.format(market.trades.length),
+			label: "Trades",
+			accent: text,
+		},
+		{
+			icon: "state",
+			value: status.charAt(0).toUpperCase() + status.slice(1),
+			label: stateLabel,
+			accent: stateAccent,
+		},
+		{
+			icon: "bonusBank",
+			value: formatCompactPoints(market.supplementaryBonusPool ?? 0),
+			label: "Bonus bank",
+			accent: text,
+		},
+	];
 };
 
 export const buildMarketChartModel = (
-  market: MarketWithRelations,
-  now = new Date(),
+	market: MarketWithRelations,
+	now = new Date(),
 ): MarketChartModel => {
-  const snapshots = buildSnapshots(market, now);
-  const summary = computeMarketSummary(market);
-  const colorScale = scaleOrdinal<string, string>()
-    .domain(summary.probabilities.map((entry) => entry.outcomeId))
-    .range(seriesPalette);
-  const startTime = snapshots[0]?.at.getTime() ?? market.createdAt.getTime();
-  const endTime = Math.max(
-    resolveMarketDiagramEndTime(market, now).getTime(),
-    snapshots[snapshots.length - 1]?.at.getTime() ?? startTime + 1,
-    startTime + 1,
-  );
-  const volumeBuckets = bucketTradeVolumes(market, startTime, endTime);
-  const maxBucketVolume = Math.max(...volumeBuckets.map((bucket) => bucket.volume), 1);
+	const snapshots = buildSnapshots(market, now);
+	const summary = computeMarketSummary(market);
+	const colorScale = scaleOrdinal<string, string>()
+		.domain(summary.probabilities.map((entry) => entry.outcomeId))
+		.range(seriesPalette);
+	const startTime = snapshots[0]?.at.getTime() ?? market.createdAt.getTime();
+	const endTime = Math.max(
+		resolveMarketDiagramEndTime(market, now).getTime(),
+		snapshots[snapshots.length - 1]?.at.getTime() ?? startTime + 1,
+		startTime + 1,
+	);
+	const volumeBuckets = bucketTradeVolumes(market, startTime, endTime);
+	const maxBucketVolume = Math.max(
+		...volumeBuckets.map((bucket) => bucket.volume),
+		1,
+	);
 
-  return {
-    startTime,
-    endTime,
-    probabilitySeries: summary.probabilities.map((entry, index) => ({
-      outcomeId: entry.outcomeId,
-      label: entry.label,
-      color: colorScale(entry.outcomeId) ?? seriesPalette[index % seriesPalette.length] ?? seriesPalette[0]!,
-      latestProbability: entry.probability,
-      points: snapshots.map((snapshot) => ({
-        time: snapshot.at.getTime(),
-        probability: snapshot.probabilities[index] ?? 0,
-      })),
-    })),
-    volumeBuckets,
-    maxBucketVolume,
-    metadata: buildMetadata(market),
-    liquidityMarkers: market.liquidityEvents.map((event) => ({
-      time: event.createdAt.getTime(),
-      label: `b=${event.nextLiquidityParameter.toFixed(0)}`,
-    })),
-  };
+	return {
+		startTime,
+		endTime,
+		probabilitySeries: summary.probabilities.map((entry, index) => ({
+			outcomeId: entry.outcomeId,
+			label: entry.label,
+			color:
+				colorScale(entry.outcomeId) ??
+				seriesPalette[index % seriesPalette.length] ??
+				seriesPalette[0]!,
+			latestProbability: entry.probability,
+			points: snapshots.map((snapshot) => ({
+				time: snapshot.at.getTime(),
+				probability: snapshot.probabilities[index] ?? 0,
+			})),
+		})),
+		volumeBuckets,
+		maxBucketVolume,
+		metadata: buildMetadata(market),
+		liquidityMarkers: market.liquidityEvents.map((event) => ({
+			time: event.createdAt.getTime(),
+			label: `b=${event.nextLiquidityParameter.toFixed(0)}`,
+		})),
+	};
 };
 
 const fillCircle = (
-  context: SKRSContext2D,
-  x: number,
-  y: number,
-  radius: number,
-  fillStyle: string,
+	context: SKRSContext2D,
+	x: number,
+	y: number,
+	radius: number,
+	fillStyle: string,
 ): void => {
-  context.beginPath();
-  context.arc(x, y, radius, 0, Math.PI * 2);
-  context.fillStyle = fillStyle;
-  context.fill();
+	context.beginPath();
+	context.arc(x, y, radius, 0, Math.PI * 2);
+	context.fillStyle = fillStyle;
+	context.fill();
 };
 
-const getProbabilityDomain = (series: ProbabilitySeries[]): [number, number] => {
-  const values = series.flatMap((entry) => entry.points.map((point) => point.probability));
-  const min = Math.min(...values, 0.5);
-  const max = Math.max(...values, 0.5);
-  const span = max - min;
-  const paddedSpan = Math.max(0.14, span + 0.08);
-  const midpoint = (min + max) / 2;
-  const lower = Math.max(0, midpoint - (paddedSpan / 2));
-  const upper = Math.min(1, midpoint + (paddedSpan / 2));
+const getProbabilityDomain = (
+	series: ProbabilitySeries[],
+): [number, number] => {
+	const values = series.flatMap((entry) =>
+		entry.points.map((point) => point.probability),
+	);
+	const min = Math.min(...values, 0.5);
+	const max = Math.max(...values, 0.5);
+	const span = max - min;
+	const paddedSpan = Math.max(0.14, span + 0.08);
+	const midpoint = (min + max) / 2;
+	const lower = Math.max(0, midpoint - paddedSpan / 2);
+	const upper = Math.min(1, midpoint + paddedSpan / 2);
 
-  if (upper - lower >= 0.14) {
-    return [lower, upper];
-  }
+	if (upper - lower >= 0.14) {
+		return [lower, upper];
+	}
 
-  if (lower <= 0) {
-    return [0, Math.min(1, 0.14)];
-  }
+	if (lower <= 0) {
+		return [0, Math.min(1, 0.14)];
+	}
 
-  return [Math.max(0, 1 - 0.14), 1];
+	return [Math.max(0, 1 - 0.14), 1];
 };
 
 const drawProbabilityGrid = (
-  context: SKRSContext2D,
-  bounds: ChartBounds,
-  domain: [number, number],
+	context: SKRSContext2D,
+	bounds: ChartBounds,
+	domain: [number, number],
 ): void => {
-  const scale = scaleLinear()
-    .domain(domain)
-    .range([bounds.y + bounds.height, bounds.y]);
-  const ticks = scale.ticks(5);
-  context.lineWidth = 1;
+	const scale = scaleLinear()
+		.domain(domain)
+		.range([bounds.y + bounds.height, bounds.y]);
+	const ticks = scale.ticks(5);
+	context.lineWidth = 1;
 
-  for (const tick of ticks) {
-    const y = scale(tick);
-    context.strokeStyle = tick === 0 || tick === 1 ? gridStrong : grid;
-    context.beginPath();
-    context.moveTo(bounds.x, y);
-    context.lineTo(bounds.x + bounds.width, y);
-    context.stroke();
+	for (const tick of ticks) {
+		const y = scale(tick);
+		context.strokeStyle = tick === 0 || tick === 1 ? gridStrong : grid;
+		context.beginPath();
+		context.moveTo(bounds.x, y);
+		context.lineTo(bounds.x + bounds.width, y);
+		context.stroke();
 
-    drawLabel(context, formatPercent(tick, 0), bounds.x - 16, y, {
-      font: `13px ${fontStack}`,
-      color: muted,
-      align: 'right',
-      baseline: 'middle',
-    });
-  }
+		drawLabel(context, formatPercent(tick, 0), bounds.x - 16, y, {
+			font: `13px ${fontStack}`,
+			color: muted,
+			align: "right",
+			baseline: "middle",
+		});
+	}
 };
 
 const drawVolumeGrid = (
-  context: SKRSContext2D,
-  bounds: ChartBounds,
-  maxBucketVolume: number,
+	context: SKRSContext2D,
+	bounds: ChartBounds,
+	maxBucketVolume: number,
 ): void => {
-  const scale = scaleLinear()
-    .domain([0, Math.max(1, maxBucketVolume)])
-    .range([bounds.y + bounds.height, bounds.y]);
-  const ticks = scale.ticks(2);
-  const topY = scale(maxBucketVolume);
-  const bottomY = scale(0);
+	const scale = scaleLinear()
+		.domain([0, Math.max(1, maxBucketVolume)])
+		.range([bounds.y + bounds.height, bounds.y]);
+	const ticks = scale.ticks(2);
+	const topY = scale(maxBucketVolume);
+	const bottomY = scale(0);
 
-  context.lineWidth = 1;
-  context.strokeStyle = gridStrong;
-  context.beginPath();
-  context.moveTo(bounds.x, topY);
-  context.lineTo(bounds.x + bounds.width, topY);
-  context.stroke();
+	context.lineWidth = 1;
+	context.strokeStyle = gridStrong;
+	context.beginPath();
+	context.moveTo(bounds.x, topY);
+	context.lineTo(bounds.x + bounds.width, topY);
+	context.stroke();
 
-  context.strokeStyle = grid;
-  context.beginPath();
-  context.moveTo(bounds.x, bottomY);
-  context.lineTo(bounds.x + bounds.width, bottomY);
-  context.stroke();
+	context.strokeStyle = grid;
+	context.beginPath();
+	context.moveTo(bounds.x, bottomY);
+	context.lineTo(bounds.x + bounds.width, bottomY);
+	context.stroke();
 
-  ticks.forEach((tick) => {
-    const y = scale(tick);
-    if (tick > 0 && tick < maxBucketVolume) {
-      context.strokeStyle = grid;
-      context.beginPath();
-      context.moveTo(bounds.x, y);
-      context.lineTo(bounds.x + bounds.width, y);
-      context.stroke();
-    }
+	ticks.forEach((tick) => {
+		const y = scale(tick);
+		if (tick > 0 && tick < maxBucketVolume) {
+			context.strokeStyle = grid;
+			context.beginPath();
+			context.moveTo(bounds.x, y);
+			context.lineTo(bounds.x + bounds.width, y);
+			context.stroke();
+		}
 
-    drawLabel(context, compactNumberFormatter.format(tick), bounds.x - 16, y, {
-      font: `13px ${fontStack}`,
-      color: muted,
-      align: 'right',
-      baseline: 'middle',
-    });
-  });
+		drawLabel(context, compactNumberFormatter.format(tick), bounds.x - 16, y, {
+			font: `13px ${fontStack}`,
+			color: muted,
+			align: "right",
+			baseline: "middle",
+		});
+	});
 };
 
 const drawStepSeries = (
-  context: SKRSContext2D,
-  bounds: ChartBounds,
-  series: ProbabilitySeries,
-  startTime: number,
-  endTime: number,
-  domain: [number, number],
+	context: SKRSContext2D,
+	bounds: ChartBounds,
+	series: ProbabilitySeries,
+	startTime: number,
+	endTime: number,
+	domain: [number, number],
 ): void => {
-  if (series.points.length === 0) {
-    return;
-  }
+	if (series.points.length === 0) {
+		return;
+	}
 
-  const xScale = scaleTime<number, number>()
-    .domain([new Date(startTime), new Date(endTime)])
-    .range([bounds.x, bounds.x + bounds.width]);
-  const yScale = scaleLinear()
-    .domain(domain)
-    .range([bounds.y + bounds.height, bounds.y]);
-  const lineGenerator = line<ProbabilityPoint>()
-    .x((point) => xScale(new Date(point.time)))
-    .y((point) => yScale(point.probability))
-    .context(context as never);
+	const xScale = scaleTime<number, number>()
+		.domain([new Date(startTime), new Date(endTime)])
+		.range([bounds.x, bounds.x + bounds.width]);
+	const yScale = scaleLinear()
+		.domain(domain)
+		.range([bounds.y + bounds.height, bounds.y]);
+	const lineGenerator = line<ProbabilityPoint>()
+		.x((point) => xScale(new Date(point.time)))
+		.y((point) => yScale(point.probability))
+		.context(context as never);
 
-  context.save();
-  context.beginPath();
-  context.rect(bounds.x, bounds.y, bounds.width, bounds.height);
-  context.clip();
-  context.lineWidth = 3;
-  context.strokeStyle = series.color;
-  context.lineCap = 'round';
-  context.lineJoin = 'round';
-  context.beginPath();
-  lineGenerator(series.points);
-  context.stroke();
+	context.save();
+	context.beginPath();
+	context.rect(bounds.x, bounds.y, bounds.width, bounds.height);
+	context.clip();
+	context.lineWidth = 3;
+	context.strokeStyle = series.color;
+	context.lineCap = "round";
+	context.lineJoin = "round";
+	context.beginPath();
+	lineGenerator(series.points);
+	context.stroke();
 
-  const latest = series.points[series.points.length - 1]!;
-  fillCircle(
-    context,
-    xScale(new Date(latest.time)),
-    yScale(latest.probability),
-    5.5,
-    series.color,
-  );
-  context.lineWidth = 2;
-  context.strokeStyle = background;
-  context.beginPath();
-  context.arc(xScale(new Date(latest.time)), yScale(latest.probability), 5.5, 0, Math.PI * 2);
-  context.stroke();
-  context.restore();
+	const latest = series.points[series.points.length - 1]!;
+	fillCircle(
+		context,
+		xScale(new Date(latest.time)),
+		yScale(latest.probability),
+		5.5,
+		series.color,
+	);
+	context.lineWidth = 2;
+	context.strokeStyle = background;
+	context.beginPath();
+	context.arc(
+		xScale(new Date(latest.time)),
+		yScale(latest.probability),
+		5.5,
+		0,
+		Math.PI * 2,
+	);
+	context.stroke();
+	context.restore();
 };
 
 const drawLiquidityMarkers = (
-  context: SKRSContext2D,
-  bounds: ChartBounds,
-  startTime: number,
-  endTime: number,
-  markers: Array<{ time: number; label: string }>,
+	context: SKRSContext2D,
+	bounds: ChartBounds,
+	startTime: number,
+	endTime: number,
+	markers: Array<{ time: number; label: string }>,
 ): void => {
-  if (markers.length === 0) {
-    return;
-  }
+	if (markers.length === 0) {
+		return;
+	}
 
-  const xScale = scaleTime<number, number>()
-    .domain([new Date(startTime), new Date(endTime)])
-    .range([bounds.x, bounds.x + bounds.width]);
+	const xScale = scaleTime<number, number>()
+		.domain([new Date(startTime), new Date(endTime)])
+		.range([bounds.x, bounds.x + bounds.width]);
 
-  markers.forEach((marker, index) => {
-    const x = xScale(new Date(marker.time));
-    const chipY = bounds.y + 10 + ((index % 2) * 18);
+	markers.forEach((marker, index) => {
+		const x = xScale(new Date(marker.time));
+		const chipY = bounds.y + 10 + (index % 2) * 18;
 
-    context.save();
-    context.strokeStyle = 'rgba(163, 173, 186, 0.28)';
-    context.lineWidth = 1;
-    context.setLineDash([5, 5]);
-    context.beginPath();
-    context.moveTo(x, bounds.y);
-    context.lineTo(x, bounds.y + bounds.height);
-    context.stroke();
-    context.setLineDash([]);
+		context.save();
+		context.strokeStyle = "rgba(163, 173, 186, 0.28)";
+		context.lineWidth = 1;
+		context.setLineDash([5, 5]);
+		context.beginPath();
+		context.moveTo(x, bounds.y);
+		context.lineTo(x, bounds.y + bounds.height);
+		context.stroke();
+		context.setLineDash([]);
 
-    context.beginPath();
-    context.arc(x, chipY + 1, 3, 0, Math.PI * 2);
-    context.fillStyle = '#8ea1b8';
-    context.fill();
+		context.beginPath();
+		context.arc(x, chipY + 1, 3, 0, Math.PI * 2);
+		context.fillStyle = "#8ea1b8";
+		context.fill();
 
-    drawLabel(context, marker.label, x + 8, chipY + 4, {
-      font: `600 12px ${fontStack}`,
-      color: muted,
-      baseline: 'middle',
-    });
-    context.restore();
-  });
+		drawLabel(context, marker.label, x + 8, chipY + 4, {
+			font: `600 12px ${fontStack}`,
+			color: muted,
+			baseline: "middle",
+		});
+		context.restore();
+	});
 };
 
 const drawVolumeHistogram = (
-  context: SKRSContext2D,
-  bounds: ChartBounds,
-  buckets: VolumeBucket[],
-  maxBucketVolume: number,
+	context: SKRSContext2D,
+	bounds: ChartBounds,
+	buckets: VolumeBucket[],
+	maxBucketVolume: number,
 ): void => {
-  if (buckets.length === 0) {
-    return;
-  }
+	if (buckets.length === 0) {
+		return;
+	}
 
-  const xScale = scaleBand<string>()
-    .domain(buckets.map((bucket) => bucket.index.toString()))
-    .range([bounds.x, bounds.x + bounds.width])
-    .paddingInner(0.14)
-    .paddingOuter(0.04);
-  const yScale = scaleLinear()
-    .domain([0, Math.max(1, maxBucketVolume)])
-    .range([bounds.y + bounds.height, bounds.y]);
+	const xScale = scaleBand<string>()
+		.domain(buckets.map((bucket) => bucket.index.toString()))
+		.range([bounds.x, bounds.x + bounds.width])
+		.paddingInner(0.14)
+		.paddingOuter(0.04);
+	const yScale = scaleLinear()
+		.domain([0, Math.max(1, maxBucketVolume)])
+		.range([bounds.y + bounds.height, bounds.y]);
 
-  buckets.forEach((bucket) => {
-    const x = xScale(bucket.index.toString());
-    if (x === undefined) {
-      return;
-    }
-    const y = yScale(bucket.volume);
-    const barWidth = xScale.bandwidth();
-    const barHeight = Math.max(1.5, (bounds.y + bounds.height) - y);
+	buckets.forEach((bucket) => {
+		const x = xScale(bucket.index.toString());
+		if (x === undefined) {
+			return;
+		}
+		const y = yScale(bucket.volume);
+		const barWidth = xScale.bandwidth();
+		const barHeight = Math.max(1.5, bounds.y + bounds.height - y);
 
-    context.fillStyle = bucket.volume > 0 ? volumeColor : 'rgba(111, 143, 192, 0.18)';
-    context.fillRect(x, y, Math.max(1, barWidth), barHeight);
-  });
+		context.fillStyle =
+			bucket.volume > 0 ? volumeColor : "rgba(111, 143, 192, 0.18)";
+		context.fillRect(x, y, Math.max(1, barWidth), barHeight);
+	});
 };
 
 const drawTimeAxis = (
-  context: SKRSContext2D,
-  bounds: ChartBounds,
-  startTime: number,
-  endTime: number,
+	context: SKRSContext2D,
+	bounds: ChartBounds,
+	startTime: number,
+	endTime: number,
 ): void => {
-  const scale = scaleTime<number, number>()
-    .domain([new Date(startTime), new Date(endTime)])
-    .range([bounds.x, bounds.x + bounds.width]);
-  const ticks = scale.ticks(4);
-  ticks.forEach((tick, index) => {
-    const x = scale(tick);
-    drawLabel(context, formatAxisTime(tick.getTime(), startTime, endTime), x, bounds.y + bounds.height + 28, {
-      font: `13px ${fontStack}`,
-      color: muted,
-      align: index === 0 ? 'left' : index === ticks.length - 1 ? 'right' : 'center',
-    });
-  });
+	const scale = scaleTime<number, number>()
+		.domain([new Date(startTime), new Date(endTime)])
+		.range([bounds.x, bounds.x + bounds.width]);
+	const ticks = scale.ticks(4);
+	ticks.forEach((tick, index) => {
+		const x = scale(tick);
+		drawLabel(
+			context,
+			formatAxisTime(tick.getTime(), startTime, endTime),
+			x,
+			bounds.y + bounds.height + 28,
+			{
+				font: `13px ${fontStack}`,
+				color: muted,
+				align:
+					index === 0
+						? "left"
+						: index === ticks.length - 1
+							? "right"
+							: "center",
+			},
+		);
+	});
 };
 
 const drawMetadataItem = async (
-  context: SKRSContext2D,
-  item: MetadataItem,
-  x: number,
-  y: number,
+	context: SKRSContext2D,
+	item: MetadataItem,
+	x: number,
+	y: number,
 ): Promise<void> => {
-  const icon = await loadTablerIcon(item.icon, 20, item.accent);
-  const textX = icon ? x + 30 : x;
-  if (icon) {
-    context.drawImage(icon, x, y + 4, 20, 20);
-  }
+	const icon = await loadTablerIcon(item.icon, 20, item.accent);
+	const textX = icon ? x + 30 : x;
+	if (icon) {
+		context.drawImage(icon, x, y + 4, 20, 20);
+	}
 
-  drawLabel(context, item.value, textX, y + 15, {
-    font: `700 20px ${fontStack}`,
-    color: item.accent,
-  });
-  drawLabel(context, item.label, textX, y + 38, {
-    font: `14px ${fontStack}`,
-    color: muted,
-  });
+	drawLabel(context, item.value, textX, y + 15, {
+		font: `700 20px ${fontStack}`,
+		color: item.accent,
+	});
+	drawLabel(context, item.label, textX, y + 38, {
+		font: `14px ${fontStack}`,
+		color: muted,
+	});
 };
 
 const drawLegend = (
-  context: SKRSContext2D,
-  series: ProbabilitySeries[],
-  x: number,
-  y: number,
-  maxWidth: number,
+	context: SKRSContext2D,
+	series: ProbabilitySeries[],
+	x: number,
+	y: number,
+	maxWidth: number,
 ): void => {
-  const columns = series.length > 3 ? 2 : Math.max(1, series.length);
-  const columnGap = 18;
-  const itemWidth = Math.floor((maxWidth - (columnGap * (columns - 1))) / columns);
-  const rowHeight = 22;
+	const columns = series.length > 3 ? 2 : Math.max(1, series.length);
+	const columnGap = 18;
+	const itemWidth = Math.floor(
+		(maxWidth - columnGap * (columns - 1)) / columns,
+	);
+	const rowHeight = 22;
 
-  series.forEach((entry, index) => {
-    const column = index % columns;
-    const row = Math.floor(index / columns);
-    const itemX = x + (column * (itemWidth + columnGap));
-    const itemY = y + (row * rowHeight);
+	series.forEach((entry, index) => {
+		const column = index % columns;
+		const row = Math.floor(index / columns);
+		const itemX = x + column * (itemWidth + columnGap);
+		const itemY = y + row * rowHeight;
 
-    context.strokeStyle = entry.color;
-    context.lineWidth = 3;
-    context.beginPath();
-    context.moveTo(itemX, itemY + 9);
-    context.lineTo(itemX + 18, itemY + 9);
-    context.stroke();
-    fillCircle(context, itemX + 9, itemY + 9, 4, entry.color);
+		context.strokeStyle = entry.color;
+		context.lineWidth = 3;
+		context.beginPath();
+		context.moveTo(itemX, itemY + 9);
+		context.lineTo(itemX + 18, itemY + 9);
+		context.stroke();
+		fillCircle(context, itemX + 9, itemY + 9, 4, entry.color);
 
-    const labelX = itemX + 28;
-    const labelY = itemY + 14;
-    context.font = `700 14px ${fontStack}`;
-    const value = formatPercent(entry.latestProbability, 1);
-    const valueWidth = context.measureText(value).width;
-    const label = truncateToWidth(context, entry.label, Math.max(46, itemWidth - 44 - valueWidth - 8));
-    drawLabel(context, label, labelX, labelY, {
-      font: `15px ${fontStack}`,
-      color: text,
-    });
-    const labelWidth = context.measureText(label).width;
-    drawLabel(context, value, labelX + labelWidth + 8, labelY, {
-      font: `700 14px ${fontStack}`,
-      color: muted,
-    });
-  });
+		const labelX = itemX + 28;
+		const labelY = itemY + 14;
+		context.font = `700 14px ${fontStack}`;
+		const value = formatPercent(entry.latestProbability, 1);
+		const valueWidth = context.measureText(value).width;
+		const label = truncateToWidth(
+			context,
+			entry.label,
+			Math.max(46, itemWidth - 44 - valueWidth - 8),
+		);
+		drawLabel(context, label, labelX, labelY, {
+			font: `15px ${fontStack}`,
+			color: text,
+		});
+		const labelWidth = context.measureText(label).width;
+		drawLabel(context, value, labelX + labelWidth + 8, labelY, {
+			font: `700 14px ${fontStack}`,
+			color: muted,
+		});
+	});
 };
 
 const getLegendMetrics = (
-  series: ProbabilitySeries[],
+	series: ProbabilitySeries[],
 ): {
-  columns: number;
-  rowCount: number;
+	columns: number;
+	rowCount: number;
 } => {
-  const columns = series.length > 3 ? 2 : Math.max(1, series.length);
-  return {
-    columns,
-    rowCount: Math.ceil(series.length / columns),
-  };
+	const columns = series.length > 3 ? 2 : Math.max(1, series.length);
+	return {
+		columns,
+		rowCount: Math.ceil(series.length / columns),
+	};
 };
 
 const buildCanvas = async (market: MarketWithRelations): Promise<Buffer> => {
-  ensurePublicSansLoaded();
-  const canvas = createCanvas(width, height);
-  const context = canvas.getContext('2d');
-  const generatedAt = new Date();
-  const model = buildMarketChartModel(market);
-  const probabilityDomain = getProbabilityDomain(model.probabilitySeries);
+	ensurePublicSansLoaded();
+	const canvas = createCanvas(width, height);
+	const context = canvas.getContext("2d");
+	const generatedAt = new Date();
+	const model = buildMarketChartModel(market);
+	const probabilityDomain = getProbabilityDomain(model.probabilitySeries);
 
-  context.fillStyle = background;
-  context.fillRect(0, 0, width, height);
+	context.fillStyle = background;
+	context.fillRect(0, 0, width, height);
 
-  context.lineWidth = 1;
-  context.strokeStyle = border;
-  context.strokeRect(28, 28, width - 56, height - 56);
+	context.lineWidth = 1;
+	context.strokeStyle = border;
+	context.strokeRect(28, 28, width - 56, height - 56);
 
-  context.font = `700 34px ${fontStack}`;
-  const titleLines = wrapText(context, market.title, 620, 2);
+	context.font = `700 34px ${fontStack}`;
+	const titleLines = wrapText(context, market.title, 620, 2);
 
-  titleLines.forEach((line, index) => {
-    drawLabel(context, line, 68, 74 + (index * 40), {
-      font: `700 34px ${fontStack}`,
-      color: text,
-    });
-  });
+	titleLines.forEach((line, index) => {
+		drawLabel(context, line, 68, 74 + index * 40, {
+			font: `700 34px ${fontStack}`,
+			color: text,
+		});
+	});
 
-  const titleBlockHeight = 40 * titleLines.length;
-  const subtitleY = 58 + titleBlockHeight;
-  drawLabel(context, 'Market probabilities over time', 68, subtitleY, {
-    font: `17px ${fontStack}`,
-    color: muted,
-  });
+	const titleBlockHeight = 40 * titleLines.length;
+	const subtitleY = 58 + titleBlockHeight;
+	drawLabel(context, "Market probabilities over time", 68, subtitleY, {
+		font: `17px ${fontStack}`,
+		color: muted,
+	});
 
-  const statsX = 782;
-  const statsY = 62;
-  await Promise.all(model.metadata.map((item, index) => drawMetadataItem(
-    context,
-    item,
-    statsX + ((index % 2) * 184),
-    statsY + (Math.floor(index / 2) * 58),
-  )));
+	const statsX = 782;
+	const statsY = 62;
+	await Promise.all(
+		model.metadata.map((item, index) =>
+			drawMetadataItem(
+				context,
+				item,
+				statsX + (index % 2) * 184,
+				statsY + Math.floor(index / 2) * 58,
+			),
+		),
+	);
 
-  const legendX = 68;
-  const legendMaxWidth = 560;
-  const legendY = subtitleY + 28;
-  const legendMetrics = getLegendMetrics(model.probabilitySeries);
-  const legendHeight = (legendMetrics.rowCount * 22);
-  drawLegend(context, model.probabilitySeries, legendX, legendY, legendMaxWidth);
+	const legendX = 68;
+	const legendMaxWidth = 560;
+	const legendY = subtitleY + 28;
+	const legendMetrics = getLegendMetrics(model.probabilitySeries);
+	const legendHeight = legendMetrics.rowCount * 22;
+	drawLegend(
+		context,
+		model.probabilitySeries,
+		legendX,
+		legendY,
+		legendMaxWidth,
+	);
 
-  const probabilityBounds: ChartBounds = {
-    x: 116,
-    y: legendY + legendHeight + 24,
-    width: 1000,
-    height: 272,
-  };
-  const volumeBounds: ChartBounds = {
-    x: probabilityBounds.x,
-    y: probabilityBounds.y + probabilityBounds.height + 56,
-    width: probabilityBounds.width,
-    height: 86,
-  };
+	const probabilityBounds: ChartBounds = {
+		x: 116,
+		y: legendY + legendHeight + 24,
+		width: 1000,
+		height: 272,
+	};
+	const volumeBounds: ChartBounds = {
+		x: probabilityBounds.x,
+		y: probabilityBounds.y + probabilityBounds.height + 56,
+		width: probabilityBounds.width,
+		height: 86,
+	};
 
-  drawLabel(context, 'PROBABILITY', probabilityBounds.x, probabilityBounds.y - 18, {
-    font: `700 12px ${fontStack}`,
-    color: quiet,
-  });
-  drawLabel(context, 'TRADING VOLUME', volumeBounds.x, volumeBounds.y - 18, {
-    font: `700 12px ${fontStack}`,
-    color: quiet,
-  });
+	drawLabel(
+		context,
+		"PROBABILITY",
+		probabilityBounds.x,
+		probabilityBounds.y - 18,
+		{
+			font: `700 12px ${fontStack}`,
+			color: quiet,
+		},
+	);
+	drawLabel(context, "TRADING VOLUME", volumeBounds.x, volumeBounds.y - 18, {
+		font: `700 12px ${fontStack}`,
+		color: quiet,
+	});
 
-  drawProbabilityGrid(context, probabilityBounds, probabilityDomain);
-  drawVolumeGrid(context, volumeBounds, model.maxBucketVolume);
-  drawLiquidityMarkers(context, probabilityBounds, model.startTime, model.endTime, model.liquidityMarkers);
+	drawProbabilityGrid(context, probabilityBounds, probabilityDomain);
+	drawVolumeGrid(context, volumeBounds, model.maxBucketVolume);
+	drawLiquidityMarkers(
+		context,
+		probabilityBounds,
+		model.startTime,
+		model.endTime,
+		model.liquidityMarkers,
+	);
 
-  context.strokeStyle = gridStrong;
-  context.lineWidth = 1;
-  context.beginPath();
-  context.moveTo(probabilityBounds.x, probabilityBounds.y + probabilityBounds.height + 42);
-  context.lineTo(probabilityBounds.x + probabilityBounds.width, probabilityBounds.y + probabilityBounds.height + 42);
-  context.stroke();
+	context.strokeStyle = gridStrong;
+	context.lineWidth = 1;
+	context.beginPath();
+	context.moveTo(
+		probabilityBounds.x,
+		probabilityBounds.y + probabilityBounds.height + 42,
+	);
+	context.lineTo(
+		probabilityBounds.x + probabilityBounds.width,
+		probabilityBounds.y + probabilityBounds.height + 42,
+	);
+	context.stroke();
 
-  model.probabilitySeries.forEach((series) => {
-    drawStepSeries(context, probabilityBounds, series, model.startTime, model.endTime, probabilityDomain);
-  });
-  drawVolumeHistogram(context, volumeBounds, model.volumeBuckets, model.maxBucketVolume);
-  drawTimeAxis(context, volumeBounds, model.startTime, model.endTime);
+	model.probabilitySeries.forEach((series) => {
+		drawStepSeries(
+			context,
+			probabilityBounds,
+			series,
+			model.startTime,
+			model.endTime,
+			probabilityDomain,
+		);
+	});
+	drawVolumeHistogram(
+		context,
+		volumeBounds,
+		model.volumeBuckets,
+		model.maxBucketVolume,
+	);
+	drawTimeAxis(context, volumeBounds, model.startTime, model.endTime);
 
-  drawLabel(context, `Market ID ${market.id}`, 68, height - 12, {
-    font: `13px ${fontStack}`,
-    color: quiet,
-    baseline: 'bottom',
-  });
-  drawLabel(context, `Generated ${formatFooterTimestamp(generatedAt)}`, width - 68, height - 12, {
-    font: `13px ${fontStack}`,
-    color: quiet,
-    align: 'right',
-    baseline: 'bottom',
-  });
+	drawLabel(context, `Market ID ${market.id}`, 68, height - 12, {
+		font: `13px ${fontStack}`,
+		color: quiet,
+		baseline: "bottom",
+	});
+	drawLabel(
+		context,
+		`Generated ${formatFooterTimestamp(generatedAt)}`,
+		width - 68,
+		height - 12,
+		{
+			font: `13px ${fontStack}`,
+			color: quiet,
+			align: "right",
+			baseline: "bottom",
+		},
+	);
 
-  return canvas.encode('png');
+	return canvas.encode("png");
 };
 
-export const buildMarketDiagram = async (market: MarketWithRelations): Promise<DiagramPayload> => {
-  const fileName = `market-${market.id}.png`;
-  const buffer = await buildCanvas(market);
+export const buildMarketDiagram = async (
+	market: MarketWithRelations,
+): Promise<DiagramPayload> => {
+	const fileName = `market-${market.id}.png`;
+	const buffer = await buildCanvas(market);
 
-  return {
-    fileName,
-    attachment: new AttachmentBuilder(buffer, {
-      name: fileName,
-    }),
-  };
+	return {
+		fileName,
+		attachment: new AttachmentBuilder(buffer, {
+			name: fileName,
+		}),
+	};
 };

--- a/src/features/markets/ui/visualize.ts
+++ b/src/features/markets/ui/visualize.ts
@@ -417,7 +417,7 @@ export const buildSnapshots = (
 	const computeSnapshotProbabilities = (at: Date): number[] =>
 		getMarketProbabilities({
 			contractMode: market.contractMode ?? null,
-			winnerCount: market.winnerCount,
+			winnerCount: market.winnerCount ?? null,
 			liquidityParameter,
 			resolvedAt: null,
 			winningOutcomeId: market.winningOutcomeId,

--- a/src/features/markets/ui/visualize.ts
+++ b/src/features/markets/ui/visualize.ts
@@ -416,7 +416,7 @@ export const buildSnapshots = (
 	let liquidityParameter = market.baseLiquidityParameter;
 	const computeSnapshotProbabilities = (at: Date): number[] =>
 		getMarketProbabilities({
-			contractMode: market.contractMode,
+			contractMode: market.contractMode ?? null,
 			winnerCount: market.winnerCount,
 			liquidityParameter,
 			resolvedAt: null,

--- a/tests/market-math.test.ts
+++ b/tests/market-math.test.ts
@@ -1,107 +1,227 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
-import { computeBuyCost, computeLmsrCost, computeLmsrProbabilities, computeSellPayout, solveBuySharesForAmount, solveSellSharesForAmount, solveShortSharesForAmount } from '../src/features/markets/core/math.js';
+import {
+	computeBuyCost,
+	computeLmsrCost,
+	computeLmsrProbabilities,
+	computeSellPayout,
+	computeTopKBuyCost,
+	computeTopKMarginals,
+	computeTopKSellPayout,
+	solveBuySharesForAmount,
+	solveSellSharesForAmount,
+	solveShortSharesForAmount,
+	solveTopKBuySharesForAmount,
+} from "../src/features/markets/core/math.js";
+import { getMarketProbabilities } from "../src/features/markets/core/shared.js";
 
-describe('market math', () => {
-  it('keeps probabilities normalized', () => {
-    const probabilities = computeLmsrProbabilities([12.5, 4.2, 8.1], 150);
-    const total = probabilities.reduce((sum, value) => sum + value, 0);
+describe("market math", () => {
+	it("keeps probabilities normalized", () => {
+		const probabilities = computeLmsrProbabilities([12.5, 4.2, 8.1], 150);
+		const total = probabilities.reduce((sum, value) => sum + value, 0);
 
-    expect(total).toBeCloseTo(1, 10);
-    expect(probabilities.every((value) => value > 0)).toBe(true);
-  });
+		expect(total).toBeCloseTo(1, 10);
+		expect(probabilities.every((value) => value > 0)).toBe(true);
+	});
 
-  it('solves buy share amounts against LMSR cost', () => {
-    const shares = [0, 0];
-    const delta = solveBuySharesForAmount(shares, 0, 75, 150);
-    const before = computeLmsrCost(shares, 150);
-    const [firstShare, secondShare] = shares;
-    const after = computeLmsrCost([(firstShare ?? 0) + delta, secondShare ?? 0], 150);
+	it("keeps categorical single-winner probabilities summing to 1", () => {
+		const probabilities = getMarketProbabilities({
+			contractMode: "categorical_single_winner",
+			winnerCount: 1,
+			resolvedAt: null,
+			liquidityParameter: 150,
+			winningOutcomeId: null,
+			outcomes: [
+				{ id: "a", pricingShares: 5, settlementValue: null },
+				{ id: "b", pricingShares: -1, settlementValue: null },
+				{ id: "c", pricingShares: 2, settlementValue: null },
+			],
+		});
 
-    expect(delta).toBeGreaterThan(0);
-    expect(after - before).toBeCloseTo(75, 5);
-  });
+		expect(probabilities.reduce((sum, value) => sum + value, 0)).toBeCloseTo(
+			1,
+			8,
+		);
+	});
 
-  it('solves sell share amounts against desired payout', () => {
-    const shares = [0, 0];
-    const boughtShares = solveBuySharesForAmount(shares, 0, 100, 150);
-    const marketShares = [boughtShares, 0];
-    const sharesToSell = solveSellSharesForAmount(marketShares, 0, 40, boughtShares, 150);
-    const payout = computeSellPayout(marketShares, 0, sharesToSell, 150);
+	it("keeps independent-set probabilities independent (sum can exceed 1)", () => {
+		const probabilities = getMarketProbabilities({
+			contractMode: "independent_binary_set",
+			winnerCount: 1,
+			resolvedAt: null,
+			liquidityParameter: 150,
+			winningOutcomeId: null,
+			outcomes: [
+				{ id: "a", pricingShares: 0, settlementValue: null },
+				{ id: "b", pricingShares: 0, settlementValue: null },
+				{ id: "c", pricingShares: 0, settlementValue: null },
+			],
+		});
 
-    expect(sharesToSell).toBeGreaterThan(0);
-    expect(sharesToSell).toBeLessThan(boughtShares);
-    expect(payout).toBeCloseTo(40, 5);
-  });
+		expect(probabilities).toEqual([0.5, 0.5, 0.5]);
+		expect(probabilities.reduce((sum, value) => sum + value, 0)).toBeCloseTo(
+			1.5,
+			8,
+		);
+	});
 
-  it('rejects sell payouts larger than the owned position can support', () => {
-    const shares = [0, 0];
-    const boughtShares = solveBuySharesForAmount(shares, 0, 25, 150);
+	it("keeps competitive multi-winner marginals summing to winnerCount", () => {
+		const probabilities = computeTopKMarginals([7, -4, 2, 1], 150, 2);
+		expect(probabilities.reduce((sum, value) => sum + value, 0)).toBeCloseTo(
+			2,
+			8,
+		);
+		expect(probabilities.every((value) => value >= 0 && value <= 1)).toBe(true);
+	});
 
-    expect(() => solveSellSharesForAmount([boughtShares, 0], 0, 30, boughtShares / 4, 150)).toThrow(/enough shares/);
-  });
+	it("starts symmetric top-2 markets at 50% per outcome", () => {
+		const probabilities = computeTopKMarginals([0, 0, 0, 0], 150, 2);
+		expect(probabilities).toEqual([0.5, 0.5, 0.5, 0.5]);
+		expect(probabilities.reduce((sum, value) => sum + value, 0)).toBeCloseTo(
+			2,
+			8,
+		);
+	});
 
-  it('solves short share amounts against desired proceeds', () => {
-    const shares = [0, 0];
-    const shortShares = solveShortSharesForAmount(shares, 0, 40, 150);
-    const proceeds = computeSellPayout(shares, 0, shortShares, 150);
+	it("increases an outcome marginal after buying it in top-k pricing", () => {
+		const shares = [0, 0, 0, 0];
+		const before = computeTopKMarginals(shares, 150, 2)[0] ?? 0;
+		const bought = solveTopKBuySharesForAmount(shares, 0, 50, 150, 2);
+		const after = computeTopKMarginals([bought, 0, 0, 0], 150, 2)[0] ?? 0;
 
-    expect(shortShares).toBeGreaterThan(0);
-    expect(proceeds).toBeCloseTo(40, 5);
-  });
+		expect(bought).toBeGreaterThan(0);
+		expect(after).toBeGreaterThan(before);
+	});
 
-  it('rejects impossible short payouts in skewed markets', () => {
-    const shares = [0, 87.43];
+	it("keeps top-k buy cost and immediate unwind payout internally consistent", () => {
+		const shares = [12, -3, 4, 0];
+		const sharesToBuy = 2.75;
+		const buyCost = computeTopKBuyCost(shares, 1, sharesToBuy, 150, 2);
+		const unwindPayout = computeTopKSellPayout(
+			[12, -3 + sharesToBuy, 4, 0],
+			1,
+			sharesToBuy,
+			150,
+			2,
+		);
 
-    expect(computeSellPayout(shares, 0, 1_000_000, 150)).toBeCloseTo(66.54, 2);
-    expect(() => solveShortSharesForAmount(shares, 0, 100, 150)).toThrow(
-      /cannot pay out that many points/i,
-    );
-  });
+		expect(buyCost).toBeGreaterThan(0);
+		expect(unwindPayout).toBeCloseTo(buyCost, 8);
+	});
 
-  it('computes cover cost for a specific share amount', () => {
-    const shares = [-8, 0];
-    const cost = computeBuyCost(shares, 0, 3, 150);
+	it("solves buy share amounts against LMSR cost", () => {
+		const shares = [0, 0];
+		const delta = solveBuySharesForAmount(shares, 0, 75, 150);
+		const before = computeLmsrCost(shares, 150);
+		const [firstShare, secondShare] = shares;
+		const after = computeLmsrCost(
+			[(firstShare ?? 0) + delta, secondShare ?? 0],
+			150,
+		);
 
-    expect(cost).toBeGreaterThan(0);
-  });
+		expect(delta).toBeGreaterThan(0);
+		expect(after - before).toBeCloseTo(75, 5);
+	});
 
-  it('keeps probabilities and trade costs unchanged when the same constant is added to every outcome', () => {
-    const shares = [35, -10, 5];
-    const shiftedShares = shares.map((value) => value + 100);
-    const probabilities = computeLmsrProbabilities(shares, 150);
-    const shiftedProbabilities = computeLmsrProbabilities(shiftedShares, 150);
+	it("solves sell share amounts against desired payout", () => {
+		const shares = [0, 0];
+		const boughtShares = solveBuySharesForAmount(shares, 0, 100, 150);
+		const marketShares = [boughtShares, 0];
+		const sharesToSell = solveSellSharesForAmount(
+			marketShares,
+			0,
+			40,
+			boughtShares,
+			150,
+		);
+		const payout = computeSellPayout(marketShares, 0, sharesToSell, 150);
 
-    probabilities.forEach((value, index) => {
-      expect(shiftedProbabilities[index]).toBeCloseTo(value, 10);
-    });
-    expect(computeBuyCost(shiftedShares, 0, 25, 150)).toBeCloseTo(computeBuyCost(shares, 0, 25, 150), 10);
-  });
+		expect(sharesToSell).toBeGreaterThan(0);
+		expect(sharesToSell).toBeLessThan(boughtShares);
+		expect(payout).toBeCloseTo(40, 5);
+	});
 
-  it('preserves probabilities when liquidity increases and pricing shares are rebased', () => {
-    const shares = [210, 0];
-    const rebasedShares = shares.map((value) => value * 2);
-    const probabilities = computeLmsrProbabilities(shares, 150);
-    const rebasedProbabilities = computeLmsrProbabilities(rebasedShares, 300);
+	it("rejects sell payouts larger than the owned position can support", () => {
+		const shares = [0, 0];
+		const boughtShares = solveBuySharesForAmount(shares, 0, 25, 150);
 
-    probabilities.forEach((value, index) => {
-      expect(rebasedProbabilities[index]).toBeCloseTo(value, 10);
-    });
-  });
+		expect(() =>
+			solveSellSharesForAmount([boughtShares, 0], 0, 30, boughtShares / 4, 150),
+		).toThrow(/enough shares/);
+	});
 
-  it('reduces price impact for the same budget after a liquidity rebase', () => {
-    const shares = [210, 0];
-    const rebasedShares = shares.map((value) => value * 2);
-    const before = computeLmsrProbabilities(rebasedShares, 300)[0] ?? 0;
-    const rebasedBuy = solveBuySharesForAmount(rebasedShares, 0, 100, 300);
-    const [rebasedFirstShare, rebasedSecondShare] = rebasedShares;
-    const [firstShare, secondShare] = shares;
-    const after = computeLmsrProbabilities([(rebasedFirstShare ?? 0) + rebasedBuy, rebasedSecondShare ?? 0], 300)[0] ?? 0;
-    const originalMove = (computeLmsrProbabilities(
-      [(firstShare ?? 0) + solveBuySharesForAmount(shares, 0, 100, 150), secondShare ?? 0],
-      150,
-    )[0] ?? 0) - (computeLmsrProbabilities(shares, 150)[0] ?? 0);
+	it("solves short share amounts against desired proceeds", () => {
+		const shares = [0, 0];
+		const shortShares = solveShortSharesForAmount(shares, 0, 40, 150);
+		const proceeds = computeSellPayout(shares, 0, shortShares, 150);
 
-    expect(after - before).toBeLessThan(originalMove);
-  });
+		expect(shortShares).toBeGreaterThan(0);
+		expect(proceeds).toBeCloseTo(40, 5);
+	});
+
+	it("rejects impossible short payouts in skewed markets", () => {
+		const shares = [0, 87.43];
+
+		expect(computeSellPayout(shares, 0, 1_000_000, 150)).toBeCloseTo(66.54, 2);
+		expect(() => solveShortSharesForAmount(shares, 0, 100, 150)).toThrow(
+			/cannot pay out that many points/i,
+		);
+	});
+
+	it("computes cover cost for a specific share amount", () => {
+		const shares = [-8, 0];
+		const cost = computeBuyCost(shares, 0, 3, 150);
+
+		expect(cost).toBeGreaterThan(0);
+	});
+
+	it("keeps probabilities and trade costs unchanged when the same constant is added to every outcome", () => {
+		const shares = [35, -10, 5];
+		const shiftedShares = shares.map((value) => value + 100);
+		const probabilities = computeLmsrProbabilities(shares, 150);
+		const shiftedProbabilities = computeLmsrProbabilities(shiftedShares, 150);
+
+		probabilities.forEach((value, index) => {
+			expect(shiftedProbabilities[index]).toBeCloseTo(value, 10);
+		});
+		expect(computeBuyCost(shiftedShares, 0, 25, 150)).toBeCloseTo(
+			computeBuyCost(shares, 0, 25, 150),
+			10,
+		);
+	});
+
+	it("preserves probabilities when liquidity increases and pricing shares are rebased", () => {
+		const shares = [210, 0];
+		const rebasedShares = shares.map((value) => value * 2);
+		const probabilities = computeLmsrProbabilities(shares, 150);
+		const rebasedProbabilities = computeLmsrProbabilities(rebasedShares, 300);
+
+		probabilities.forEach((value, index) => {
+			expect(rebasedProbabilities[index]).toBeCloseTo(value, 10);
+		});
+	});
+
+	it("reduces price impact for the same budget after a liquidity rebase", () => {
+		const shares = [210, 0];
+		const rebasedShares = shares.map((value) => value * 2);
+		const before = computeLmsrProbabilities(rebasedShares, 300)[0] ?? 0;
+		const rebasedBuy = solveBuySharesForAmount(rebasedShares, 0, 100, 300);
+		const [rebasedFirstShare, rebasedSecondShare] = rebasedShares;
+		const [firstShare, secondShare] = shares;
+		const after =
+			computeLmsrProbabilities(
+				[(rebasedFirstShare ?? 0) + rebasedBuy, rebasedSecondShare ?? 0],
+				300,
+			)[0] ?? 0;
+		const originalMove =
+			(computeLmsrProbabilities(
+				[
+					(firstShare ?? 0) + solveBuySharesForAmount(shares, 0, 100, 150),
+					secondShare ?? 0,
+				],
+				150,
+			)[0] ?? 0) - (computeLmsrProbabilities(shares, 150)[0] ?? 0);
+
+		expect(after - before).toBeLessThan(originalMove);
+	});
 });


### PR DESCRIPTION
## Summary

Adds a new prediction market contract mode: **competitive multi-winner** (fixed-k winners). In this mode, exactly `k` outcomes win, each paying 1 per share, while losers pay 0. The displayed marginals sum to `k` (not 1), representing each outcome's chance to be among the winners.

## Why Not Softmax or Independent Settlement?

Two alternative approaches were considered and rejected:

1. **Softmax LMSR on individual outcomes**: This would treat the market as a single-winner prediction where probabilities sum to 1, then scale by `k`. However, this violates the no-arbitrage property—the cost function must directly model the actual payout structure.

2. **Independent binary settlement**: This would treat each outcome as an independent binary market. But the outcomes are **not independent**—knowing one outcome won affects the probability of others winning since exactly `k` must win. Independent settlement would allow arbitrage (e.g., buying all outcomes guarantees profit when k < n).

## The Math: LMSR over Winner Subsets

The correct approach models the market as a **single LMSR over all possible winner sets**.

### Definitions

```
n = number of outcomes
k = winnerCount (exactly k winners)
S = a subset of outcomes with |S| = k (a possible winner set)
q_i = quantity vector for outcome i
b = liquidity parameter
```

### Subset Enumeration

All valid winner sets are the k-combinations of n outcomes:

$$\mathcal{W} = \{ S \subseteq \{1,...,n\} : |S| = k \}$$

$$|\mathcal{W}| = \binom{n}{k}$$

### Cost Function

The LMSR cost function sums over all winner subsets, with each subset's value being the sum of quantities for outcomes in that subset:

$$C(\mathbf{q}) = b \cdot \log \left( \sum_{S \in \mathcal{W}} \exp\left( \frac{1}{b} \sum_{i \in S} q_i \right) \right)$$

### Instantaneous Prices (Marginals)

The marginal price for outcome $i$ is the probability that $i$ is among the winners:

$$p_i = \frac{\partial C}{\partial q_i} = \frac{\sum_{S \in \mathcal{W} : i \in S} \exp\left( \frac{1}{b} \sum_{j \in S} q_j \right)}{\sum_{S \in \mathcal{W}} \exp\left( \frac{1}{b} \sum_{j \in S} q_j \right)}$$

**Key property**: $\sum_{i=1}^{n} p_i = k$ (each winner set contributes 1 to exactly $k$ outcomes)

### Trade Pricing

**Buy** $s$ shares of outcome $i$:
$$\text{Cost} = C(\mathbf{q} + s \cdot \mathbf{e}_i) - C(\mathbf{q})$$

**Sell** $s$ shares of outcome $i$ (existing position):
$$\text{Payout} = C(\mathbf{q}) - C(\mathbf{q} - s \cdot \mathbf{e}_i)$$

### Symmetric Initialization

For $n=4, k=2$ with equal quantities $q_i = q$ for all $i$:

$$\sum_{j \in S} q_j = 2q \text{ for all } S \in \mathcal{W}$$

Each outcome appears in $\binom{n-1}{k-1} = \binom{3}{1} = 3$ subsets:

$$p_i = \frac{3 \cdot \exp(2q/b)}{6 \cdot \exp(2q/b)} = 0.5 \quad \Rightarrow \quad \sum_{i=1}^{4} p_i = 2 = k \checkmark$$

## Changes Made

### Schema
- Added `competitive_multi_winner` to `ContractMode` enum
- Added `winnerCount Int @default(1)` to `Market` model
- Created migration for new enum value and column

### Core Math (`src/features/markets/core/math.ts`)
- `computeLogSumExp`: numerically stable log-sum-exp
- `computeCombinationCount`: n choose k with overflow guard
- `enumerateWinnerSubsets`: generate all k-combinations
- `computeTopKCost`: LMSR cost over winner subsets
- `computeTopKMarginals`: instantaneous prices summing to k
- `computeTopKBuyCost` / `computeTopKSellPayout`: trade pricing
- `solveTopKBuySharesForAmount` / `solveTopKSellSharesForAmount`: share solvers

### Core Shared (`src/features/markets/core/shared.ts`)
- `isCompetitiveMultiWinnerMarketMode`: mode check helper
- `resolveMarketWinnerCount`: extracts k from market
- `getMarketProbabilities`: competitive mode uses top-k marginals
- `getTradeLockReason`: blocks short/cover with: \"Shorting is not yet supported for competitive multi-winner markets.\"
- `getMaxSellPayout`: competitive mode uses `computeTopKSellPayout`

### Validation (`src/features/markets/services/records.ts`)
- Validates `winnerCount` is integer >= 1 and < outcome count
- Combinatorics guardrail: caps at `maxCompetitiveWinnerSubsets = 1000`
- Supports editing `contractMode` and `winnerCount` on draft markets
- Revalidates on outcome append

### Trading Execution (`src/features/markets/services/trading/execution.ts`)
- Competitive mode branch before categorical path
- Uses top-k solvers for share deltas and payout
- Blocks short/cover operations
- Persists probability snapshots with top-k marginals

### Quote Engine (`src/features/markets/services/trading/quotes.ts`)
- Competitive mode branch for buy/sell quotes
- Returns `winnerCount` in quote for UI display

### Resolution (`src/features/markets/services/trading/resolution.ts`)
- Validates exactly `k` winners provided for competitive mode
- Validates no duplicates, all IDs exist
- Sets `settlementValue = 1` for winners, `0` for losers
- Long wins if outcome in winner set, short wins if not

### UI Updates
- Contract label helpers in market/render/trades.ts
- Probability section: \"Chances To Be Among Winners\" for competitive mode
- Resolve prompts: \"exactly {k} winners\" for competitive mode
- Short button disabled with clear messaging

### Forecast & Visualization
- `src/features/markets/services/forecast/shared.ts`: competitive marginals treated like independent (not renormalized)
- `src/features/markets/ui/visualize.ts`: uses mode-aware `getMarketProbabilities` instead of hardcoded single-winner LMSR

### Tests (`tests/market-math.test.ts`)
- Single-winner probs sum to 1
- Independent set behavior
- Competitive marginals sum to winnerCount
- Symmetric init: n=4,k=2 → each 0.5, sum=2
- Marginal movement after buy
- Top-k buy/sell consistency

## Limitations & Future Work

- **Shorting not supported**: Short/cover operations are blocked for competitive mode. Implementing shorts correctly requires tracking which winner sets the user is betting against, significantly complicating the payout logic.
- **Combinatorics scaling**: Currently capped at 1000 subsets (e.g., n=10,k=5 → 252 subsets, n=15,k=7 → 6435 subsets). For larger markets, would need approximation methods or Monte Carlo sampling.
- **Parallel markets**: Cannot currently combine competitive mode with independent markets.

## Testing

```bash
pnpm prisma generate
pnpm test tests/market-math.test.ts
```

All existing tests continue to pass for single-winner and independent-set modes.