### PR TITLE
[codex] Add market resolution dropdown

### DIFF
--- a/src/features/markets/handlers/interactions/buttons.ts
+++ b/src/features/markets/handlers/interactions/buttons.ts
@@ -3,13 +3,13 @@ import { MessageFlags, type ButtonInteraction } from "discord.js";
 import { redis } from "@/lib/redis.js";
 import {
 	buildMarketCancelModal,
+	buildMarketResolveSelector,
 	buildMarketSessionAmountModal,
 	buildMarketTradeModal,
 	buildMarketTradeSelector,
 } from "@/features/markets/ui/render/trades.js";
 import { buildMarketStatusEmbed } from "@/features/markets/ui/render/market.js";
 import { buildPortfolioMessage } from "@/features/markets/ui/render/portfolio.js";
-import { buildMarketResolveModal } from "@/features/markets/ui/render/trades.js";
 import {
 	deleteMarketTradeQuoteSession,
 	getMarketTradeQuoteSession,
@@ -558,7 +558,18 @@ export const handleMarketButton = async (
 		interaction.customId,
 	);
 	if (resolveMarketId) {
-		await interaction.showModal(buildMarketResolveModal(resolveMarketId));
+		const market = await getMarketById(resolveMarketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
+
+		await interaction.reply({
+			flags: MessageFlags.Ephemeral,
+			...buildMarketResolveSelector(market),
+			allowedMentions: {
+				parse: [],
+			},
+		});
 		return;
 	}
 

--- a/src/features/markets/handlers/interactions/modals.ts
+++ b/src/features/markets/handlers/interactions/modals.ts
@@ -16,6 +16,7 @@ import { getMarketById } from "@/features/markets/services/records.js";
 import { scheduleMarketRefresh } from "@/features/markets/services/scheduler.js";
 import { cancelMarket } from "@/features/markets/services/trading/cancel.js";
 import { resolveMarket } from "@/features/markets/services/trading/resolution.js";
+import type { MarketWithRelations } from "@/features/markets/core/types.js";
 import {
 	parseOutcomeSelection,
 	parseOutcomeSelections,
@@ -32,10 +33,48 @@ import {
 } from "@/features/markets/handlers/interactions/session.js";
 import {
 	parseMarketSessionId,
+	parseMarketResolveModalCustomId,
 	parseSimpleMarketId,
 	parseTradeModalCustomId,
 	validateEvidenceUrl,
 } from "@/features/markets/handlers/interactions/shared.js";
+
+const resolveOutcomesFromIndexes = (
+	market: MarketWithRelations,
+	outcomeIndexes: number[],
+): MarketWithRelations["outcomes"] | null => {
+	if (outcomeIndexes.length === 0) {
+		return null;
+	}
+
+	if (market.contractMode === "independent_binary_set") {
+		throw new Error(
+			"Independent markets resolve outcome-by-outcome with /market resolve-outcome.",
+		);
+	}
+
+	const expectedCount = isCompetitiveMultiWinnerMarketMode(market)
+		? resolveMarketWinnerCount(market)
+		: 1;
+	if (outcomeIndexes.length !== expectedCount) {
+		throw new Error(
+			`Choose exactly ${expectedCount} winning outcome${expectedCount === 1 ? "" : "s"}.`,
+		);
+	}
+
+	if (new Set(outcomeIndexes).size !== outcomeIndexes.length) {
+		throw new Error("Choose distinct winning outcomes.");
+	}
+
+	return outcomeIndexes.map((index) => {
+		const outcome = market.outcomes[index];
+		if (!outcome) {
+			throw new Error("Selected winning outcome is no longer available.");
+		}
+
+		return outcome;
+	});
+};
 
 export const handleMarketModal = async (
 	client: Client,
@@ -93,21 +132,26 @@ export const handleMarketModal = async (
 		return;
 	}
 
-	const resolveMarketId = parseSimpleMarketId(
-		"market:resolve-modal",
-		interaction.customId,
-	);
-	if (resolveMarketId) {
-		const market = await getMarketById(resolveMarketId);
+	const resolveRequest = parseMarketResolveModalCustomId(interaction.customId);
+	if (resolveRequest) {
+		const market = await getMarketById(resolveRequest.marketId);
 		if (!market) {
 			throw new Error("Market not found.");
 		}
 
-		const winningOutcomeInput =
-			interaction.fields.getTextInputValue("winning_outcome");
-		const winningOutcomes = isCompetitiveMultiWinnerMarketMode(market)
-			? parseOutcomeSelections(winningOutcomeInput, market.outcomes)
-			: [parseOutcomeSelection(winningOutcomeInput, market.outcomes)];
+		const selectedOutcomes = resolveOutcomesFromIndexes(
+			market,
+			resolveRequest.outcomeIndexes,
+		);
+		const winningOutcomes =
+			selectedOutcomes ??
+			(() => {
+				const winningOutcomeInput =
+					interaction.fields.getTextInputValue("winning_outcome");
+				return isCompetitiveMultiWinnerMarketMode(market)
+					? parseOutcomeSelections(winningOutcomeInput, market.outcomes)
+					: [parseOutcomeSelection(winningOutcomeInput, market.outcomes)];
+			})();
 		const resolved = await resolveMarket({
 			marketId: market.id,
 			actorId: interaction.user.id,

--- a/src/features/markets/handlers/interactions/selects.ts
+++ b/src/features/markets/handlers/interactions/selects.ts
@@ -1,6 +1,14 @@
 import type { StringSelectMenuInteraction } from "discord.js";
 
-import { buildMarketTradeModal } from "@/features/markets/ui/render/trades.js";
+import {
+	buildMarketResolveModal,
+	buildMarketTradeModal,
+} from "@/features/markets/ui/render/trades.js";
+import type { MarketWithRelations } from "@/features/markets/core/types.js";
+import {
+	isCompetitiveMultiWinnerMarketMode,
+	resolveMarketWinnerCount,
+} from "@/features/markets/core/shared.js";
 import { getMarketById } from "@/features/markets/services/records.js";
 import { marketPortfolioSelectCustomId } from "@/features/markets/ui/custom-ids.js";
 import {
@@ -17,6 +25,39 @@ import {
 	parseTradeSelectCustomId,
 } from "@/features/markets/handlers/interactions/shared.js";
 import { buildProtectionEntryMessage } from "@/features/markets/handlers/interactions/protection.js";
+
+const resolveSelectedOutcomeIndexes = (
+	market: MarketWithRelations,
+	values: string[],
+): number[] => {
+	if (market.contractMode === "independent_binary_set") {
+		throw new Error(
+			"Independent markets resolve outcome-by-outcome with /market resolve-outcome.",
+		);
+	}
+
+	const expectedCount = isCompetitiveMultiWinnerMarketMode(market)
+		? resolveMarketWinnerCount(market)
+		: 1;
+	if (values.length !== expectedCount) {
+		throw new Error(
+			`Choose exactly ${expectedCount} winning outcome${expectedCount === 1 ? "" : "s"}.`,
+		);
+	}
+
+	const indexes = values.map((value) =>
+		market.outcomes.findIndex((outcome) => outcome.id === value),
+	);
+	if (indexes.some((index) => index < 0)) {
+		throw new Error("Choose a valid market outcome.");
+	}
+
+	if (new Set(indexes).size !== indexes.length) {
+		throw new Error("Choose distinct winning outcomes.");
+	}
+
+	return indexes;
+};
 
 export const handleMarketSelect = async (
 	interaction: StringSelectMenuInteraction,
@@ -80,6 +121,25 @@ export const handleMarketSelect = async (
 		});
 		await interaction.update(
 			await buildRootMarketInteractionSessionResponse(nextSession),
+		);
+		return;
+	}
+
+	const resolveMarketId = parseSimpleMarketId(
+		"market:resolve-select",
+		interaction.customId,
+	);
+	if (resolveMarketId) {
+		const market = await getMarketById(resolveMarketId);
+		if (!market) {
+			throw new Error("Market not found.");
+		}
+
+		await interaction.showModal(
+			buildMarketResolveModal(
+				market.id,
+				resolveSelectedOutcomeIndexes(market, interaction.values),
+			),
 		);
 		return;
 	}

--- a/src/features/markets/handlers/interactions/shared.ts
+++ b/src/features/markets/handlers/interactions/shared.ts
@@ -142,6 +142,33 @@ export const parseSimpleMarketId = (
 	return match?.[1] ?? null;
 };
 
+export const parseMarketResolveModalCustomId = (
+	customId: string,
+): { marketId: string; outcomeIndexes: number[] } | null => {
+	const match = /^market:resolve-modal:([^:]+)(?::([0-9]+(?:,[0-9]+)*))?$/.exec(
+		customId,
+	);
+	if (!match?.[1]) {
+		return null;
+	}
+
+	const outcomeIndexes = match[2]
+		? match[2].split(",").map((value) => Number(value))
+		: [];
+	if (
+		outcomeIndexes.some(
+			(index) => !Number.isInteger(index) || index < 0,
+		)
+	) {
+		return null;
+	}
+
+	return {
+		marketId: match[1],
+		outcomeIndexes,
+	};
+};
+
 export const parseQuoteSessionId = (
 	prefix: "market:quote-confirm" | "market:quote-cancel",
 	customId: string,

--- a/src/features/markets/ui/custom-ids.ts
+++ b/src/features/markets/ui/custom-ids.ts
@@ -121,7 +121,14 @@ export const marketResolveButtonCustomId = (marketId: string): string =>
 	`market:resolve:${marketId}`;
 export const marketCancelButtonCustomId = (marketId: string): string =>
 	`market:cancel:${marketId}`;
-export const marketResolveModalCustomId = (marketId: string): string =>
-	`market:resolve-modal:${marketId}`;
+export const marketResolveSelectCustomId = (marketId: string): string =>
+	`market:resolve-select:${marketId}`;
+export const marketResolveModalCustomId = (
+	marketId: string,
+	outcomeIndexes: number[] = [],
+): string =>
+	outcomeIndexes.length > 0
+		? `market:resolve-modal:${marketId}:${outcomeIndexes.join(",")}`
+		: `market:resolve-modal:${marketId}`;
 export const marketCancelModalCustomId = (marketId: string): string =>
 	`market:cancel-modal:${marketId}`;

--- a/src/features/markets/ui/render/market.ts
+++ b/src/features/markets/ui/render/market.ts
@@ -366,8 +366,8 @@ export const buildMarketResolvePrompt = (
 			market.contractMode === "independent_binary_set"
 				? `Trading on **${market.title}** is closed. Resolve remaining outcomes with **/market resolve-outcome** and a value between 0 and 1, or cancel to refund positions.`
 				: market.contractMode === "competitive_multi_winner"
-					? `Trading on **${market.title}** is closed. Choose **Resolve** and provide exactly ${resolveMarketWinnerCount(market)} winners (comma-separated), or **Cancel** to refund positions.`
-					: `Trading on **${market.title}** is closed. Choose **Resolve** to pick a winner or **Cancel** to refund positions.`,
+					? `Trading on **${market.title}** is closed. Choose **Resolve** and select exactly ${resolveMarketWinnerCount(market)} winners, or **Cancel** to refund positions.`
+					: `Trading on **${market.title}** is closed. Choose **Resolve** to select a winner or **Cancel** to refund positions.`,
 			0x60a5fa,
 		),
 	],

--- a/src/features/markets/ui/render/trades.ts
+++ b/src/features/markets/ui/render/trades.ts
@@ -26,6 +26,7 @@ import {
 	marketProtectionSelectCustomId,
 	marketQuickTradeButtonCustomId,
 	marketResolveModalCustomId,
+	marketResolveSelectCustomId,
 	marketTradeModalCustomId,
 	marketTradeQuoteCancelCustomId,
 	marketTradeQuoteConfirmCustomId,
@@ -111,6 +112,55 @@ export const buildMarketTradeSelector = (
 							label: `${index + 1}. ${entry.label}`,
 							value: entry.outcomeId,
 							description: `Net shares: ${entry.shares.toFixed(2)}`,
+						})),
+					),
+			),
+		],
+	};
+};
+
+export const buildMarketResolveSelector = (
+	market: MarketWithRelations,
+): {
+	embeds: [EmbedBuilder];
+	components: ActionRowBuilder<StringSelectMenuBuilder>[];
+} => {
+	if (market.contractMode === "independent_binary_set") {
+		return {
+			embeds: [
+				buildMarketStatusEmbed(
+					"Resolve Market",
+					"Independent markets resolve outcome-by-outcome with /market resolve-outcome.",
+					0x60a5fa,
+				),
+			],
+			components: [],
+		};
+	}
+
+	const winnerCount =
+		market.contractMode === "competitive_multi_winner"
+			? resolveMarketWinnerCount(market)
+			: 1;
+	const maxValues = Math.min(winnerCount, market.outcomes.length);
+	const description =
+		market.contractMode === "competitive_multi_winner"
+			? `Select exactly ${winnerCount} winning outcomes. You can add a note and evidence URL next.`
+			: "Select the winning outcome. You can add a note and evidence URL next.";
+
+	return {
+		embeds: [buildMarketStatusEmbed("Resolve Market", description, 0x57f287)],
+		components: [
+			new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+				new StringSelectMenuBuilder()
+					.setCustomId(marketResolveSelectCustomId(market.id))
+					.setPlaceholder("Select winning outcome")
+					.setMinValues(maxValues)
+					.setMaxValues(maxValues)
+					.addOptions(
+						market.outcomes.map((outcome, index) => ({
+							label: `${index + 1}. ${truncateLabel(outcome.label, 90)}`,
+							value: outcome.id,
 						})),
 					),
 			),
@@ -240,11 +290,16 @@ export const buildMarketSessionAmountModal = (
 		);
 };
 
-export const buildMarketResolveModal = (marketId: string): ModalBuilder =>
-	new ModalBuilder()
-		.setCustomId(marketResolveModalCustomId(marketId))
-		.setTitle("Resolve Market")
-		.addComponents(
+export const buildMarketResolveModal = (
+	marketId: string,
+	outcomeIndexes: number[] = [],
+): ModalBuilder => {
+	const modal = new ModalBuilder()
+		.setCustomId(marketResolveModalCustomId(marketId, outcomeIndexes))
+		.setTitle("Resolve Market");
+
+	if (outcomeIndexes.length === 0) {
+		modal.addComponents(
 			new ActionRowBuilder<TextInputBuilder>().addComponents(
 				new TextInputBuilder()
 					.setCustomId("winning_outcome")
@@ -253,23 +308,28 @@ export const buildMarketResolveModal = (marketId: string): ModalBuilder =>
 					.setRequired(true)
 					.setPlaceholder("1 or exact label; comma-separated for multi-winner"),
 			),
-			new ActionRowBuilder<TextInputBuilder>().addComponents(
-				new TextInputBuilder()
-					.setCustomId("note")
-					.setLabel("Resolution note")
-					.setStyle(TextInputStyle.Paragraph)
-					.setRequired(false)
-					.setMaxLength(500),
-			),
-			new ActionRowBuilder<TextInputBuilder>().addComponents(
-				new TextInputBuilder()
-					.setCustomId("evidence_url")
-					.setLabel("Evidence URL")
-					.setStyle(TextInputStyle.Short)
-					.setRequired(false)
-					.setPlaceholder("https://example.com"),
-			),
 		);
+	}
+
+	return modal.addComponents(
+		new ActionRowBuilder<TextInputBuilder>().addComponents(
+			new TextInputBuilder()
+				.setCustomId("note")
+				.setLabel("Resolution note")
+				.setStyle(TextInputStyle.Paragraph)
+				.setRequired(false)
+				.setMaxLength(500),
+		),
+		new ActionRowBuilder<TextInputBuilder>().addComponents(
+			new TextInputBuilder()
+				.setCustomId("evidence_url")
+				.setLabel("Evidence URL")
+				.setStyle(TextInputStyle.Short)
+				.setRequired(false)
+				.setPlaceholder("https://example.com"),
+		),
+	);
+};
 
 export const buildMarketCancelModal = (marketId: string): ModalBuilder =>
 	new ModalBuilder()

--- a/tests/market-interactions.test.ts
+++ b/tests/market-interactions.test.ts
@@ -485,6 +485,55 @@ const createModalInteraction = (customId: string, amount = "25") => ({
 	reply: vi.fn(),
 });
 
+const collectObjectsByCustomId = (
+	value: unknown,
+	customId: string,
+): Record<string, unknown>[] => {
+	const matches: Record<string, unknown>[] = [];
+	const visit = (entry: unknown): void => {
+		if (Array.isArray(entry)) {
+			for (const item of entry) visit(item);
+			return;
+		}
+
+		if (!entry || typeof entry !== "object") {
+			return;
+		}
+
+		const record = entry as Record<string, unknown>;
+		if (record.custom_id === customId) {
+			matches.push(record);
+		}
+
+		for (const child of Object.values(record)) {
+			visit(child);
+		}
+	};
+
+	visit(value);
+	return matches;
+};
+
+const toBuilderJson = (value: unknown): unknown => {
+	if (Array.isArray(value)) {
+		return value.map((entry) => toBuilderJson(entry));
+	}
+
+	if (!value || typeof value !== "object") {
+		return value;
+	}
+
+	const record = value as Record<string, unknown>;
+	if (typeof record.toJSON === "function") {
+		const candidate = record as { toJSON: () => unknown };
+		return toBuilderJson(candidate.toJSON());
+	}
+
+	return Object.fromEntries(
+		Object.entries(record).map(([key, entry]) => [key, toBuilderJson(entry)]),
+	);
+};
+
 describe("market interactions", () => {
 	beforeEach(() => {
 		env.DISCORD_ADMIN_USER_IDS = [...defaultAdminUserIds];
@@ -961,6 +1010,96 @@ describe("market interactions", () => {
 		).rejects.toThrow("Evidence URL must be a valid http or https URL.");
 
 		expect(resolveMarket).not.toHaveBeenCalled();
+	});
+
+	it("opens an outcome dropdown when resolving a market from the button", async () => {
+		const interaction = createButtonInteraction("market:resolve:market_1");
+		getMarketById.mockResolvedValue(baseMarket);
+
+		await handleMarketButton(interaction as never);
+
+		expect(getMarketById).toHaveBeenCalledWith("market_1");
+		expect(interaction.reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				flags: 64,
+				components: expect.any(Array),
+			}),
+		);
+
+		const reply = interaction.reply.mock.calls[0]?.[0];
+		const select = collectObjectsByCustomId(
+			toBuilderJson(reply),
+			"market:resolve-select:market_1",
+		)[0];
+		expect(select).toEqual(
+			expect.objectContaining({
+				custom_id: "market:resolve-select:market_1",
+				min_values: 1,
+				max_values: 1,
+			}),
+		);
+
+		const options = Array.isArray(select?.options) ? select.options : [];
+		expect(
+			options.map((option) => (option as Record<string, unknown>).value),
+		).toEqual(["outcome_yes", "outcome_no"]);
+	});
+
+	it("opens the resolution details modal after selecting a winning outcome", async () => {
+		const interaction = createStringSelectInteraction(
+			"market:resolve-select:market_1",
+			["outcome_no"],
+		);
+		getMarketById.mockResolvedValue(baseMarket);
+
+		await handleMarketSelect(interaction as never);
+
+		expect(interaction.showModal).toHaveBeenCalledTimes(1);
+		const modal = toBuilderJson(interaction.showModal.mock.calls[0]?.[0]);
+		expect(modal).toEqual(
+			expect.objectContaining({
+				custom_id: "market:resolve-modal:market_1:1",
+				title: "Resolve Market",
+			}),
+		);
+		expect(
+			collectObjectsByCustomId(modal, "winning_outcome"),
+		).toHaveLength(0);
+	});
+
+	it("uses the selected winning outcome when submitting resolution details", async () => {
+		const interaction = {
+			customId: "market:resolve-modal:market_1:1",
+			user: {
+				id: "user_1",
+			},
+			fields: {
+				getTextInputValue: vi.fn((name: string) => {
+					if (name === "note") return "Final result posted.";
+					if (name === "evidence_url") return "https://example.com/final";
+					return "";
+				}),
+			},
+			memberPermissions: null,
+			inGuild: () => true,
+			reply: vi.fn(),
+		};
+		getMarketById.mockResolvedValue(baseMarket);
+
+		await handleMarketModal({} as never, interaction as never);
+
+		expect(resolveMarket).toHaveBeenCalledWith(
+			expect.objectContaining({
+				marketId: "market_1",
+				actorId: "user_1",
+				winningOutcomeId: "outcome_no",
+				note: "Final result posted.",
+				evidenceUrl: "https://example.com/final",
+			}),
+		);
+		expect(interaction.fields.getTextInputValue).not.toHaveBeenCalledWith(
+			"winning_outcome",
+		);
 	});
 
 	it("shows a quote preview instead of executing a buy trade immediately", async () => {


### PR DESCRIPTION
## Summary

This changes the market Resolve button flow from a typed winning-outcome modal to an outcome dropdown. The selected outcome or outcomes are carried into the follow-up resolution details modal, which still collects the optional note and evidence URL.

The flow now supports single-winner and competitive multi-winner markets through Discord select menus, while independent markets continue to use `/market resolve-outcome` for per-outcome settlement.

## Validation

- `pnpm lint:fix` exited 0. Biome still reports existing warning-level diagnostics elsewhere in the repository and applied no fixes.
- `pnpm build`
- `pnpm test`