### PR TITLE
feat(shorting): Enable shorting for competitive top-K markets

### DIFF
--- a/src/features/markets/core/math.ts
+++ b/src/features/markets/core/math.ts
@@ -409,6 +409,75 @@ export const solveBinarySellSharesForAmount = (
 	return clampSmall(high);
 };
 
+const computeTopKMaxShortPayout = (
+	shares: number[],
+	outcomeIndex: number,
+	liquidity: number,
+	winnerCount: number,
+): number => {
+	const baseline = computeTopKCost(shares, liquidity, winnerCount);
+	if (winnerCount === shares.length) {
+		return Number.POSITIVE_INFINITY;
+	}
+
+	const remainingShares = shares.filter((_, index) => index !== outcomeIndex);
+	const minCost = computeTopKCost(remainingShares, liquidity, winnerCount);
+	return clampSmall(baseline - minCost);
+};
+
+export const solveTopKShortSharesForAmount = (
+	shares: number[],
+	outcomeIndex: number,
+	desiredPayout: number,
+	liquidity: number,
+	winnerCount: number,
+): number => {
+	const maxPayout = computeTopKMaxShortPayout(
+		shares,
+		outcomeIndex,
+		liquidity,
+		winnerCount,
+	);
+	if (desiredPayout > maxPayout + 1e-6) {
+		throw new Error(
+			"That short cannot pay out that many points. Try a smaller point amount or specify shares.",
+		);
+	}
+
+	let low = 0;
+	let high = Math.max(1, desiredPayout);
+
+	while (
+		computeTopKSellPayout(
+			shares,
+			outcomeIndex,
+			high,
+			liquidity,
+			winnerCount,
+		) < desiredPayout
+	) {
+		high *= 2;
+	}
+
+	for (let index = 0; index < binarySearchIterations; index += 1) {
+		const mid = (low + high) / 2;
+		const payout = computeTopKSellPayout(
+			shares,
+			outcomeIndex,
+			mid,
+			liquidity,
+			winnerCount,
+		);
+		if (payout < desiredPayout) {
+			low = mid;
+		} else {
+			high = mid;
+		}
+	}
+
+	return clampSmall(high);
+};
+
 export const solveBinaryShortSharesForAmount = (
 	shares: number,
 	desiredPayout: number,

--- a/src/features/markets/core/shared.ts
+++ b/src/features/markets/core/shared.ts
@@ -424,10 +424,6 @@ export const getTradeLockReason = (
 	outcomeId: string,
 	action: MarketTradeSide,
 ): string | null => {
-	if (isCompetitiveMultiWinnerMarketMode(market) && action === "short") {
-		return "Shorting is not yet supported for competitive multi-winner markets.";
-	}
-
 	if (action !== "buy" && action !== "short") {
 		return null;
 	}

--- a/src/features/markets/services/trading/execution.ts
+++ b/src/features/markets/services/trading/execution.ts
@@ -25,6 +25,7 @@ import {
 	computeBinarySellPayout,
 	computeBuyCost,
 	computeLmsrProbabilities,
+	computeTopKBuyCost,
 	computeSellPayout,
 	computeTopKMarginals,
 	computeTopKSellPayout,
@@ -34,6 +35,7 @@ import {
 	solveBuySharesForAmount,
 	solveSellSharesForAmount,
 	solveTopKBuySharesForAmount,
+	solveTopKShortSharesForAmount,
 	solveTopKSellSharesForAmount,
 	solveShortSharesForAmount,
 } from "../../core/math.js";
@@ -421,12 +423,6 @@ export const executeMarketTrade = async (input: {
 		}
 
 		if (isCompetitiveMultiWinnerMarketMode(market)) {
-			if (input.action === "short" || input.action === "cover") {
-				throw new Error(
-					"Shorting is not yet supported for competitive multi-winner markets.",
-				);
-			}
-
 			const settledWinnerCount = market.outcomes.reduce(
 				(sum, marketOutcome) =>
 					marketOutcome.settlementValue === null
@@ -446,7 +442,7 @@ export const executeMarketTrade = async (input: {
 				case "buy": {
 					if (shortPosition && shortPosition.shares > 1e-6) {
 						throw new Error(
-							"Shorting is not yet supported for competitive multi-winner markets.",
+							"You must cover your short position in that outcome before buying it.",
 						);
 					}
 
@@ -525,6 +521,139 @@ export const executeMarketTrade = async (input: {
 					grossCashAmount = roundCurrency(cashAmount);
 					netCashAmount = roundCurrency(cashAmount);
 					positionSide = "long";
+					break;
+				}
+				case "short": {
+					if (longPosition && longPosition.shares > 1e-6) {
+						throw new Error(
+							"You must sell your long position in that outcome before shorting it.",
+						);
+					}
+
+					const sharesToShort =
+						input.amountMode === "shares"
+							? input.amount
+							: solveTopKShortSharesForAmount(
+									pricingShares,
+									tradableIndex,
+									input.amount,
+									market.liquidityParameter,
+									remainingWinnerCount,
+								);
+					const proceedsReceived =
+						input.amountMode === "shares"
+							? roundCurrency(
+									computeTopKSellPayout(
+										pricingShares,
+										tradableIndex,
+										sharesToShort,
+										market.liquidityParameter,
+										remainingWinnerCount,
+									),
+								)
+							: input.amount;
+					const collateralToLock = roundCurrency(sharesToShort);
+					if (
+						account.bankroll + proceedsReceived - collateralToLock <
+						-1e-6
+					) {
+						throw new Error(
+							"You do not have enough bankroll to collateralize that short.",
+						);
+					}
+
+					shareDelta = -sharesToShort;
+					nextPricingShares[tradableIndex] =
+						(nextPricingShares[tradableIndex] ?? 0) + shareDelta;
+					nextOutstandingShares[tradableIndex] =
+						(nextOutstandingShares[tradableIndex] ?? 0) + shareDelta;
+					nextShortShares += sharesToShort;
+					nextShortProceeds += proceedsReceived;
+					nextShortCollateral += collateralToLock;
+					nextBankroll += proceedsReceived - collateralToLock;
+					cashAmount = roundCurrency(proceedsReceived);
+					grossCashAmount = roundCurrency(proceedsReceived);
+					netCashAmount = roundCurrency(proceedsReceived);
+					positionSide = "short";
+					break;
+				}
+				case "cover": {
+					const ownedShortShares = shortPosition?.shares ?? 0;
+					if (ownedShortShares <= 1e-6) {
+						throw new Error(
+							"You do not have a short position in that outcome yet.",
+						);
+					}
+
+					if (input.amountMode !== "shares") {
+						const maxCoverCost = computeTopKBuyCost(
+							pricingShares,
+							tradableIndex,
+							ownedShortShares,
+							market.liquidityParameter,
+							remainingWinnerCount,
+						);
+						if (input.amount > maxCoverCost + 1e-6) {
+							throw new Error(
+								"You do not have enough short shares in that outcome to cover that much.",
+							);
+						}
+					}
+
+					const sharesToCover =
+						input.amountMode === "shares"
+							? input.amount
+							: solveTopKBuySharesForAmount(
+									pricingShares,
+									tradableIndex,
+									input.amount,
+									market.liquidityParameter,
+									remainingWinnerCount,
+								);
+					if (sharesToCover > ownedShortShares + 1e-6) {
+						throw new Error(
+							"You do not have enough short shares in that outcome to cover that much.",
+						);
+					}
+
+					const coverCost =
+						input.amountMode === "shares"
+							? roundCurrency(
+									computeTopKBuyCost(
+										pricingShares,
+										tradableIndex,
+										sharesToCover,
+										market.liquidityParameter,
+										remainingWinnerCount,
+									),
+								)
+							: input.amount;
+					const averageProceeds =
+						(shortPosition?.proceeds ?? 0) / ownedShortShares;
+					const averageCollateral =
+						(shortPosition?.collateralLocked ?? 0) / ownedShortShares;
+					const releasedProceeds = averageProceeds * sharesToCover;
+					const releasedCollateral = averageCollateral * sharesToCover;
+					if (account.bankroll + releasedCollateral < coverCost - 1e-6) {
+						throw new Error(
+							"You do not have enough bankroll to cover that short.",
+						);
+					}
+
+					shareDelta = sharesToCover;
+					nextPricingShares[tradableIndex] =
+						(nextPricingShares[tradableIndex] ?? 0) + shareDelta;
+					nextOutstandingShares[tradableIndex] =
+						(nextOutstandingShares[tradableIndex] ?? 0) + shareDelta;
+					nextShortShares -= sharesToCover;
+					nextShortProceeds -= releasedProceeds;
+					nextShortCollateral -= releasedCollateral;
+					nextBankroll += releasedCollateral - coverCost;
+					cashAmount = roundCurrency(coverCost);
+					realizedProfitDelta = roundCurrency(releasedProceeds - coverCost);
+					grossCashAmount = roundCurrency(coverCost);
+					netCashAmount = roundCurrency(coverCost);
+					positionSide = "short";
 					break;
 				}
 				default:
@@ -618,7 +747,10 @@ export const executeMarketTrade = async (input: {
 							userId: input.userId,
 							outcomeId: outcome.id,
 							side: input.action,
-							cashDelta: input.action === "buy" ? -cashAmount : cashAmount,
+							cashDelta:
+								input.action === "buy" || input.action === "cover"
+									? -cashAmount
+									: cashAmount,
 							shareDelta: roundCurrency(shareDelta),
 							feeCharged,
 							probabilitySnapshot: computedProbabilities[tradableIndex] ?? 0,

--- a/src/features/markets/services/trading/quotes.ts
+++ b/src/features/markets/services/trading/quotes.ts
@@ -16,6 +16,7 @@ import {
 	computeBinaryLmsrProbability,
 	computeBinarySellPayout,
 	computeBuyCost,
+	computeTopKBuyCost,
 	computeSellPayout,
 	computeTopKSellPayout,
 	solveBinaryBuySharesForAmount,
@@ -24,6 +25,7 @@ import {
 	solveBuySharesForAmount,
 	solveSellSharesForAmount,
 	solveTopKBuySharesForAmount,
+	solveTopKShortSharesForAmount,
 	solveTopKSellSharesForAmount,
 	solveShortSharesForAmount,
 } from "../../core/math.js";
@@ -557,7 +559,7 @@ const calculateMarketTradeQuoteUnsafe = async (input: {
 		if (input.action === "buy") {
 			if (shortPosition && shortPosition.shares > 1e-6) {
 				throw new Error(
-					"Shorting is not yet supported for competitive multi-winner markets.",
+					"You must cover your short position in that outcome before buying it.",
 				);
 			}
 
@@ -719,9 +721,217 @@ const calculateMarketTradeQuoteUnsafe = async (input: {
 			};
 		}
 
-		throw new Error(
-			"Shorting is not yet supported for competitive multi-winner markets.",
+		if (longPosition && longPosition.shares > 1e-6) {
+			throw new Error(
+				"You must sell your long position in that outcome before shorting it.",
+			);
+		}
+
+		if (input.action === "short") {
+			const sharesToShort =
+				amountMode === "shares"
+					? input.amount
+					: solveTopKShortSharesForAmount(
+							pricingShares,
+							tradableIndex,
+							input.amount,
+							market.liquidityParameter,
+							remainingWinnerCount,
+						);
+			const proceedsReceived =
+				amountMode === "shares"
+					? roundCurrency(
+							computeTopKSellPayout(
+								pricingShares,
+								tradableIndex,
+								sharesToShort,
+								market.liquidityParameter,
+								remainingWinnerCount,
+							),
+						)
+					: roundCurrency(input.amount);
+			const collateralToLock = roundCurrency(sharesToShort);
+			if (account.bankroll + proceedsReceived - collateralToLock < -1e-6) {
+				throw new Error(
+					"You do not have enough bankroll to collateralize that short.",
+				);
+			}
+
+			nextPricingShares[tradableIndex] =
+				(nextPricingShares[tradableIndex] ?? 0) - sharesToShort;
+			const positionSharesAfter = roundCurrency(
+				(shortPosition?.shares ?? 0) + sharesToShort,
+			);
+			const positionProceedsAfter = roundCurrency(
+				(shortPosition?.proceeds ?? 0) + proceedsReceived,
+			);
+			const positionCollateralAfter = roundCurrency(
+				(shortPosition?.collateralLocked ?? 0) + collateralToLock,
+			);
+			const bankrollAfter = roundCurrency(
+				account.bankroll + proceedsReceived - collateralToLock,
+			);
+			const probabilities = buildProbabilities();
+
+			return {
+				action: input.action,
+				contractMode: market.contractMode ?? "categorical_single_winner",
+				winnerCount: market.winnerCount ?? 1,
+				marketId: market.id,
+				marketTitle: market.title,
+				outcomeId: outcome.id,
+				outcomeLabel: outcome.label,
+				userId: input.userId,
+				guildId: market.guildId,
+				amount: input.amount,
+				amountMode,
+				rawAmount: input.rawAmount,
+				shares: roundCurrency(sharesToShort),
+				averagePrice:
+					sharesToShort > 0
+						? roundCurrency(proceedsReceived / sharesToShort)
+						: null,
+				currentProbability: probabilities.currentProbability,
+				nextProbability: probabilities.nextProbability,
+				immediateCash: roundCurrency(proceedsReceived),
+				grossImmediateCash: roundCurrency(proceedsReceived),
+				netImmediateCash: roundCurrency(proceedsReceived),
+				feeCharged: 0,
+				collateralLocked: collateralToLock,
+				collateralReleased: 0,
+				netBankrollChange: roundCurrency(proceedsReceived - collateralToLock),
+				bankrollAfter,
+				positionSide: "short",
+				positionSharesAfter,
+				positionCostBasisAfter: 0,
+				positionProceedsAfter,
+				positionCollateralAfter,
+				realizedProfitDelta: 0,
+				settlementIfChosen: 0,
+				settlementIfNotChosen: positionCollateralAfter,
+				maxProfitIfChosen: 0,
+				maxProfitIfNotChosen: positionProceedsAfter,
+				maxLossIfChosen: roundCurrency(
+					positionCollateralAfter - positionProceedsAfter,
+				),
+				maxLossIfNotChosen: 0,
+			};
+		}
+
+		const ownedShortShares = shortPosition?.shares ?? 0;
+		if (ownedShortShares <= 1e-6) {
+			throw new Error("You do not have a short position in that outcome yet.");
+		}
+
+		if (amountMode !== "shares") {
+			const maxCoverCost = computeTopKBuyCost(
+				pricingShares,
+				tradableIndex,
+				ownedShortShares,
+				market.liquidityParameter,
+				remainingWinnerCount,
+			);
+			if (input.amount > maxCoverCost + 1e-6) {
+				throw new Error(
+					"You do not have enough short shares in that outcome to cover that much.",
+				);
+			}
+		}
+
+		const sharesToCover =
+			amountMode === "shares"
+				? input.amount
+				: solveTopKBuySharesForAmount(
+						pricingShares,
+						tradableIndex,
+						input.amount,
+						market.liquidityParameter,
+						remainingWinnerCount,
+					);
+		if (sharesToCover > ownedShortShares + 1e-6) {
+			throw new Error(
+				"You do not have enough short shares in that outcome to cover that much.",
+			);
+		}
+
+		const coverCost =
+			amountMode === "shares"
+				? roundCurrency(
+						computeTopKBuyCost(
+							pricingShares,
+							tradableIndex,
+							sharesToCover,
+							market.liquidityParameter,
+							remainingWinnerCount,
+						),
+					)
+				: roundCurrency(input.amount);
+		const averageProceeds = (shortPosition?.proceeds ?? 0) / ownedShortShares;
+		const averageCollateral =
+			(shortPosition?.collateralLocked ?? 0) / ownedShortShares;
+		const releasedProceeds = roundCurrency(averageProceeds * sharesToCover);
+		const releasedCollateral = roundCurrency(
+			averageCollateral * sharesToCover,
 		);
+		if (account.bankroll + releasedCollateral < coverCost - 1e-6) {
+			throw new Error("You do not have enough bankroll to cover that short.");
+		}
+
+		nextPricingShares[tradableIndex] =
+			(nextPricingShares[tradableIndex] ?? 0) + sharesToCover;
+		const positionSharesAfter = roundCurrency(ownedShortShares - sharesToCover);
+		const positionProceedsAfter = roundCurrency(
+			(shortPosition?.proceeds ?? 0) - releasedProceeds,
+		);
+		const positionCollateralAfter = roundCurrency(
+			(shortPosition?.collateralLocked ?? 0) - releasedCollateral,
+		);
+		const bankrollAfter = roundCurrency(
+			account.bankroll + releasedCollateral - coverCost,
+		);
+		const probabilities = buildProbabilities();
+
+		return {
+			action: input.action,
+			contractMode: market.contractMode ?? "categorical_single_winner",
+			winnerCount: market.winnerCount ?? 1,
+			marketId: market.id,
+			marketTitle: market.title,
+			outcomeId: outcome.id,
+			outcomeLabel: outcome.label,
+			userId: input.userId,
+			guildId: market.guildId,
+			amount: input.amount,
+			amountMode,
+			rawAmount: input.rawAmount,
+			shares: roundCurrency(sharesToCover),
+			averagePrice:
+				sharesToCover > 0 ? roundCurrency(coverCost / sharesToCover) : null,
+			currentProbability: probabilities.currentProbability,
+			nextProbability: probabilities.nextProbability,
+			immediateCash: coverCost,
+			grossImmediateCash: coverCost,
+			netImmediateCash: coverCost,
+			feeCharged: 0,
+			collateralLocked: 0,
+			collateralReleased: releasedCollateral,
+			netBankrollChange: roundCurrency(releasedCollateral - coverCost),
+			bankrollAfter,
+			positionSide: "short",
+			positionSharesAfter,
+			positionCostBasisAfter: 0,
+			positionProceedsAfter,
+			positionCollateralAfter,
+			realizedProfitDelta: roundCurrency(releasedProceeds - coverCost),
+			settlementIfChosen: 0,
+			settlementIfNotChosen: positionCollateralAfter,
+			maxProfitIfChosen: 0,
+			maxProfitIfNotChosen: positionProceedsAfter,
+			maxLossIfChosen: roundCurrency(
+				positionCollateralAfter - positionProceedsAfter,
+			),
+			maxLossIfNotChosen: 0,
+		};
 	}
 
 	let nextPricingShares = [...pricingShares];

--- a/src/features/markets/ui/render/trades.ts
+++ b/src/features/markets/ui/render/trades.ts
@@ -162,7 +162,7 @@ export const buildMarketOutcomeTradePrompt = (
 					isIndependentMarket
 						? "Choose whether to buy YES exposure or short YES exposure (take the NO side)."
 						: isCompetitiveMultiWinner
-							? `Choose whether you want to buy this outcome's chance to finish in the top ${resolveMarketWinnerCount(market)}.`
+							? `Choose whether you want to buy this outcome's chance to finish in the top ${resolveMarketWinnerCount(market)} or short that outcome.`
 							: "Choose whether you want to buy this outcome or short it.",
 				].join("\n"),
 				0x60a5fa,
@@ -181,11 +181,7 @@ export const buildMarketOutcomeTradePrompt = (
 					.setCustomId(
 						marketQuickTradeButtonCustomId("short", market.id, outcomeId),
 					)
-					.setLabel(
-						isCompetitiveMultiWinner
-							? "Short (unavailable)"
-							: `Short ${formatProbabilityPercent(1 - entry.probability)}`,
-					)
+					.setLabel(`Short ${formatProbabilityPercent(1 - entry.probability)}`)
 					.setDisabled(shortLocked)
 					.setStyle(ButtonStyle.Danger),
 			),
@@ -506,7 +502,7 @@ export const buildMarketInteractionSessionMessage = (input: {
 				: session.preview?.kind === "trade"
 					? buildTradeQuoteDescription(session.preview.quote)
 					: isCompetitiveMultiWinner
-						? "Select an outcome, then use a quick amount or enter a custom amount to preview the trade. Shorting is not yet supported for competitive multi-winner markets."
+						? "Select an outcome, then use a quick amount or enter a custom amount to preview a top-K trade."
 						: "Select an outcome, then use a quick amount or enter a custom amount to preview the trade.",
 		].join("\n");
 
@@ -527,7 +523,6 @@ export const buildMarketInteractionSessionMessage = (input: {
 						marketSessionSideButtonCustomId(session.sessionId, "short"),
 					)
 					.setLabel("Short")
-					.setDisabled(isCompetitiveMultiWinner)
 					.setStyle(
 						selectedAction === "short"
 							? ButtonStyle.Danger

--- a/tests/market-math.test.ts
+++ b/tests/market-math.test.ts
@@ -12,6 +12,7 @@ import {
 	solveSellSharesForAmount,
 	solveShortSharesForAmount,
 	solveTopKBuySharesForAmount,
+	solveTopKShortSharesForAmount,
 } from "../src/features/markets/core/math.js";
 import { getMarketProbabilities } from "../src/features/markets/core/shared.js";
 
@@ -107,6 +108,15 @@ describe("market math", () => {
 
 		expect(buyCost).toBeGreaterThan(0);
 		expect(unwindPayout).toBeCloseTo(buyCost, 8);
+	});
+
+	it("solves top-k short share amounts against desired proceeds", () => {
+		const shares = [0, 0, 0, 0];
+		const shortShares = solveTopKShortSharesForAmount(shares, 0, 40, 150, 2);
+		const proceeds = computeTopKSellPayout(shares, 0, shortShares, 150, 2);
+
+		expect(shortShares).toBeGreaterThan(0);
+		expect(proceeds).toBeCloseTo(40, 5);
 	});
 
 	it("solves buy share amounts against LMSR cost", () => {

--- a/tests/market-render.test.ts
+++ b/tests/market-render.test.ts
@@ -12,6 +12,9 @@ vi.mock("../src/features/markets/core/shared.js", () => ({
 					: "open",
 	),
 	getTradeLockReason: vi.fn(() => null),
+	resolveMarketWinnerCount: vi.fn((market: MarketWithRelations) =>
+		Math.max(1, Math.floor(market.winnerCount ?? 1)),
+	),
 	computeMarketSummary: vi.fn((market: MarketWithRelations) => ({
 		status: market.cancelledAt
 			? "cancelled"
@@ -34,6 +37,7 @@ vi.mock("../src/features/markets/core/shared.js", () => ({
 
 import { buildMarketMessage } from "../src/features/markets/ui/render/market.js";
 import { buildPortfolioMessage } from "../src/features/markets/ui/render/portfolio.js";
+import { buildMarketOutcomeTradePrompt } from "../src/features/markets/ui/render/trades.js";
 
 const market = {
 	id: "market_1",
@@ -143,6 +147,12 @@ const market = {
 	trades: [],
 	positions: [],
 	liquidityEvents: [],
+};
+
+const topKMarket = {
+	...market,
+	contractMode: "competitive_multi_winner" as const,
+	winnerCount: 2,
 };
 
 describe("market render", () => {
@@ -411,5 +421,20 @@ describe("market render", () => {
 
 		const selectJson = payload.components[0]!.components[0]!.toJSON();
 		expect(selectJson.options).toHaveLength(25);
+	});
+
+	it("offers shorting in competitive top-k trade prompts", () => {
+		const payload = buildMarketOutcomeTradePrompt(topKMarket, "a");
+		const embed = payload.embeds[0].toJSON();
+		const buttons = (payload.components[0]?.toJSON().components ?? []) as Array<{
+			label?: string;
+			disabled?: boolean;
+		}>;
+
+		expect(embed.description).toContain(
+			"buy this outcome's chance to finish in the top 2 or short that outcome",
+		);
+		expect(buttons[1]?.label).toBe("Short 66.0%");
+		expect(buttons[1]?.disabled).toBe(false);
 	});
 });

--- a/tests/market-service.test.ts
+++ b/tests/market-service.test.ts
@@ -191,6 +191,42 @@ const market = {
 	liquidityEvents: [],
 };
 
+const competitiveTopKMarket = {
+	...market,
+	id: "market_topk",
+	title: "Who finishes top 2?",
+	contractMode: "competitive_multi_winner" as const,
+	winnerCount: 2,
+	outcomes: [
+		{
+			...market.outcomes[0],
+			id: "topk_a",
+			marketId: "market_topk",
+			label: "Alpha",
+		},
+		{
+			...market.outcomes[1],
+			id: "topk_b",
+			marketId: "market_topk",
+			label: "Beta",
+		},
+		{
+			...market.outcomes[0],
+			id: "topk_c",
+			marketId: "market_topk",
+			label: "Gamma",
+			sortOrder: 2,
+		},
+		{
+			...market.outcomes[1],
+			id: "topk_d",
+			marketId: "market_topk",
+			label: "Delta",
+			sortOrder: 3,
+		},
+	],
+};
+
 type TestMarketPosition = {
 	id: string;
 	marketId: string;
@@ -736,6 +772,48 @@ describe("market service", () => {
 						create: expect.objectContaining({
 							side: "short",
 							cashDelta: result.cashAmount,
+							shareDelta: -3,
+						}),
+					}),
+				}),
+			}),
+		);
+	});
+
+	it("opens a short position in a competitive top-k market", async () => {
+		transaction.market.findUnique.mockResolvedValue(competitiveTopKMarket);
+		runTransaction();
+
+		const result = await executeMarketTrade({
+			marketId: "market_topk",
+			userId: "user_2",
+			outcomeId: "topk_a",
+			action: "short",
+			amount: 3,
+			amountMode: "shares",
+		});
+
+		expect(result.shareDelta).toBeCloseTo(-3, 5);
+		expect(result.positionSide).toBe("short");
+		expect(result.cashAmount).toBeGreaterThan(0);
+		expect(transaction.marketPosition.upsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				create: expect.objectContaining({
+					marketId: "market_topk",
+					outcomeId: "topk_a",
+					side: "short",
+					shares: 3,
+					collateralLocked: 3,
+				}),
+			}),
+		);
+		expect(transaction.market.update).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					trades: expect.objectContaining({
+						create: expect.objectContaining({
+							outcomeId: "topk_a",
+							side: "short",
 							shareDelta: -3,
 						}),
 					}),
@@ -1414,6 +1492,28 @@ describe("market service", () => {
 		expect(quote.collateralLocked).toBeGreaterThan(0);
 		expect(quote.settlementIfChosen).toBe(0);
 		expect(quote.settlementIfNotChosen).toBeGreaterThan(0);
+	});
+
+	it("quotes a competitive top-k short trade", async () => {
+		prisma.market.findUnique.mockResolvedValue(competitiveTopKMarket);
+		prisma.marketAccount.findUnique.mockResolvedValue(baseAccount);
+
+		const quote = await calculateMarketTradeQuote({
+			marketId: "market_topk",
+			userId: "user_2",
+			outcomeId: "topk_a",
+			action: "short",
+			amount: 10,
+			amountMode: "points",
+			rawAmount: "10 pts",
+		});
+
+		expect(quote.action).toBe("short");
+		expect(quote.contractMode).toBe("competitive_multi_winner");
+		expect(quote.winnerCount).toBe(2);
+		expect(quote.immediateCash).toBe(10);
+		expect(quote.collateralLocked).toBeGreaterThan(0);
+		expect(quote.nextProbability).toBeLessThan(quote.currentProbability);
 	});
 
 	it("quotes a sell trade against the remaining long position", async () => {


### PR DESCRIPTION
## Summary

Enable `short` and `cover` trades for `competitive_multi_winner` markets.

This removes the remaining top-K shorting guardrails in quote generation, execution, and UI, and adds the missing top-K short-share solver so point-based shorts can be priced correctly.

## Changes

- add `solveTopKShortSharesForAmount()` to top-K math helpers
- allow top-K markets to open and cover short positions
- use top-K buy/sell pricing for short and cover flows
- remove the hard “shorting is not yet supported” lock for competitive multi-winner markets
- update market trade UI copy/buttons to expose shorting in top-K markets
- add regression tests for math, service, and render flows

## Verification

```bash
pnpm test tests/market-math.test.ts tests/market-service.test.ts tests/market-render.test.ts
pnpm build
